### PR TITLE
chore: add Dependabot and dependency-submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,80 @@
+version: 2
+updates:
+  # Root workspace — Angular workspace config, dev tooling, and shared deps
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+          - "@angular/material"
+          - "@angular/cdk"
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+      karma-testing:
+        patterns:
+          - "karma*"
+          - "jasmine*"
+          - "@types/jasmine*"
+          - "@types/jasminewd2"
+      types:
+        patterns:
+          - "@types/*"
+
+  # Library package — the publishable Angular library (projects/collection-editor-library)
+  - package-ecosystem: "npm"
+    directory: "/projects/collection-editor-library"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+
+  # Web component build — standalone ES module distribution
+  - package-ecosystem: "npm"
+    directory: "/web-component"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,68 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/collection-editor-library/package.json'
+      - 'web-component/package.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/collection-editor-library/package.json'
+      - 'web-component/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-npm-root:
+    name: Submit npm (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  submit-npm-library:
+    name: Submit npm (projects/collection-editor-library)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # No lock file in library subpackage — generate one without installing node_modules
+      - run: npm install --package-lock-only
+        working-directory: projects/collection-editor-library
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./projects/collection-editor-library
+
+  submit-npm-web-component:
+    name: Submit npm (web-component)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # No lock file in web-component/ — generate one without installing node_modules
+      - run: npm install --package-lock-only
+        working-directory: web-component
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./web-component


### PR DESCRIPTION
Description:                                           
                                                                                                                                                                                      
  ## Summary                                             
                                                                                                                                                                                      
  - Enables Dependabot for automated weekly dependency updates across all three npm workspaces (root, `projects/collection-editor-library`, `web-component`) and GitHub Actions
  workflows.                                                                                                                                                                          
  - Adds a dependency-submission workflow to populate GitHub's Dependency Graph before Dependabot runs, ensuring accurate security alerts and version-update PRs.
  - Groups related packages (Angular, Sunbird, Karma/testing, `@types/*`) to consolidate update PRs and reduce review noise.                                                          
                                                                                                                                                                                      
  ## Changes                                                                                                                                                                          
                                                                                                                                                                                      
  - Add `.github/dependabot.yml` with four update targets: npm root, `projects/collection-editor-library`, `web-component`, and `github-actions`; all scheduled weekly on Mondays at  
  03:30 UTC
  - Configure package groups in the root npm target — `angular`, `sunbird`, `karma-testing`, and `types` — so grouped PRs replace many individual ones                                
  - Add `.github/workflows/dependency-submission.yml` with three parallel jobs submitting npm dependency snapshots for each workspace to GitHub's Dependency Graph via                
  `advanced-security/npm-dependency-submission-action@v1`                                                                                                                             
  `package.json` or `package-lock.json` changes                                                                                                                                       
                                                                                                                                                                                      
  ## How to Test                                         
                                                                                                                                                                                      
  1. Merge this PR, then go to **Settings → Security & analysis** — Dependabot version updates should show as active and the Dependency Graph should list all three npm workspaces.
  2. Trigger the workflow manually: **Actions → Dependency Submission → Run workflow** — all three jobs (`Submit npm (root)`, `Submit npm (library)`, `Submit npm (web-component)`)   
  should complete successfully.                                                                                                                                                    
  3. On the next Monday at 03:30 UTC, confirm Dependabot opens PRs labelled `dependencies` (and grouped where applicable) for any outdated packages.                                  
                                                                                                                                                    
  ## Checklist                                                                                                                                                                        
                                                         
  - [ ] Tests added or updated                                                                                                                                                        
  - [ ] Documentation updated (if public API or behavior changed)                                                                                                                     
  - [ ] No breaking changes — or breaking changes noted with `!` in title and explained in Summary
  - [ ] Reviewed my own diff before requesting review