### PR TITLE
React Collection Editor

### DIFF
--- a/.github/workflows/publish_react.yml
+++ b/.github/workflows/publish_react.yml
@@ -1,0 +1,39 @@
+name: Publish collection-editor-react Package
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish-react:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # All steps run inside the React project so its own package.json /
+        # package-lock.json drive install, build and publish — not the root
+        # Angular workspace.
+        working-directory: projects/collection-editor-react
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.21.1'
+          # Writes ~/.npmrc with the registry so NODE_AUTH_TOKEN is picked up
+          # by `npm publish` automatically.
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # dependencies
 /node_modules
+/projects/collection-editor-react/node_modules
+/projects/collection-editor-react/dist
 
 # profiling files
 chrome-profiler-events.json
@@ -46,3 +48,4 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+projects/collection-editor-react/public/assets/

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@project-sunbird/sunbird-epub-player-web-component": "2.0.0",
         "@project-sunbird/sunbird-file-upload-library": "1.0.2",
         "@project-sunbird/sunbird-pdf-player-web-component": "2.0.0",
-        "@project-sunbird/sunbird-quml-player-web-component": "6.0.0",
+        "@project-sunbird/sunbird-quml-player-web-component": "^6.0.10",
         "@project-sunbird/sunbird-resource-library": "8.0.0",
         "@project-sunbird/sunbird-video-player-web-component": "2.0.0",
         "@project-sunbird/telemetry-sdk": "^1.3.0",
@@ -5342,9 +5342,9 @@
       "license": "MIT"
     },
     "node_modules/@project-sunbird/sunbird-quml-player-web-component": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.0.tgz",
-      "integrity": "sha512-3PmhFKUmFahTltp/86W4FuP5YkJftBQ+W1AikmY7YEIPoOU+4l3BQpf3PeCOXlaltKcTsEGu8eolj2hx7dvkSw==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.10.tgz",
+      "integrity": "sha512-v6uaAkQ8Vdr8x6RGCH53uLRv0AgaLaDZzYorNS3uF6fSuo8iQmTXH8SGonXyYcgQnZkLhDHvEvqZ64yX5h4M3g==",
       "license": "MIT"
     },
     "node_modules/@project-sunbird/sunbird-resource-library": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@project-sunbird/sunbird-epub-player-web-component": "2.0.0",
     "@project-sunbird/sunbird-file-upload-library": "1.0.2",
     "@project-sunbird/sunbird-pdf-player-web-component": "2.0.0",
-    "@project-sunbird/sunbird-quml-player-web-component": "6.0.0",
+    "@project-sunbird/sunbird-quml-player-web-component": "^6.0.10",
     "@project-sunbird/sunbird-resource-library": "8.0.0",
     "@project-sunbird/sunbird-video-player-web-component": "2.0.0",
     "@project-sunbird/telemetry-sdk": "^1.3.0",

--- a/projects/collection-editor-react/.gitignore
+++ b/projects/collection-editor-react/.gitignore
@@ -1,0 +1,40 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+lib/
+
+# Vite cache
+.vite/
+
+# TypeScript
+*.tsbuildinfo
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Editor directories
+.idea/
+.vscode/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test coverage
+coverage/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/projects/collection-editor-react/README.md
+++ b/projects/collection-editor-react/README.md
@@ -1,0 +1,238 @@
+# @project-sunbird/collection-editor-react
+
+A React component library for the Sunbird Collection Editor — build, organise and manage hierarchical content collections (courses, textbooks, playlists) inside any React 18 application or as a framework-agnostic web component.
+
+---
+
+## Installation
+
+```bash
+npm install @project-sunbird/collection-editor-react
+```
+
+**Peer dependencies** (install separately if not already present):
+
+```bash
+npm install react@^18 react-dom@^18
+```
+
+---
+
+## Quick start — React
+
+```tsx
+import { CollectionEditor } from '@project-sunbird/collection-editor-react';
+import '@project-sunbird/collection-editor-react/dist/style.css';
+
+const config = {
+  context: {
+    authToken: 'your-bearer-token', // omit when using a server-side proxy
+    userId: 'user-id',
+    sid: 'session-id',
+    did: 'device-id',
+    channel: 'channel-id',
+    pdata: { id: 'your.app.id', ver: '1.0' },
+    env: 'collection_editor',
+    identifier: 'do_123456789',   // content identifier to load
+    contentId: 'do_123456789',
+  },
+  config: {
+    mode: 'edit',                 // 'edit' | 'review' | 'read' | 'sourcingreview'
+    objectType: 'Collection',
+    primaryCategory: 'Content Playlist',
+    maxDepth: 4,
+  },
+};
+
+export default function App() {
+  return (
+    <CollectionEditor
+      {...config}
+      onToolbarEvent={({ action, data }) => {
+        if (action === 'back') window.history.back();
+      }}
+    />
+  );
+}
+```
+
+---
+
+## Quick start — Web component (framework-agnostic)
+
+Register once (e.g. in your app entry point), then use the custom element anywhere:
+
+```ts
+import { registerCollectionEditor } from '@project-sunbird/collection-editor-react';
+import '@project-sunbird/collection-editor-react/dist/style.css';
+
+registerCollectionEditor(); // registers <sb-collection-editor>
+```
+
+```html
+<sb-collection-editor id="editor"></sb-collection-editor>
+
+<script>
+  const el = document.getElementById('editor');
+  el.config = JSON.stringify({
+    context: { /* ... */ },
+    config: { mode: 'edit', objectType: 'Collection' },
+  });
+  el.onToolbarEvent = (e) => console.log('toolbar:', e.detail);
+</script>
+```
+
+You can pass a custom tag name to avoid collisions:
+
+```ts
+registerCollectionEditor('my-collection-editor');
+```
+
+---
+
+## API
+
+### `<CollectionEditor>` props
+
+| Prop | Type | Required | Description |
+|---|---|---|---|
+| `context` | `IContext` | ✅ | Runtime context — user, session, channel, framework |
+| `config` | `IConfig` | ✅ | Editor behaviour — mode, objectType, depth, category |
+| `metadata` | `Record<string, unknown>` | — | Pre-loaded content metadata |
+| `apiBaseUrl` | `string` | — | Base URL for all API calls. Omit when using a server-side proxy |
+| `onToolbarEvent` | `(e: { action: ToolbarAction; data?: unknown }) => void` | — | Fired on every toolbar button click |
+| `onContentAdded` | `(item: unknown, targetNodeId: string) => void` | — | Fired when content is added from library |
+| `onHierarchySaved` | `(hierarchy: unknown) => void` | — | Fired after a successful hierarchy save |
+| `onError` | `(error: Error) => void` | — | Fired on unrecoverable editor errors |
+
+### `IContext`
+
+```ts
+interface IContext {
+  authToken: string;          // Bearer token; use '' when auth is cookie-based
+  userId: string;
+  sid: string;                // Session ID
+  did: string;                // Device ID
+  channel: string;            // Org channel / hashTagId
+  pdata: { id: string; ver: string; pid?: string }; // Producer data (telemetry)
+  env: string;                // e.g. 'collection_editor'
+  contentId?: string;         // Identifier of the collection to load
+  identifier?: string;        // Alias for contentId
+  framework?: string;         // Org framework ID
+  targetFWIds?: string[];     // Target framework IDs
+  uid?: string;
+  rollup?: Record<string, string>;
+  tags?: string[];
+}
+```
+
+### `IConfig`
+
+```ts
+interface IConfig {
+  mode: 'edit' | 'review' | 'read' | 'sourcingreview';
+  objectType: string;          // e.g. 'Collection'
+  primaryCategory?: string;    // e.g. 'Content Playlist', 'Course'
+  framework?: string[];
+  targetFWIds?: string[];
+  maxDepth?: number;           // Max folder nesting depth (default: 4)
+  allowContentUnderRoot?: boolean;
+  hierarchy?: Record<string, unknown>;
+  defaultFields?: Record<string, unknown>;
+}
+```
+
+### `ToolbarAction`
+
+```ts
+type ToolbarAction =
+  | 'back' | 'preview' | 'saveCollection' | 'publish'
+  | 'sendForReview' | 'reject' | 'sendBackForCorrections'
+  | 'sourcingApprove' | 'sourcingReject'
+  | 'addUnit' | 'addSubUnit'
+  | 'manageCollaborators' | 'csvUpload'
+  | 'onFormValueChange' | 'onFormStatusChange';
+```
+
+---
+
+## API base URL
+
+By default all API calls are made relative to the page origin (works with a server-side proxy). To point directly at a backend:
+
+```ts
+import { setApiBaseUrl } from '@project-sunbird/collection-editor-react';
+
+setApiBaseUrl('https://api.your-sunbird-instance.com');
+```
+
+Or pass it inline — the editor calls `setApiBaseUrl` automatically on mount:
+
+```tsx
+<CollectionEditor
+  {...config}
+  apiBaseUrl="https://api.your-sunbird-instance.com"
+/>
+```
+
+---
+
+## Stores (advanced)
+
+The editor exposes its internal Zustand stores for advanced integration scenarios — for example, reading the current tree selection from outside the component:
+
+```ts
+import { useEditorStore, useTreeStore, useLibraryStore } from '@project-sunbird/collection-editor-react';
+
+// Inside a React component
+const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
+const editorMode    = useEditorStore((s) => s.editorMode);
+```
+
+---
+
+## Styles
+
+The stylesheet **must** be imported once in your app — it is not auto-injected:
+
+```ts
+import '@project-sunbird/collection-editor-react/dist/style.css';
+```
+
+---
+
+## Development setup
+
+```bash
+# Clone the monorepo
+git clone https://github.com/Sunbird-Ed/sunbird-collection-editor.git
+cd sunbird-collection-editor/projects/collection-editor-react
+
+# Install
+npm install
+
+# Dev server (proxies /action and /api to localhost:3000)
+npm run dev
+
+# Build library
+npm run build
+
+# Run tests
+npm test
+```
+
+---
+
+## Compatibility
+
+| Dependency | Version |
+|---|---|
+| React | 18.x |
+| React DOM | 18.x |
+| Node | 18+ |
+
+---
+
+## License
+
+MIT — see the repository root for the full licence text.

--- a/projects/collection-editor-react/index.html
+++ b/projects/collection-editor-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collection Editor React — Dev</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/dev-main.tsx"></script>
+  </body>
+</html>

--- a/projects/collection-editor-react/package-lock.json
+++ b/projects/collection-editor-react/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@sunbird/collection-editor-react",
+  "name": "@project-sunbird/collection-editor-react",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sunbird/collection-editor-react",
+      "name": "@project-sunbird/collection-editor-react",
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",

--- a/projects/collection-editor-react/package-lock.json
+++ b/projects/collection-editor-react/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/collection-editor-react",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@project-sunbird/sunbird-quml-player-web-component": "^6.0.10",
+        "@project-sunbird/sunbird-quml-player-web-component-react": "^0.1.2",
         "@tanstack/react-query": "^5.51.0",
         "axios": "^1.7.2",
         "lucide-react": "^0.400.0",
@@ -1262,10 +1262,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@project-sunbird/sunbird-quml-player-web-component": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.10.tgz",
-      "integrity": "sha512-v6uaAkQ8Vdr8x6RGCH53uLRv0AgaLaDZzYorNS3uF6fSuo8iQmTXH8SGonXyYcgQnZkLhDHvEvqZ64yX5h4M3g==",
+    "node_modules/@project-sunbird/sunbird-quml-player-web-component-react": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component-react/-/sunbird-quml-player-web-component-react-0.1.2.tgz",
+      "integrity": "sha512-l5JRbxbToc6yubGdOK5nAqIpY25pnBvO+DmXM0ksw1ThsqrBcg5i/elE4f5DswthvxVRmNB1J0rGWY43510lgA==",
       "license": "MIT"
     },
     "node_modules/@react-dnd/asap": {

--- a/projects/collection-editor-react/package-lock.json
+++ b/projects/collection-editor-react/package-lock.json
@@ -14,9 +14,7 @@
         "@tanstack/react-query": "^5.51.0",
         "axios": "^1.7.2",
         "lucide-react": "^0.400.0",
-        "react": "^18.3.1",
         "react-arborist": "^3.4.0",
-        "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.0",
         "react-hot-toast": "^2.4.1",
         "react-to-webcomponent": "^1.1.0",
@@ -3183,6 +3181,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -3466,6 +3465,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3534,6 +3534,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3743,6 +3744,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/projects/collection-editor-react/package-lock.json
+++ b/projects/collection-editor-react/package-lock.json
@@ -1,0 +1,4309 @@
+{
+  "name": "@sunbird/collection-editor-react",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sunbird/collection-editor-react",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@tanstack/react-query": "^5.51.0",
+        "axios": "^1.7.2",
+        "lucide-react": "^0.400.0",
+        "react": "^18.3.1",
+        "react-arborist": "^3.4.0",
+        "react-dom": "^18.3.1",
+        "react-hook-form": "^7.52.0",
+        "react-hot-toast": "^2.4.1",
+        "react-to-webcomponent": "^1.1.0",
+        "zod": "^3.23.8",
+        "zustand": "^4.5.4"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.6",
+        "@testing-library/react": "^16.0.0",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "sass": "^1.77.6",
+        "typescript": "^5.5.3",
+        "vite": "^5.3.4",
+        "vite-plugin-dts": "^3.9.1",
+        "vitest": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.43.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.43.0.tgz",
+      "integrity": "sha512-GFhTcJpB+MI6FhvXEI9b2K0snulNLWHqC/BbcJtyNYcKUiw7l3Lgis5ApsYncJ0leALX7/of4XfmXk+maT111w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.28.13",
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "4.0.2",
+        "@rushstack/rig-package": "0.5.2",
+        "@rushstack/terminal": "0.10.0",
+        "@rushstack/ts-command-line": "4.19.1",
+        "lodash": "~4.17.15",
+        "minimatch": "~3.0.3",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
+        "source-map": "~0.6.1",
+        "typescript": "5.4.2"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.28.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.13.tgz",
+      "integrity": "sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "4.0.2"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
+      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.0.2.tgz",
+      "integrity": "sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
+        "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.2.tgz",
+      "integrity": "sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "~1.22.1",
+        "strip-json-comments": "~3.1.1"
+      }
+    },
+    "node_modules/@rushstack/terminal": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.10.0.tgz",
+      "integrity": "sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/node-core-library": "4.0.2",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.19.1.tgz",
+      "integrity": "sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/terminal": "0.10.0",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
+      "integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "1.11.1"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
+      "integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "muggle-string": "^0.3.1"
+      }
+    },
+    "node_modules/@volar/typescript": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
+      "integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "1.11.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "1.8.27",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.27.tgz",
+      "integrity": "sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "~1.11.1",
+        "@volar/source-map": "~1.11.1",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "computeds": "^0.0.1",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.3.1",
+        "path-browserify": "^1.0.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/computeds": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dnd-core": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-14.0.1.tgz",
+      "integrity": "sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^4.0.0",
+        "@react-dnd/invariant": "^2.0.0",
+        "redux": "^4.1.1"
+      }
+    },
+    "node_modules/dnd-core/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.400.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.400.0.tgz",
+      "integrity": "sha512-rpp7pFHh3Xd93KHixNgB0SqThMHpYNzsGUu69UaQbSZ75Q/J3m5t6EhKyMT3m4w2WOxmJ2mY0tD3vebnXqQryQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-arborist": {
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-3.10.5.tgz",
+      "integrity": "sha512-gbxFTLb0vCGmFOcJ/ZY2/ymCIdG4U8ok6fApsSeUWhGxUXwgtLpbylKNbSpzhjovv1D3VRFTW3OiiRs+Coh1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-dnd": "^14.0.3",
+        "react-dnd-html5-backend": "^14.0.3",
+        "react-window": "^1.8.11",
+        "redux": "^5.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14",
+        "react-dom": ">= 16.14"
+      }
+    },
+    "node_modules/react-dnd": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.5.tgz",
+      "integrity": "sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^2.0.0",
+        "@react-dnd/shallowequal": "^2.0.0",
+        "dnd-core": "14.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.1.0.tgz",
+      "integrity": "sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "14.0.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.79.0.tgz",
+      "integrity": "sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-to-webcomponent": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/react-to-webcomponent/-/react-to-webcomponent-1.7.6.tgz",
+      "integrity": "sha512-Y2CLlp3hUTov+6UAvaIzDya7JzvopxHjl9jKg4LiFHmwjgcFBAGcbcP03LgR8FivXuly4Ze6F/v/9bYqtTalKw==",
+      "license": "MIT"
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-dts": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.9.1.tgz",
+      "integrity": "sha512-rVp2KM9Ue22NGWB8dNtWEr+KekN3rIgz1tWD050QnRGlriUCmaDwa7qA5zDEjbXg5lAXhYMSBJtx3q3hQIJZSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor": "7.43.0",
+        "@rollup/pluginutils": "^5.1.0",
+        "@vue/language-core": "^1.8.27",
+        "debug": "^4.3.4",
+        "kolorist": "^1.8.0",
+        "magic-string": "^0.30.8",
+        "vue-tsc": "^1.8.27"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-template-compiler": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
+      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "1.8.27",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.27.tgz",
+      "integrity": "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "~1.11.1",
+        "@vue/language-core": "1.8.27",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/projects/collection-editor-react/package-lock.json
+++ b/projects/collection-editor-react/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.0",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/collection-editor-react",
-      "version": "0.1.0",
+      "version": "0.1.19",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@project-sunbird/sunbird-quml-player-web-component": "^6.0.10",
         "@tanstack/react-query": "^5.51.0",
         "axios": "^1.7.2",
         "lucide-react": "^0.400.0",
@@ -34,8 +35,8 @@
         "vitest": "^2.0.3"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1260,6 +1261,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/@project-sunbird/sunbird-quml-player-web-component": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.10.tgz",
+      "integrity": "sha512-v6uaAkQ8Vdr8x6RGCH53uLRv0AgaLaDZzYorNS3uF6fSuo8iQmTXH8SGonXyYcgQnZkLhDHvEvqZ64yX5h4M3g==",
+      "license": "MIT"
     },
     "node_modules/@react-dnd/asap": {
       "version": "4.0.1",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",
@@ -58,7 +58,7 @@
     "vitest": "^2.0.3"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   }
 }

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -24,6 +24,8 @@
     "access": "public"
   },
   "scripts": {
+    "copy-player-assets": "node scripts/copy-player-assets.mjs",
+    "predev": "npm run copy-player-assets",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
+    "@project-sunbird/sunbird-quml-player-web-component": "^6.0.10",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.51.0",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sunbird/collection-editor-react",
+  "name": "@project-sunbird/collection-editor-react",
   "version": "0.1.0",
   "private": false,
   "type": "module",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -11,7 +11,17 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./dist/style.css": "./dist/style.css"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": [
+    "*.css"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "dev": "vite",
@@ -26,9 +36,7 @@
     "@tanstack/react-query": "^5.51.0",
     "axios": "^1.7.2",
     "lucide-react": "^0.400.0",
-    "react": "^18.3.1",
     "react-arborist": "^3.4.0",
-    "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.0",
     "react-hot-toast": "^2.4.1",
     "react-to-webcomponent": "^1.1.0",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
-    "@project-sunbird/sunbird-quml-player-web-component": "^6.0.10",
+    "@project-sunbird/sunbird-quml-player-web-component-react": "^0.1.2",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.51.0",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/collection-editor-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "type": "module",
   "main": "dist/index.cjs",

--- a/projects/collection-editor-react/package.json
+++ b/projects/collection-editor-react/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@sunbird/collection-editor-react",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@tanstack/react-query": "^5.51.0",
+    "axios": "^1.7.2",
+    "lucide-react": "^0.400.0",
+    "react": "^18.3.1",
+    "react-arborist": "^3.4.0",
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.52.0",
+    "react-hot-toast": "^2.4.1",
+    "react-to-webcomponent": "^1.1.0",
+    "zod": "^3.23.8",
+    "zustand": "^4.5.4"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "sass": "^1.77.6",
+    "typescript": "^5.5.3",
+    "vite": "^5.3.4",
+    "vite-plugin-dts": "^3.9.1",
+    "vitest": "^2.0.3"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/projects/collection-editor-react/scripts/copy-player-assets.mjs
+++ b/projects/collection-editor-react/scripts/copy-player-assets.mjs
@@ -18,26 +18,48 @@ const projectRoot = resolve(__dirname, '..');
 const nodeModules = resolve(projectRoot, '../../node_modules');
 const destDir = resolve(projectRoot, 'public/assets');
 
-const PLAYERS = [
+// Flattened players (pdf/video/epub) — served at /assets/sunbird-*-player.js.
+// Their contents share the /assets root as angular.json does.
+const FLAT_PLAYERS = [
   '@project-sunbird/sunbird-pdf-player-web-component/assets/pdf-player',
   '@project-sunbird/sunbird-video-player-web-component/assets/video-player',
   '@project-sunbird/sunbird-epub-player-web-component/assets/epub-player',
-  '@project-sunbird/sunbird-quml-player-web-component/assets/quml-player',
+];
+
+// QuML is copied into its own subdir so its styles.css does not collide with
+// the other players' styles.css when flattened. Served at
+// /assets/quml-player/sunbird-quml-player.js and /assets/quml-player/styles.css.
+const SUBDIR_PLAYERS = [
+  {
+    rel: '@project-sunbird/sunbird-quml-player-web-component/assets/quml-player',
+    dest: resolve(destDir, 'quml-player'),
+  },
 ];
 
 mkdirSync(destDir, { recursive: true });
 
 let copied = 0;
-for (const rel of PLAYERS) {
+const total = FLAT_PLAYERS.length + SUBDIR_PLAYERS.length;
+for (const rel of FLAT_PLAYERS) {
   const src = resolve(nodeModules, rel);
   if (!existsSync(src)) {
     console.warn(`[copy-player-assets] skip (not found): ${rel}`);
     continue;
   }
-  // Flatten each player dir's contents directly into public/assets (as angular.json does)
   cpSync(src, destDir, { recursive: true });
   copied++;
   console.log(`[copy-player-assets] copied ${rel} -> public/assets/`);
 }
+for (const { rel, dest } of SUBDIR_PLAYERS) {
+  const src = resolve(nodeModules, rel);
+  if (!existsSync(src)) {
+    console.warn(`[copy-player-assets] skip (not found): ${rel}`);
+    continue;
+  }
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+  copied++;
+  console.log(`[copy-player-assets] copied ${rel} -> ${dest}/`);
+}
 
-console.log(`[copy-player-assets] done (${copied}/${PLAYERS.length} players)`);
+console.log(`[copy-player-assets] done (${copied}/${total} players)`);

--- a/projects/collection-editor-react/scripts/copy-player-assets.mjs
+++ b/projects/collection-editor-react/scripts/copy-player-assets.mjs
@@ -29,9 +29,11 @@ const FLAT_PLAYERS = [
 // QuML is copied into its own subdir so its styles.css does not collide with
 // the other players' styles.css when flattened. Served at
 // /assets/quml-player/sunbird-quml-player.js and /assets/quml-player/styles.css.
+// Source is the React-based rebuild of the player (same custom element and
+// player-config contract; new data.sections/identifier config schema).
 const SUBDIR_PLAYERS = [
   {
-    rel: '@project-sunbird/sunbird-quml-player-web-component/assets/quml-player',
+    rel: '@project-sunbird/sunbird-quml-player-web-component-react/assets/quml-player',
     dest: resolve(destDir, 'quml-player'),
   },
 ];

--- a/projects/collection-editor-react/scripts/copy-player-assets.mjs
+++ b/projects/collection-editor-react/scripts/copy-player-assets.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Copies the Sunbird web-component player assets (pdf / video / epub / quml)
+ * from node_modules into public/assets so the dev server (and any static
+ * build) serves them at /assets/sunbird-*-player.js — mirroring what the
+ * Angular app does via angular.json `assets`/`scripts`.
+ *
+ * Runs automatically on `predev` and `prebuild`.
+ */
+import { existsSync, mkdirSync, cpSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+
+// node_modules is hoisted to the monorepo root
+const nodeModules = resolve(projectRoot, '../../node_modules');
+const destDir = resolve(projectRoot, 'public/assets');
+
+const PLAYERS = [
+  '@project-sunbird/sunbird-pdf-player-web-component/assets/pdf-player',
+  '@project-sunbird/sunbird-video-player-web-component/assets/video-player',
+  '@project-sunbird/sunbird-epub-player-web-component/assets/epub-player',
+  '@project-sunbird/sunbird-quml-player-web-component/assets/quml-player',
+];
+
+mkdirSync(destDir, { recursive: true });
+
+let copied = 0;
+for (const rel of PLAYERS) {
+  const src = resolve(nodeModules, rel);
+  if (!existsSync(src)) {
+    console.warn(`[copy-player-assets] skip (not found): ${rel}`);
+    continue;
+  }
+  // Flatten each player dir's contents directly into public/assets (as angular.json does)
+  cpSync(src, destDir, { recursive: true });
+  copied++;
+  console.log(`[copy-player-assets] copied ${rel} -> public/assets/`);
+}
+
+console.log(`[copy-player-assets] done (${copied}/${PLAYERS.length} players)`);

--- a/projects/collection-editor-react/src/api/asset.ts
+++ b/projects/collection-editor-react/src/api/asset.ts
@@ -49,7 +49,8 @@ export async function uploadToBlob(
     method: 'PUT',
     body: file,
     headers: {
-      'Content-Type': file.type,
+      'x-ms-blob-type': 'BlockBlob',
+      'Content-Type': 'application/octet-stream',
       ...presignedHeaders,
     },
   });

--- a/projects/collection-editor-react/src/api/asset.ts
+++ b/projects/collection-editor-react/src/api/asset.ts
@@ -1,0 +1,82 @@
+import { apiClient } from './client';
+
+export async function createMediaAsset(
+  name: string,
+  mimeType: string,
+  createdBy: string,
+  channel: string,
+): Promise<string> {
+  const resp = await apiClient.post('/action/asset/v1/create', {
+    request: {
+      asset: {
+        primaryCategory: 'asset',
+        language: ['English'],
+        code: crypto.randomUUID(),
+        name,
+        mediaType: 'image',
+        mimeType,
+        createdBy,
+        creator: null,
+        channel,
+        keywords: '',
+      },
+    },
+  });
+  const nodeId: string | undefined = resp.data?.result?.node_id;
+  if (!nodeId) throw new Error('Asset creation failed: no node_id returned');
+  return nodeId;
+}
+
+export async function getPreSignedUrl(
+  assetId: string,
+  fileName: string,
+): Promise<string> {
+  const resp = await apiClient.post(
+    `/action/content/v3/upload/url/${assetId}`,
+    { request: { content: { fileName } } },
+  );
+  const url: string | undefined = resp.data?.result?.pre_signed_url;
+  if (!url) throw new Error('Pre-signed URL fetch failed');
+  return url;
+}
+
+export async function uploadToBlob(
+  signedUrl: string,
+  file: File,
+  presignedHeaders: Record<string, string> = {},
+): Promise<void> {
+  const resp = await fetch(signedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': file.type,
+      ...presignedHeaders,
+    },
+  });
+  if (!resp.ok) throw new Error(`Blob upload failed: ${resp.status} ${resp.statusText}`);
+}
+
+export async function finalizeAssetUpload(
+  assetId: string,
+  fileUrl: string,
+  mimeType: string,
+): Promise<string> {
+  const formData = new FormData();
+  formData.append('fileUrl', fileUrl);
+  formData.append('mimeType', mimeType);
+  const resp = await apiClient.post(
+    `/action/asset/v1/upload/${assetId}`,
+    formData,
+    {
+      params: {
+        enctype: 'multipart/form-data',
+        processData: false,
+        contentType: false,
+        cache: false,
+      },
+    },
+  );
+  const contentUrl: string | undefined = resp.data?.result?.content_url;
+  if (!contentUrl) throw new Error('Asset finalize failed: no content_url returned');
+  return contentUrl;
+}

--- a/projects/collection-editor-react/src/api/bulkUpload.ts
+++ b/projects/collection-editor-react/src/api/bulkUpload.ts
@@ -35,15 +35,25 @@ async function uploadToSignedUrl(signedUrl: string, file: File): Promise<string>
 }
 
 // Stage 3 — kick off the import from the uploaded fileUrl.
+// The collection/v1/import API expects multipart/form-data with bare fields —
+// NOT a JSON body with a request wrapper. Sending JSON causes a 400/422.
 export async function uploadCsvHierarchy(
   contentId: string,
   file: File,
 ): Promise<{ processId: string }> {
   const signedUrl = await getUploadUrl(contentId, file.name);
   const fileUrl = await uploadToSignedUrl(signedUrl, file);
-  const response = await apiClient.post(`/action/collection/v1/import/${contentId}`, {
-    request: { fileUrl, mimeType: 'text/csv' },
-  });
+
+  const formData = new FormData();
+  formData.append('fileUrl', fileUrl);
+  formData.append('mimeType', file.type || 'text/csv');
+
+  // Do NOT set Content-Type manually — let the browser/axios set
+  // multipart/form-data with the correct boundary automatically.
+  const response = await apiClient.post(
+    `/action/collection/v1/import/${contentId}`,
+    formData,
+  );
   const result = response.data?.result ?? {};
   return { processId: (result.processId as string) ?? '' };
 }

--- a/projects/collection-editor-react/src/api/bulkUpload.ts
+++ b/projects/collection-editor-react/src/api/bulkUpload.ts
@@ -1,0 +1,26 @@
+import { apiClient } from './client';
+
+export async function uploadCsvHierarchy(contentId: string, file: File): Promise<{ processId: string }> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const response = await apiClient.post(
+    `/action/collection/v1/import/${contentId}`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } },
+  );
+  return response.data?.result ?? { processId: '' };
+}
+
+export async function getCsvUploadStatus(processId: string): Promise<{
+  status: 'PENDING' | 'COMPLETED' | 'FAILED';
+  failedRecords?: unknown[];
+  successCount?: number;
+}> {
+  const response = await apiClient.get(`/action/collection/v1/import/status/${processId}`);
+  return response.data?.result ?? { status: 'PENDING' };
+}
+
+export async function downloadSampleCsv(contentId: string): Promise<Blob> {
+  const response = await apiClient.get(`/action/collection/v1/export/${contentId}`, { responseType: 'blob' });
+  return response.data as Blob;
+}

--- a/projects/collection-editor-react/src/api/bulkUpload.ts
+++ b/projects/collection-editor-react/src/api/bulkUpload.ts
@@ -1,14 +1,51 @@
 import { apiClient } from './client';
 
-export async function uploadCsvHierarchy(contentId: string, file: File): Promise<{ processId: string }> {
-  const formData = new FormData();
-  formData.append('file', file);
+// ---------------------------------------------------------------------------
+// CSV import is a 3-stage flow (matching the Sunbird collection editor):
+//   1. ask the content service for a pre-signed blob URL
+//   2. PUT the CSV file straight to that blob URL
+//   3. tell the collection service to import from the uploaded fileUrl
+// ---------------------------------------------------------------------------
+
+// Stage 1 — get a pre-signed upload URL for the hierarchy CSV.
+async function getUploadUrl(contentId: string, fileName: string): Promise<string> {
   const response = await apiClient.post(
-    `/action/collection/v1/import/${contentId}`,
-    formData,
-    { headers: { 'Content-Type': 'multipart/form-data' } },
+    `/action/content/v3/upload/url/${contentId}?type=hierarchy`,
+    { request: { content: { fileName } } },
   );
-  return response.data?.result ?? { processId: '' };
+  const result = response.data?.result ?? {};
+  const url = (result.content?.preSignedURL ?? result.pre_signed_url ?? result.preSignedUrl) as
+    | string
+    | undefined;
+  if (!url) throw new Error('Could not obtain an upload URL');
+  return url;
+}
+
+// Stage 2 — upload the file binary to the (Azure) blob via the signed URL.
+// Goes directly to blob storage, so it must NOT carry the apiClient auth header.
+async function uploadToSignedUrl(signedUrl: string, file: File): Promise<string> {
+  const res = await fetch(signedUrl, {
+    method: 'PUT',
+    headers: { 'x-ms-blob-type': 'BlockBlob', 'Content-Type': 'text/csv' },
+    body: file,
+  });
+  if (!res.ok) throw new Error(`Blob upload failed (${res.status})`);
+  // The committed file URL is the signed URL without its query string.
+  return signedUrl.split('?')[0];
+}
+
+// Stage 3 — kick off the import from the uploaded fileUrl.
+export async function uploadCsvHierarchy(
+  contentId: string,
+  file: File,
+): Promise<{ processId: string }> {
+  const signedUrl = await getUploadUrl(contentId, file.name);
+  const fileUrl = await uploadToSignedUrl(signedUrl, file);
+  const response = await apiClient.post(`/action/collection/v1/import/${contentId}`, {
+    request: { fileUrl, mimeType: 'text/csv' },
+  });
+  const result = response.data?.result ?? {};
+  return { processId: (result.processId as string) ?? '' };
 }
 
 export async function getCsvUploadStatus(processId: string): Promise<{
@@ -20,7 +57,16 @@ export async function getCsvUploadStatus(processId: string): Promise<{
   return response.data?.result ?? { status: 'PENDING' };
 }
 
-export async function downloadSampleCsv(contentId: string): Promise<Blob> {
-  const response = await apiClient.get(`/action/collection/v1/export/${contentId}`, { responseType: 'blob' });
-  return response.data as Blob;
+// Export the current folder hierarchy as CSV. The export API returns a JSON
+// body with a pre-signed `tocUrl`, not a file blob.
+export async function exportFolderCsv(contentId: string): Promise<string> {
+  const response = await apiClient.get(`/action/collection/v1/export/${contentId}`);
+  const tocUrl = response.data?.result?.collection?.tocUrl as string | undefined;
+  if (!tocUrl) throw new Error('No export URL returned');
+  return tocUrl;
+}
+
+// Backwards-compatible alias — returns the export CSV URL for sample/download use.
+export async function downloadSampleCsv(contentId: string): Promise<string> {
+  return exportFolderCsv(contentId);
 }

--- a/projects/collection-editor-react/src/api/categoryDefinition.ts
+++ b/projects/collection-editor-react/src/api/categoryDefinition.ts
@@ -37,8 +37,8 @@ export interface ICategoryField {
 
 export interface IParsedCategoryDefinition {
   rootForm: ICategoryField[];          // forms.create
-  unitForm: ICategoryField[];          // forms.unitMetadata
-  childForm: ICategoryField[];         // forms.childMetadata
+  unitForm: ICategoryField[];          // forms.unitMetadata  (name / description / keywords / topic)
+  childForm: ICategoryField[];         // forms.childMetadata (name / author / copyright / license …)
   searchForm: ICategoryField[];        // forms.search
   relationalForm: ICategoryField[];    // forms.relationalMetadata
   publishChecklist: ICategoryField[];  // forms.publishchecklist

--- a/projects/collection-editor-react/src/api/categoryDefinition.ts
+++ b/projects/collection-editor-react/src/api/categoryDefinition.ts
@@ -1,76 +1,161 @@
 import { apiClient } from './client';
 
-export interface ICategoryDefinitionField {
+// API version: prod historically used v1; the current backend serves v4.
+// Kept as a constant so it can be swapped per environment without touching call sites.
+const CATEGORY_DEFINITION_VERSION = 'v4';
+
+// ---------------------------------------------------------------------------
+// A single normalized field, derived from one entry in a form's `properties`
+// (or a section's `fields[]`). Carries everything the form layer needs.
+// ---------------------------------------------------------------------------
+export interface ICategoryField {
   code: string;
-  label?: string;
+  label: string;
+  name?: string;
   inputType?: string;
   dataType?: string;
-  required?: boolean;
-  editable?: boolean;
+  required: boolean;
+  editable: boolean;
+  visible: boolean;
   placeholder?: string;
   maxLength?: number;
-  range?: Array<{ name: string; identifier: string }>;
-  enum?: string[];
   depends?: string[];
+  /** Framework category the field's options are sourced from (board/medium/…). */
+  sourceCategory?: string;
+  /** Raw range: string[] OR Array<{ name; identifier }>. */
+  range?: unknown;
+  enum?: string[];
   default?: unknown;
-  validations?: unknown;
+  defaultValue?: unknown;
+  index?: number;
+  /** Section title the field was grouped under (drives tab assignment). */
+  section?: string;
+  /** 'name' | 'identifier' — which term property to store as the value. */
+  output?: string;
   [key: string]: unknown;
 }
 
-export interface ICategoryDefinitionForm {
-  properties?: ICategoryDefinitionField[];
+export interface IParsedCategoryDefinition {
+  rootForm: ICategoryField[];          // forms.create
+  unitForm: ICategoryField[];          // forms.unitMetadata
+  childForm: ICategoryField[];         // forms.childMetadata
+  searchForm: ICategoryField[];        // forms.search
+  relationalForm: ICategoryField[];    // forms.relationalMetadata
+  publishChecklist: ICategoryField[];  // forms.publishchecklist
+  reviewChecklist: ICategoryField[];   // forms.review
+  rfcChecklist: ICategoryField[];      // forms.requestforchangeschecklist
+  /** schema.properties[*].default keyed by property name (generateDIALCodes, …). */
+  schemaDefaults: Record<string, unknown>;
+  frameworkMetadata: { orgFWType?: string[]; targetFWType?: string[] };
+  sourcingSettings: Record<string, unknown>;
 }
 
-export interface ICategoryDefinitionForms {
-  create?: ICategoryDefinitionForm;
-  unitMetadata?: ICategoryDefinitionForm;
-  [key: string]: ICategoryDefinitionForm | undefined;
+// Back-compat alias retained for any older imports.
+export type ICategoryDefinitionField = ICategoryField;
+
+function maxLengthFromValidations(field: Record<string, unknown>): number | undefined {
+  const validations = field.validations as Array<Record<string, unknown>> | undefined;
+  const ml = validations?.find(v => v.type === 'maxlength' || v.type === 'maxLength');
+  if (!ml) return field.maxLength as number | undefined;
+  const n = Number(ml.value);
+  return Number.isFinite(n) ? n : undefined;
 }
 
-export interface ICategoryDefinitionResult {
-  rootFormFields: ICategoryDefinitionField[];
-  unitFormFields: ICategoryDefinitionField[];
+function normalizeField(raw: Record<string, unknown>, section?: string): ICategoryField {
+  return {
+    code: (raw.code as string) ?? '',
+    label: (raw.label as string) ?? (raw.name as string) ?? (raw.code as string) ?? '',
+    name: raw.name as string | undefined,
+    inputType: raw.inputType as string | undefined,
+    dataType: raw.dataType as string | undefined,
+    // A field is required if flagged, has a required validation, or the
+    // rendering-hints class includes "required" (Sunbird convention).
+    required:
+      raw.required === true ||
+      (Array.isArray(raw.validations) &&
+        (raw.validations as Array<Record<string, unknown>>).some(v => v.type === 'required')) ||
+      String((raw.renderingHints as Record<string, unknown>)?.class ?? '').includes('required'),
+    editable: raw.editable !== false,
+    visible: raw.visible !== false,
+    placeholder: raw.placeholder as string | undefined,
+    maxLength: maxLengthFromValidations(raw),
+    depends: raw.depends as string[] | undefined,
+    sourceCategory: raw.sourceCategory as string | undefined,
+    range: raw.range,
+    enum: raw.enum as string[] | undefined,
+    default: raw.default,
+    defaultValue: raw.defaultValue,
+    index: raw.index as number | undefined,
+    section,
+    output: raw.output as string | undefined,
+  };
+}
+
+// Flatten a form's `properties` (sections with `fields[]`, or flat fields)
+// into a single ordered field list, tagging each field with its section title.
+function parseForm(form: unknown): ICategoryField[] {
+  const properties = (form as { properties?: unknown })?.properties;
+  if (!Array.isArray(properties)) return [];
+
+  const fields: ICategoryField[] = [];
+  for (const item of properties as Array<Record<string, unknown>>) {
+    if (Array.isArray(item.fields)) {
+      const sectionTitle = (item.title as string) ?? (item.name as string) ?? undefined;
+      for (const f of item.fields as Array<Record<string, unknown>>) {
+        if (f.code) fields.push(normalizeField(f, sectionTitle));
+      }
+    } else if (item.code) {
+      fields.push(normalizeField(item));
+    }
+  }
+  // Stable order by `index` when present.
+  return fields.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+}
+
+function parseSchemaDefaults(schema: unknown): Record<string, unknown> {
+  const props = (schema as { properties?: Record<string, Record<string, unknown>> })?.properties;
+  if (!props) return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, def] of Object.entries(props)) {
+    if (def && 'default' in def) out[key] = def.default;
+  }
+  return out;
 }
 
 export async function getCategoryDefinition(
   categoryName: string,
   channel: string,
   objectType = 'Collection',
-): Promise<ICategoryDefinitionResult> {
+): Promise<IParsedCategoryDefinition> {
   const response = await apiClient.post(
-    '/action/object/category/definition/v1/read?fields=objectMetadata,forms,name,label',
+    `/action/object/category/definition/${CATEGORY_DEFINITION_VERSION}/read?fields=objectMetadata,forms,name,label`,
     {
       request: {
         objectCategoryDefinition: {
           objectType,
           name: categoryName,
-          channel,
+          ...(channel ? { channel } : {}),
         },
       },
     },
   );
 
-  const forms = response.data?.result?.objectCategoryDefinition?.forms as ICategoryDefinitionForms | undefined;
-  if (!forms) return { rootFormFields: [], unitFormFields: [] };
+  const ocd = response.data?.result?.objectCategoryDefinition as Record<string, unknown> | undefined;
+  const forms = (ocd?.forms ?? {}) as Record<string, unknown>;
+  const objectMetadata = (ocd?.objectMetadata ?? {}) as Record<string, unknown>;
+  const config = (objectMetadata.config ?? {}) as Record<string, unknown>;
 
   return {
-    rootFormFields: extractFields(forms.create),
-    unitFormFields: extractFields(forms.unitMetadata),
+    rootForm: parseForm(forms.create),
+    unitForm: parseForm(forms.unitMetadata),
+    childForm: parseForm(forms.childMetadata),
+    searchForm: parseForm(forms.search ?? forms.searchConfig),
+    relationalForm: parseForm(forms.relationalMetadata),
+    publishChecklist: parseForm(forms.publishchecklist),
+    reviewChecklist: parseForm(forms.review),
+    rfcChecklist: parseForm(forms.requestforchangeschecklist),
+    schemaDefaults: parseSchemaDefaults(objectMetadata.schema),
+    frameworkMetadata: (config.frameworkMetadata ?? {}) as { orgFWType?: string[]; targetFWType?: string[] },
+    sourcingSettings: (config.sourcingSettings ?? {}) as Record<string, unknown>,
   };
-}
-
-function extractFields(form?: ICategoryDefinitionForm): ICategoryDefinitionField[] {
-  if (!form?.properties?.length) return [];
-  const fields: ICategoryDefinitionField[] = [];
-  for (const item of form.properties) {
-    // items can be grouped as { fields: [...] } or flat field objects with `code`
-    if (Array.isArray((item as Record<string, unknown>).fields)) {
-      for (const f of (item as Record<string, unknown>).fields as ICategoryDefinitionField[]) {
-        if (f.code) fields.push(f);
-      }
-    } else if (item.code) {
-      fields.push(item);
-    }
-  }
-  return fields;
 }

--- a/projects/collection-editor-react/src/api/categoryDefinition.ts
+++ b/projects/collection-editor-react/src/api/categoryDefinition.ts
@@ -1,8 +1,8 @@
 import { apiClient } from './client';
 
-// API version: prod historically used v1; the current backend serves v4.
-// Kept as a constant so it can be swapped per environment without touching call sites.
-const CATEGORY_DEFINITION_VERSION = 'v4';
+// Default API version. Sandbox/older environments serve v1; current backends serve v4.
+// Callers can pass a version override via getCategoryDefinition's `version` param.
+const DEFAULT_CATEGORY_DEFINITION_VERSION = 'v4';
 
 // ---------------------------------------------------------------------------
 // A single normalized field, derived from one entry in a form's `properties`
@@ -126,9 +126,10 @@ export async function getCategoryDefinition(
   categoryName: string,
   channel: string,
   objectType = 'Collection',
+  version: 'v1' | 'v4' = DEFAULT_CATEGORY_DEFINITION_VERSION,
 ): Promise<IParsedCategoryDefinition> {
   const response = await apiClient.post(
-    `/action/object/category/definition/${CATEGORY_DEFINITION_VERSION}/read?fields=objectMetadata,forms,name,label`,
+    `/action/object/category/definition/${version}/read?fields=objectMetadata,forms,name,label`,
     {
       request: {
         objectCategoryDefinition: {

--- a/projects/collection-editor-react/src/api/categoryDefinition.ts
+++ b/projects/collection-editor-react/src/api/categoryDefinition.ts
@@ -1,0 +1,76 @@
+import { apiClient } from './client';
+
+export interface ICategoryDefinitionField {
+  code: string;
+  label?: string;
+  inputType?: string;
+  dataType?: string;
+  required?: boolean;
+  editable?: boolean;
+  placeholder?: string;
+  maxLength?: number;
+  range?: Array<{ name: string; identifier: string }>;
+  enum?: string[];
+  depends?: string[];
+  default?: unknown;
+  validations?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ICategoryDefinitionForm {
+  properties?: ICategoryDefinitionField[];
+}
+
+export interface ICategoryDefinitionForms {
+  create?: ICategoryDefinitionForm;
+  unitMetadata?: ICategoryDefinitionForm;
+  [key: string]: ICategoryDefinitionForm | undefined;
+}
+
+export interface ICategoryDefinitionResult {
+  rootFormFields: ICategoryDefinitionField[];
+  unitFormFields: ICategoryDefinitionField[];
+}
+
+export async function getCategoryDefinition(
+  categoryName: string,
+  channel: string,
+  objectType = 'Collection',
+): Promise<ICategoryDefinitionResult> {
+  const response = await apiClient.post(
+    '/action/object/category/definition/v1/read?fields=objectMetadata,forms,name,label',
+    {
+      request: {
+        objectCategoryDefinition: {
+          objectType,
+          name: categoryName,
+          channel,
+        },
+      },
+    },
+  );
+
+  const forms = response.data?.result?.objectCategoryDefinition?.forms as ICategoryDefinitionForms | undefined;
+  if (!forms) return { rootFormFields: [], unitFormFields: [] };
+
+  return {
+    rootFormFields: extractFields(forms.create),
+    unitFormFields: extractFields(forms.unitMetadata),
+  };
+}
+
+function extractFields(form?: ICategoryDefinitionForm): ICategoryDefinitionField[] {
+  if (!form?.properties?.length) return [];
+  const fields: ICategoryDefinitionField[] = [];
+  for (const item of form.properties) {
+    // items can be grouped as { fields: [...] } or flat field objects with `code`
+    if (Array.isArray((item as Record<string, unknown>).fields)) {
+      for (const f of (item as Record<string, unknown>).fields as ICategoryDefinitionField[]) {
+        if (f.code) fields.push(f);
+      }
+    } else if (item.code) {
+      fields.push(item);
+    }
+  }
+  return fields;
+}

--- a/projects/collection-editor-react/src/api/categoryDefinition.ts
+++ b/projects/collection-editor-react/src/api/categoryDefinition.ts
@@ -92,7 +92,9 @@ function normalizeField(raw: Record<string, unknown>, section?: string): ICatego
 }
 
 // Flatten a form's `properties` (sections with `fields[]`, or flat fields)
-// into a single ordered field list, tagging each field with its section title.
+// into a single ordered field list, tagging each field with its section name.
+// Fields are sorted within each section by their `index`, then sections are
+// concatenated in API order — preserving section grouping for the tab renderer.
 function parseForm(form: unknown): ICategoryField[] {
   const properties = (form as { properties?: unknown })?.properties;
   if (!Array.isArray(properties)) return [];
@@ -100,16 +102,19 @@ function parseForm(form: unknown): ICategoryField[] {
   const fields: ICategoryField[] = [];
   for (const item of properties as Array<Record<string, unknown>>) {
     if (Array.isArray(item.fields)) {
-      const sectionTitle = (item.title as string) ?? (item.name as string) ?? undefined;
-      for (const f of item.fields as Array<Record<string, unknown>>) {
-        if (f.code) fields.push(normalizeField(f, sectionTitle));
+      // Use machine name (not display title) so SECTION_TAB_MAP / SECTION_DISPLAY lookups work.
+      const sectionName = (item.name as string) ?? undefined;
+      const sectionFields = (item.fields as Array<Record<string, unknown>>)
+        .filter(f => !!f.code)
+        .sort((a, b) => ((a.index as number) ?? 0) - ((b.index as number) ?? 0));
+      for (const f of sectionFields) {
+        fields.push(normalizeField(f, sectionName));
       }
     } else if (item.code) {
       fields.push(normalizeField(item));
     }
   }
-  // Stable order by `index` when present.
-  return fields.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+  return fields;
 }
 
 function parseSchemaDefaults(schema: unknown): Record<string, unknown> {

--- a/projects/collection-editor-react/src/api/categoryDefinition.ts
+++ b/projects/collection-editor-react/src/api/categoryDefinition.ts
@@ -1,8 +1,8 @@
 import { apiClient } from './client';
 
-// Default API version. Sandbox/older environments serve v1; current backends serve v4.
+// Default API version. Both sandbox and test environments serve v1.
 // Callers can pass a version override via getCategoryDefinition's `version` param.
-const DEFAULT_CATEGORY_DEFINITION_VERSION = 'v4';
+const DEFAULT_CATEGORY_DEFINITION_VERSION = 'v1';
 
 // ---------------------------------------------------------------------------
 // A single normalized field, derived from one entry in a form's `properties`

--- a/projects/collection-editor-react/src/api/channel.ts
+++ b/projects/collection-editor-react/src/api/channel.ts
@@ -1,0 +1,15 @@
+import { apiClient } from './client';
+
+export interface IChannelData {
+  identifier: string;
+  name?: string;
+  frameworks?: Array<{ identifier: string; name: string; type?: string }>;
+  collectionAdditionalCategories?: string[];
+  contentAdditionalCategories?: string[];
+  defaultLicense?: string;
+}
+
+export async function getChannelData(channelId: string): Promise<IChannelData> {
+  const response = await apiClient.get(`/api/channel/v1/read/${channelId}`);
+  return response.data?.result?.channel as IChannelData;
+}

--- a/projects/collection-editor-react/src/api/client.ts
+++ b/projects/collection-editor-react/src/api/client.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+import type { InternalAxiosRequestConfig } from 'axios';
+
+let baseUrl = '';
+
+export function setApiBaseUrl(url: string): void {
+  baseUrl = url;
+}
+
+export const apiClient = axios.create({
+  timeout: 30000,
+});
+
+apiClient.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
+  // Lazy import to avoid circular dependency
+  const { useEditorStore } = await import('../store/editor.store');
+  const state = useEditorStore.getState();
+  const authToken = state.editorConfig?.context?.authToken;
+
+  if (authToken) {
+    config.headers = config.headers ?? {};
+    config.headers['Authorization'] = `Bearer ${authToken}`;
+  }
+
+  if (baseUrl) {
+    config.baseURL = baseUrl;
+  }
+
+  return config;
+});
+
+export default apiClient;

--- a/projects/collection-editor-react/src/api/client.ts
+++ b/projects/collection-editor-react/src/api/client.ts
@@ -23,6 +23,12 @@ apiClient.interceptors.request.use(async (config: InternalAxiosRequestConfig) =>
     config.headers['Authorization'] = `Bearer ${ctx.authToken}`;
   }
 
+  // Portal proxy routes (/api/*) require the user session token in addition
+  // to the Bearer auth token. The dialcode validate and link APIs use /api/*.
+  if (ctx?.userToken) {
+    config.headers['X-Authenticated-User-Token'] = ctx.userToken;
+  }
+
   // Sunbird user/content APIs scope results to the tenant via X-Channel-Id.
   // Omitting it causes user-search to return cross-tenant results or nothing.
   if (ctx?.channel) {

--- a/projects/collection-editor-react/src/api/client.ts
+++ b/projects/collection-editor-react/src/api/client.ts
@@ -15,11 +15,18 @@ apiClient.interceptors.request.use(async (config: InternalAxiosRequestConfig) =>
   // Lazy import to avoid circular dependency
   const { useEditorStore } = await import('../store/editor.store');
   const state = useEditorStore.getState();
-  const authToken = state.editorConfig?.context?.authToken;
+  const ctx = state.editorConfig?.context;
 
-  if (authToken) {
-    config.headers = config.headers ?? {};
-    config.headers['Authorization'] = `Bearer ${authToken}`;
+  config.headers = config.headers ?? {};
+
+  if (ctx?.authToken) {
+    config.headers['Authorization'] = `Bearer ${ctx.authToken}`;
+  }
+
+  // Sunbird user/content APIs scope results to the tenant via X-Channel-Id.
+  // Omitting it causes user-search to return cross-tenant results or nothing.
+  if (ctx?.channel) {
+    config.headers['X-Channel-Id'] = ctx.channel;
   }
 
   if (baseUrl) {

--- a/projects/collection-editor-react/src/api/content.ts
+++ b/projects/collection-editor-react/src/api/content.ts
@@ -12,7 +12,6 @@ export async function compositeSearch(params: {
 }): Promise<{ content: IContent[]; count: number }> {
   const baseFilters: Record<string, unknown> = {
     status: ['Live'],
-    contentType: ['Resource'],
     ...(params.filters ?? {}),
   };
   if (params.channel) {

--- a/projects/collection-editor-react/src/api/content.ts
+++ b/projects/collection-editor-react/src/api/content.ts
@@ -1,0 +1,62 @@
+import { apiClient } from './client';
+import type { IContent } from '../types/content';
+
+export async function compositeSearch(params: {
+  filters?: Record<string, unknown>;
+  query?: string;
+  limit?: number;
+  offset?: number;
+  fields?: string[];
+  channel?: string;
+  sortBy?: Record<string, string>;
+}): Promise<{ content: IContent[]; count: number }> {
+  const baseFilters: Record<string, unknown> = {
+    status: ['Live'],
+    contentType: ['Resource'],
+    ...(params.filters ?? {}),
+  };
+  if (params.channel) {
+    baseFilters['channel'] = params.channel;
+  }
+
+  const response = await apiClient.post('/action/composite/v3/search', {
+    request: {
+      filters: baseFilters,
+      query: params.query ?? '',
+      limit: params.limit ?? 20,
+      offset: params.offset ?? 0,
+      sort_by: params.sortBy ?? { lastUpdatedOn: 'desc' },
+      fields: params.fields ?? [
+        'identifier',
+        'name',
+        'mimeType',
+        'contentType',
+        'primaryCategory',
+        'appIcon',
+        'channel',
+        'organisation',
+        'pkgVersion',
+      ],
+    },
+  }, {
+    headers: {
+      'X-Source': 'web',
+      'X-msgid': Math.random().toString(36).slice(2),
+    },
+  });
+
+  const result = response.data?.result ?? {};
+  return {
+    content: (result.content ?? []) as IContent[],
+    count: (result.count ?? 0) as number,
+  };
+}
+
+export async function fetchContentDetails(
+  contentId: string,
+): Promise<IContent> {
+  const response = await apiClient.get(
+    `/action/content/v3/read/${contentId}`,
+  );
+  return response.data?.result?.content as IContent;
+}

--- a/projects/collection-editor-react/src/api/content.ts
+++ b/projects/collection-editor-react/src/api/content.ts
@@ -45,8 +45,12 @@ export async function compositeSearch(params: {
   });
 
   const result = response.data?.result ?? {};
+  const NON_CONTENT_KEYS = new Set(['count', 'facets']);
+  const content = Object.entries(result as Record<string, unknown>)
+    .filter(([key]) => !NON_CONTENT_KEYS.has(key))
+    .flatMap(([, items]) => Array.isArray(items) ? items : []) as IContent[];
   return {
-    content: (result.content ?? []) as IContent[],
+    content,
     count: (result.count ?? 0) as number,
   };
 }

--- a/projects/collection-editor-react/src/api/dialcode.ts
+++ b/projects/collection-editor-react/src/api/dialcode.ts
@@ -48,7 +48,10 @@ export async function getDialcodeProcessStatus(processId: string): Promise<{
   dialcodes?: Array<{ identifier: string }>;
 }> {
   const response = await apiClient.get(`/action/dialcode/v1/process/status/${processId}`);
-  return response.data?.result ?? { status: 'PENDING' };
+  const raw = (response.data?.result ?? { status: 'PENDING' }) as { status: string; url?: string; dialcodes?: Array<{ identifier: string }> };
+  // Normalize the API's 'PENDING' sentinel to the internal 'in-process' value
+  // used by Topbar so both callers agree on a single status string.
+  return { ...raw, status: raw.status === 'PENDING' ? 'in-process' : raw.status };
 }
 
 export async function releaseDialcodes(_contentId: string, ids: string[]): Promise<void> {

--- a/projects/collection-editor-react/src/api/dialcode.ts
+++ b/projects/collection-editor-react/src/api/dialcode.ts
@@ -26,18 +26,25 @@ export async function linkDialCode(
   return response.data;
 }
 
-export async function reserveDialcodes(contentId: string, count: number): Promise<string> {
+export async function reserveDialcodes(
+  contentId: string,
+  count: number,
+): Promise<{ processId: string; reservedDialcodes: Record<string, unknown> }> {
   const response = await apiClient.post(`/action/dialcode/v1/reserve/${contentId}`, {
     request: {
       dialcodes: { count, qrCodeSpec: { errorCorrectionLevel: 'H' } },
     },
   });
-  return response.data?.result?.processId as string ?? '';
+  const result = response.data?.result ?? {};
+  return {
+    processId: (result.processId as string) ?? '',
+    reservedDialcodes: (result.reservedDialcodes as Record<string, unknown>) ?? {},
+  };
 }
 
 export async function getDialcodeProcessStatus(processId: string): Promise<{
   status: string;
-  zipFileName?: string;
+  url?: string;
   dialcodes?: Array<{ identifier: string }>;
 }> {
   const response = await apiClient.get(`/action/dialcode/v1/process/status/${processId}`);

--- a/projects/collection-editor-react/src/api/dialcode.ts
+++ b/projects/collection-editor-react/src/api/dialcode.ts
@@ -1,0 +1,57 @@
+import { apiClient } from './client';
+
+export async function checkDialCode(dialCode: string): Promise<unknown> {
+  const response = await apiClient.post('/api/dialcode/v1/read', {
+    request: {
+      dialcodes: [dialCode],
+    },
+  });
+  return response.data;
+}
+
+export async function linkDialCode(
+  contentId: string,
+  dialCode: string,
+): Promise<unknown> {
+  const response = await apiClient.post('/api/content/v3/dialcode/link', {
+    request: {
+      content: [
+        {
+          identifier: contentId,
+          dialcodes: [dialCode],
+        },
+      ],
+    },
+  });
+  return response.data;
+}
+
+export async function reserveDialcodes(contentId: string, count: number): Promise<string> {
+  const response = await apiClient.post(`/action/dialcode/v1/reserve/${contentId}`, {
+    request: {
+      dialcodes: { count, qrCodeSpec: { errorCorrectionLevel: 'H' } },
+    },
+  });
+  return response.data?.result?.processId as string ?? '';
+}
+
+export async function getDialcodeProcessStatus(processId: string): Promise<{
+  status: string;
+  zipFileName?: string;
+  dialcodes?: Array<{ identifier: string }>;
+}> {
+  const response = await apiClient.get(`/action/dialcode/v1/process/status/${processId}`);
+  return response.data?.result ?? { status: 'PENDING' };
+}
+
+export async function releaseDialcodes(_contentId: string, ids: string[]): Promise<void> {
+  await apiClient.patch('/api/dialcode/v1/update', {
+    request: { dialcodes: ids.map(id => ({ identifier: id, status: 'Draft' })) },
+  });
+}
+
+export async function unlinkDialcode(contentId: string): Promise<void> {
+  await apiClient.post('/api/content/v3/dialcode/link', {
+    request: { content: [{ identifier: contentId, dialcodes: [] }] },
+  });
+}

--- a/projects/collection-editor-react/src/api/framework.ts
+++ b/projects/collection-editor-react/src/api/framework.ts
@@ -22,3 +22,36 @@ export async function searchTerms(
   });
   return (response.data?.result?.terms ?? []) as ITerm[];
 }
+
+export interface IFrameworkSearchResult {
+  identifier: string;
+  name: string;
+  type?: string;
+}
+
+/**
+ * Discover Live frameworks via composite search — mirrors Angular
+ * FrameworkService.getFrameworkData (framework.service.ts:102-119). Used to
+ * extend the "Course Type" dropdown with frameworks whose orgFWType the
+ * channel does not already list.
+ */
+export async function searchFrameworks(filters: {
+  type?: string[];
+  identifier?: string[];
+  channel?: string;
+  systemDefault?: string;
+}): Promise<IFrameworkSearchResult[]> {
+  const response = await apiClient.post('/action/composite/v3/search', {
+    request: {
+      filters: {
+        objectType: 'Framework',
+        status: ['Live'],
+        ...(filters.type ? { type: filters.type } : {}),
+        ...(filters.identifier ? { identifier: filters.identifier } : {}),
+        ...(filters.channel ? { channel: filters.channel } : {}),
+        ...(filters.systemDefault ? { systemDefault: filters.systemDefault } : {}),
+      },
+    },
+  });
+  return (response.data?.result?.Framework ?? []) as IFrameworkSearchResult[];
+}

--- a/projects/collection-editor-react/src/api/framework.ts
+++ b/projects/collection-editor-react/src/api/framework.ts
@@ -1,0 +1,24 @@
+import { apiClient } from './client';
+import type { IFramework, ITerm } from '../types/framework';
+
+export async function getFramework(frameworkId: string): Promise<IFramework> {
+  const response = await apiClient.get(
+    `/api/framework/v1/read/${frameworkId}`,
+  );
+  return response.data?.result?.framework as IFramework;
+}
+
+export async function searchTerms(
+  frameworkId: string,
+  categoryCode: string,
+  query?: string,
+): Promise<ITerm[]> {
+  const response = await apiClient.get('/api/framework/v1/term/read', {
+    params: {
+      frameworkId,
+      codeId: categoryCode,
+      ...(query ? { query } : {}),
+    },
+  });
+  return (response.data?.result?.terms ?? []) as ITerm[];
+}

--- a/projects/collection-editor-react/src/api/hierarchy.ts
+++ b/projects/collection-editor-react/src/api/hierarchy.ts
@@ -1,11 +1,18 @@
 import { apiClient } from './client';
 import type { INode } from '../types/editor';
+import { readQuestionSetHierarchy } from './question';
 
-function mapToINode(raw: unknown, parentId?: string): INode {
+export function mapToINode(raw: unknown, parentId?: string): INode {
   const r = (raw ?? {}) as Record<string, unknown>;
   const identifier = (r['identifier'] as string) ?? '';
   const objectType = (r['objectType'] as string) ?? '';
   const mime = (r['mimeType'] as string) ?? '';
+
+  const rawChildren = r['children'];
+  const children: INode[] = Array.isArray(rawChildren)
+    ? rawChildren.map((child) => mapToINode(child, identifier))
+    : [];
+
   const isFolder =
     mime === 'application/vnd.ekstep.content-collection' ||
     objectType.toLowerCase().includes('unit') ||
@@ -13,12 +20,11 @@ function mapToINode(raw: unknown, parentId?: string): INode {
     objectType.toLowerCase().includes('collection') ||
     objectType.toLowerCase().includes('course') ||
     objectType.toLowerCase().includes('lesson') ||
-    (r['visibility'] as string) === 'Parent';
-
-  const rawChildren = r['children'];
-  const children: INode[] = Array.isArray(rawChildren)
-    ? rawChildren.map((child) => mapToINode(child, identifier))
-    : [];
+    (r['visibility'] as string) === 'Parent' ||
+    // A QuestionSet with children is the root of a questionset editor (a
+    // container of units/questions). A childless QuestionSet is a leaf
+    // resource inside a Collection — kept as a leaf so it previews as a set.
+    (mime === 'application/vnd.sunbird.questionset' && children.length > 0);
 
   return {
     id: identifier,
@@ -60,6 +66,20 @@ export async function readHierarchy(
   }
   const rootNode = mapToINode(content);
   return { content, rootNode };
+}
+
+/**
+ * Loads a QuestionSet hierarchy as an editor tree. Used when the editor root
+ * itself is a QuestionSet (objectType === 'QuestionSet'), where the correct
+ * endpoint is /questionset/v2/hierarchy (payload under result.questionset)
+ * rather than the content-collection endpoint.
+ */
+export async function readQuestionSetHierarchyTree(
+  questionSetId: string,
+): Promise<{ content: Record<string, unknown>; rootNode: INode }> {
+  const questionset = await readQuestionSetHierarchy(questionSetId);
+  const rootNode = mapToINode(questionset);
+  return { content: questionset, rootNode };
 }
 
 export async function updateHierarchy(

--- a/projects/collection-editor-react/src/api/hierarchy.ts
+++ b/projects/collection-editor-react/src/api/hierarchy.ts
@@ -2,7 +2,7 @@ import { apiClient } from './client';
 import type { INode } from '../types/editor';
 
 function mapToINode(raw: unknown, parentId?: string): INode {
-  const r = raw as Record<string, unknown>;
+  const r = (raw ?? {}) as Record<string, unknown>;
   const identifier = (r['identifier'] as string) ?? '';
   const objectType = (r['objectType'] as string) ?? '';
   const mime = (r['mimeType'] as string) ?? '';
@@ -47,7 +47,17 @@ export async function readHierarchy(
     `/action/content/v3/hierarchy/${contentId}`,
     { params: { mode: 'edit' } },
   );
-  const content = response.data?.result?.content as Record<string, unknown>;
+  const content = response.data?.result?.content as Record<string, unknown> | undefined;
+  if (!content || !content['identifier']) {
+    // Surface the API's own error (auth failure, missing content, unexpected
+    // shape) instead of crashing in mapToINode on undefined content.
+    const reason =
+      (response.data?.params?.errmsg as string) ||
+      (response.data?.params?.err as string) ||
+      (response.data?.responseCode as string) ||
+      `No content returned for "${contentId}"`;
+    throw new Error(`Unable to load hierarchy: ${reason}`);
+  }
   const rootNode = mapToINode(content);
   return { content, rootNode };
 }

--- a/projects/collection-editor-react/src/api/hierarchy.ts
+++ b/projects/collection-editor-react/src/api/hierarchy.ts
@@ -1,0 +1,117 @@
+import { apiClient } from './client';
+import type { INode } from '../types/editor';
+
+function mapToINode(raw: unknown, parentId?: string): INode {
+  const r = raw as Record<string, unknown>;
+  const identifier = (r['identifier'] as string) ?? '';
+  const objectType = (r['objectType'] as string) ?? '';
+  const mime = (r['mimeType'] as string) ?? '';
+  const isFolder =
+    mime === 'application/vnd.ekstep.content-collection' ||
+    objectType.toLowerCase().includes('unit') ||
+    objectType.toLowerCase().includes('textbook') ||
+    objectType.toLowerCase().includes('collection') ||
+    objectType.toLowerCase().includes('course') ||
+    objectType.toLowerCase().includes('lesson') ||
+    (r['visibility'] as string) === 'Parent';
+
+  const rawChildren = r['children'];
+  const children: INode[] = Array.isArray(rawChildren)
+    ? rawChildren.map((child) => mapToINode(child, identifier))
+    : [];
+
+  return {
+    id: identifier,
+    identifier,
+    name: (r['name'] as string) ?? 'Untitled',
+    title: (r['name'] as string) ?? 'Untitled',
+    description: r['description'] as string | undefined,
+    primaryCategory: r['primaryCategory'] as string | undefined,
+    mimeType: r['mimeType'] as string | undefined,
+    objectType,
+    contentType: r['contentType'] as string | undefined,
+    visibility: r['visibility'] as string | undefined,
+    status: r['status'] as string | undefined,
+    appIcon: r['appIcon'] as string | undefined,
+    isFolder,
+    children,
+    metadata: r as Record<string, unknown>,
+    parent: parentId,
+  };
+}
+
+export async function readHierarchy(
+  contentId: string,
+): Promise<{ content: Record<string, unknown>; rootNode: INode }> {
+  const response = await apiClient.get(
+    `/action/content/v3/hierarchy/${contentId}`,
+    { params: { mode: 'edit' } },
+  );
+  const content = response.data?.result?.content as Record<string, unknown>;
+  const rootNode = mapToINode(content);
+  return { content, rootNode };
+}
+
+export async function updateHierarchy(
+  _contentId: string,
+  nodesModified: Record<string, unknown>,
+  hierarchy: Record<string, unknown>,
+): Promise<void> {
+  await apiClient.patch('/action/content/v3/hierarchy/update', {
+    request: {
+      data: {
+        nodesModified,
+        hierarchy,
+      },
+    },
+  });
+}
+
+export async function publishContent(contentId: string): Promise<void> {
+  await apiClient.post(`/action/content/v3/publish/${contentId}`, {
+    request: {
+      content: {
+        lastPublishedBy: '',
+      },
+    },
+  });
+}
+
+export async function readContent(
+  contentId: string,
+): Promise<Record<string, unknown>> {
+  const response = await apiClient.get(
+    `/action/content/v3/read/${contentId}`,
+  );
+  return response.data?.result?.content as Record<string, unknown>;
+}
+
+export async function sendForReview(contentId: string): Promise<void> {
+  await apiClient.post(`/action/content/v3/review/${contentId}`, {
+    request: { content: {} },
+  });
+}
+
+export async function rejectContent(contentId: string, comment: string): Promise<void> {
+  await apiClient.post(`/action/content/v3/reject/${contentId}`, {
+    request: { content: { rejectComment: comment } },
+  });
+}
+
+export async function updateCollaborators(contentId: string, collaborators: string[]): Promise<void> {
+  await apiClient.patch('/action/content/v3/hierarchy/update', {
+    request: {
+      data: {
+        nodesModified: {
+          [contentId]: {
+            metadata: { collaborators },
+            objectType: 'Collection',
+            root: true,
+            isNew: false,
+          },
+        },
+        hierarchy: {},
+      },
+    },
+  });
+}

--- a/projects/collection-editor-react/src/api/hierarchy.ts
+++ b/projects/collection-editor-react/src/api/hierarchy.ts
@@ -67,8 +67,8 @@ export async function updateHierarchy(
   nodesModified: Record<string, unknown>,
   hierarchy: Record<string, unknown>,
   lastUpdatedBy?: string,
-): Promise<void> {
-  await apiClient.patch('/action/content/v3/hierarchy/update', {
+): Promise<{ identifiers?: Record<string, string> }> {
+  const response = await apiClient.patch('/action/content/v3/hierarchy/update', {
     request: {
       data: {
         nodesModified,
@@ -78,6 +78,7 @@ export async function updateHierarchy(
       },
     },
   });
+  return (response.data?.result ?? {}) as { identifiers?: Record<string, string> };
 }
 
 export async function publishContent(

--- a/projects/collection-editor-react/src/api/hierarchy.ts
+++ b/projects/collection-editor-react/src/api/hierarchy.ts
@@ -80,11 +80,14 @@ export async function updateHierarchy(
   });
 }
 
-export async function publishContent(contentId: string): Promise<void> {
+export async function publishContent(
+  contentId: string,
+  lastPublishedBy = '',
+): Promise<void> {
   await apiClient.post(`/action/content/v3/publish/${contentId}`, {
     request: {
       content: {
-        lastPublishedBy: '',
+        lastPublishedBy,
       },
     },
   });

--- a/projects/collection-editor-react/src/api/hierarchy.ts
+++ b/projects/collection-editor-react/src/api/hierarchy.ts
@@ -66,12 +66,15 @@ export async function updateHierarchy(
   _contentId: string,
   nodesModified: Record<string, unknown>,
   hierarchy: Record<string, unknown>,
+  lastUpdatedBy?: string,
 ): Promise<void> {
   await apiClient.patch('/action/content/v3/hierarchy/update', {
     request: {
       data: {
         nodesModified,
         hierarchy,
+        // lastUpdatedBy belongs at the data level, not inside nodesModified entries
+        ...(lastUpdatedBy ? { lastUpdatedBy } : {}),
       },
     },
   });
@@ -109,19 +112,10 @@ export async function rejectContent(contentId: string, comment: string): Promise
 }
 
 export async function updateCollaborators(contentId: string, collaborators: string[]): Promise<void> {
-  await apiClient.patch('/action/content/v3/hierarchy/update', {
+  // Collaborators are managed by a dedicated endpoint, not the hierarchy update.
+  await apiClient.patch(`/action/content/v1/collaborator/update/${contentId}`, {
     request: {
-      data: {
-        nodesModified: {
-          [contentId]: {
-            metadata: { collaborators },
-            objectType: 'Collection',
-            root: true,
-            isNew: false,
-          },
-        },
-        hierarchy: {},
-      },
+      content: { collaborators },
     },
   });
 }

--- a/projects/collection-editor-react/src/api/question.ts
+++ b/projects/collection-editor-react/src/api/question.ts
@@ -1,0 +1,43 @@
+import { apiClient } from './client';
+
+/**
+ * Reads the full QuestionSet hierarchy — the tree of units/questions with
+ * child stubs.
+ * Response shape: { result: { questionset: {...} } }
+ */
+export async function readQuestionSetHierarchy(
+  questionSetId: string,
+): Promise<Record<string, unknown>> {
+  const response = await apiClient.get(
+    `/action/questionset/v2/hierarchy/${questionSetId}`,
+  );
+  const questionset = response.data?.result?.questionset as
+    | Record<string, unknown>
+    | undefined;
+  if (!questionset || !questionset['identifier']) {
+    const reason =
+      (response.data?.params?.errmsg as string) ||
+      (response.data?.params?.err as string) ||
+      (response.data?.responseCode as string) ||
+      `No questionset returned for "${questionSetId}"`;
+    throw new Error(`Unable to load questionset hierarchy: ${reason}`);
+  }
+  return questionset;
+}
+
+/**
+ * Fetches full question data (body, responseDeclaration, interactions, etc.)
+ * for the given identifiers.
+ * Response shape: { result: { questions: [...] } }
+ */
+export async function getQuestionList(
+  identifiers: string[],
+): Promise<Array<Record<string, unknown>>> {
+  if (!identifiers.length) return [];
+  const response = await apiClient.post('/action/question/v2/list', {
+    request: { search: { identifier: identifiers } },
+  });
+  return (response.data?.result?.questions ?? []) as Array<
+    Record<string, unknown>
+  >;
+}

--- a/projects/collection-editor-react/src/api/question.ts
+++ b/projects/collection-editor-react/src/api/question.ts
@@ -1,15 +1,21 @@
 import { apiClient } from './client';
 
+// questionset/v2 routes are exposed under the portal-service proxy (session
+// auth), not /action — /action/questionset/v2/* 404s on Sunbird deployments.
+// Matches spark-portal's http-client, whose default apiPrefix is '/portal'.
+const QUESTIONSET_API_PREFIX = '/portal';
+
 /**
  * Reads the full QuestionSet hierarchy — the tree of units/questions with
- * child stubs.
+ * child stubs. mode=edit returns the draft hierarchy (required in the editor).
  * Response shape: { result: { questionset: {...} } }
  */
 export async function readQuestionSetHierarchy(
   questionSetId: string,
 ): Promise<Record<string, unknown>> {
   const response = await apiClient.get(
-    `/action/questionset/v2/hierarchy/${questionSetId}`,
+    `${QUESTIONSET_API_PREFIX}/questionset/v2/hierarchy/${questionSetId}`,
+    { params: { mode: 'edit' } },
   );
   const questionset = response.data?.result?.questionset as
     | Record<string, unknown>
@@ -34,9 +40,10 @@ export async function getQuestionList(
   identifiers: string[],
 ): Promise<Array<Record<string, unknown>>> {
   if (!identifiers.length) return [];
-  const response = await apiClient.post('/action/question/v2/list', {
-    request: { search: { identifier: identifiers } },
-  });
+  const response = await apiClient.post(
+    `${QUESTIONSET_API_PREFIX}/question/v2/list`,
+    { request: { search: { identifier: identifiers } } },
+  );
   return (response.data?.result?.questions ?? []) as Array<
     Record<string, unknown>
   >;

--- a/projects/collection-editor-react/src/api/user.ts
+++ b/projects/collection-editor-react/src/api/user.ts
@@ -1,0 +1,20 @@
+import { apiClient } from './client';
+
+export interface IUser {
+  identifier: string;
+  firstName: string;
+  lastName?: string;
+  email?: string;
+  userName?: string;
+}
+
+export async function searchUsers(query: string): Promise<IUser[]> {
+  const response = await apiClient.post('/api/user/v1/search', {
+    request: {
+      query,
+      filters: {},
+      limit: 20,
+    },
+  });
+  return (response.data?.result?.response?.content ?? []) as IUser[];
+}

--- a/projects/collection-editor-react/src/api/user.ts
+++ b/projects/collection-editor-react/src/api/user.ts
@@ -97,3 +97,14 @@ export async function getUsersByIds(ids: string[]): Promise<IUser[]> {
   });
   return (response.data?.result?.response?.content ?? []) as IUser[];
 }
+
+/**
+ * Read a user's profile — used to auto-fill the author field with the current
+ * user's name. Served via the portal-service proxy (session auth), the same
+ * route family as the questionset APIs (/portal/*).
+ * Response shape: { result: { response: { firstName, lastName, userName, … } } }
+ */
+export async function readUser(userId: string): Promise<IUser> {
+  const response = await apiClient.get(`/portal/user/v5/read/${userId}`);
+  return (response.data?.result?.response ?? {}) as IUser;
+}

--- a/projects/collection-editor-react/src/api/user.ts
+++ b/projects/collection-editor-react/src/api/user.ts
@@ -6,14 +6,48 @@ export interface IUser {
   lastName?: string;
   email?: string;
   userName?: string;
+  organisations?: Array<{ orgName?: string }>;
 }
 
-export async function searchUsers(query: string): Promise<IUser[]> {
+// Fields the user-search API must return for the collaborator UI.
+const USER_FIELDS = ['email', 'firstName', 'lastName', 'identifier', 'organisations', 'rootOrgName', 'phone'];
+
+interface SearchOpts {
+  rootOrgId?: string;
+  limit?: number;
+}
+
+/**
+ * Search content-creator users by name/email. Mirrors the Sunbird collaborator
+ * search: restricts to CONTENT_CREATOR role and (optionally) the same org.
+ */
+export async function searchUsers(query: string, opts: SearchOpts = {}): Promise<IUser[]> {
+  const filters: Record<string, unknown> = { 'organisations.roles': 'CONTENT_CREATOR' };
+  if (opts.rootOrgId) filters.rootOrgId = opts.rootOrgId;
+
   const response = await apiClient.post('/api/user/v1/search', {
     request: {
       query,
-      filters: {},
-      limit: 20,
+      filters,
+      fields: USER_FIELDS,
+      offset: 0,
+      limit: opts.limit ?? 20,
+    },
+  });
+  return (response.data?.result?.response?.content ?? []) as IUser[];
+}
+
+/**
+ * Resolve a set of user identifiers to full user objects (used to render the
+ * content's existing collaborators by name rather than raw id).
+ */
+export async function getUsersByIds(ids: string[]): Promise<IUser[]> {
+  if (!ids.length) return [];
+  const response = await apiClient.post('/api/user/v1/search', {
+    request: {
+      filters: { userId: ids },
+      fields: USER_FIELDS,
+      limit: ids.length,
     },
   });
   return (response.data?.result?.response?.content ?? []) as IUser[];

--- a/projects/collection-editor-react/src/api/user.ts
+++ b/projects/collection-editor-react/src/api/user.ts
@@ -5,43 +5,75 @@ export interface IUser {
   firstName: string;
   lastName?: string;
   email?: string;
+  phone?: string;
   userName?: string;
-  organisations?: Array<{ orgName?: string }>;
+  rootOrgName?: string;
+  organisations?: Array<{ orgName?: string; roles?: string[] }>;
 }
 
 // Fields the user-search API must return for the collaborator UI.
 const USER_FIELDS = ['email', 'firstName', 'lastName', 'identifier', 'organisations', 'rootOrgName', 'phone'];
 
 interface SearchOpts {
+  // User's rootOrgId — scopes search to the current tenant (mirrors Angular's
+  // ecEditor.getContext('user').orgIds). Without this Sunbird returns cross-
+  // tenant results or nothing depending on server-side tenant isolation policy.
   rootOrgId?: string;
+  // Passed as X-Channel-Id; redundant when client.ts injects it globally but
+  // kept here for explicit per-call control if ever needed.
+  objectType?: string;
   limit?: number;
 }
 
 /**
- * Search content-creator users by name/email. Mirrors the Sunbird collaborator
- * search: restricts to CONTENT_CREATOR role and (optionally) the same org.
+ * Search content-creator users by name, email, or phone number.
+ * Mirrors the Angular collaborator plugin's three-branch detection logic:
+ *   - Contains "@"         → filters.email  (exact match)
+ *   - All digits, ≥10 chars → filters.phone  (exact match)
+ *   - Everything else      → request.query  (free-text name search)
+ *
+ * The ?fields=orgName query param instructs the API to populate orgName inside
+ * each user's organisations array, which is required to display the org name.
  */
 export async function searchUsers(query: string, opts: SearchOpts = {}): Promise<IUser[]> {
-  const filters: Record<string, unknown> = { 'organisations.roles': 'CONTENT_CREATOR' };
-  // rootOrgId must be an array (matches the Sunbird user-search contract).
-  if (opts.rootOrgId) filters.rootOrgId = [opts.rootOrgId];
+  // Role: TextBook uses BOOK_CREATOR, everything else uses CONTENT_CREATOR.
+  const role = opts.objectType?.toLowerCase() === 'textbook' ? 'BOOK_CREATOR' : 'CONTENT_CREATOR';
+  const filters: Record<string, unknown> = { 'organisations.roles': [role] };
 
-  // Must use the /action proxy path — that's where the portal injects the
-  // authenticated user token. /api/* is not authenticated and returns 401.
-  const response = await apiClient.post('/action/user/v1/search', {
-    request: {
-      query,
-      filters,
-      fields: USER_FIELDS,
-      offset: 0,
-      limit: opts.limit ?? 20,
+  // Scope to the current tenant so search returns relevant users only.
+  if (opts.rootOrgId) filters['rootOrgId'] = [opts.rootOrgId];
+
+  // Three-branch detection — mirrors Angular collaboratorApp.js
+  const isEmail = query.includes('@');
+  const isPhone = /^\d{10,}$/.test(query.trim());
+
+  const requestBody: Record<string, unknown> = {
+    filters,
+    fields: USER_FIELDS,
+    offset: 0,
+    limit: opts.limit ?? 200,
+  };
+
+  if (isEmail) {
+    filters['email'] = query.trim();
+  } else if (isPhone) {
+    filters['phone'] = query.trim();
+  } else {
+    requestBody['query'] = query;
+  }
+
+  const response = await apiClient.post(
+    '/action/user/v1/search',
+    { request: requestBody },
+    {
+      // ?fields=orgName populates orgName inside each user's organisations array.
+      params: { fields: 'orgName' },
+      headers: {
+        'X-Source': 'web',
+        'X-msgid': Math.random().toString(36).slice(2),
+      },
     },
-  }, {
-    headers: {
-      'X-Source': 'web',
-      'X-msgid': Math.random().toString(36).slice(2),
-    },
-  });
+  );
   return (response.data?.result?.response?.content ?? []) as IUser[];
 }
 

--- a/projects/collection-editor-react/src/api/user.ts
+++ b/projects/collection-editor-react/src/api/user.ts
@@ -23,15 +23,23 @@ interface SearchOpts {
  */
 export async function searchUsers(query: string, opts: SearchOpts = {}): Promise<IUser[]> {
   const filters: Record<string, unknown> = { 'organisations.roles': 'CONTENT_CREATOR' };
-  if (opts.rootOrgId) filters.rootOrgId = opts.rootOrgId;
+  // rootOrgId must be an array (matches the Sunbird user-search contract).
+  if (opts.rootOrgId) filters.rootOrgId = [opts.rootOrgId];
 
-  const response = await apiClient.post('/api/user/v1/search', {
+  // Must use the /action proxy path — that's where the portal injects the
+  // authenticated user token. /api/* is not authenticated and returns 401.
+  const response = await apiClient.post('/action/user/v1/search', {
     request: {
       query,
       filters,
       fields: USER_FIELDS,
       offset: 0,
       limit: opts.limit ?? 20,
+    },
+  }, {
+    headers: {
+      'X-Source': 'web',
+      'X-msgid': Math.random().toString(36).slice(2),
     },
   });
   return (response.data?.result?.response?.content ?? []) as IUser[];
@@ -43,11 +51,16 @@ export async function searchUsers(query: string, opts: SearchOpts = {}): Promise
  */
 export async function getUsersByIds(ids: string[]): Promise<IUser[]> {
   if (!ids.length) return [];
-  const response = await apiClient.post('/api/user/v1/search', {
+  const response = await apiClient.post('/action/user/v1/search', {
     request: {
       filters: { userId: ids },
       fields: USER_FIELDS,
       limit: ids.length,
+    },
+  }, {
+    headers: {
+      'X-Source': 'web',
+      'X-msgid': Math.random().toString(36).slice(2),
     },
   });
   return (response.data?.result?.response?.content ?? []) as IUser[];

--- a/projects/collection-editor-react/src/components/AssetBrowser/AssetBrowser.module.scss
+++ b/projects/collection-editor-react/src/components/AssetBrowser/AssetBrowser.module.scss
@@ -1,16 +1,16 @@
 .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; }
-.modal { background: #fff; border-radius: 8px; width: 640px; max-height: 80vh; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
-.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid #e8e8e8; }
+.modal { background: #fff; border-radius: var(--sbx-r-md); width: 640px; max-height: 80vh; display: flex; flex-direction: column; box-shadow: var(--sbx-shadow-3); }
+.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid var(--sbx-gray-200); }
 .header button { background: none; border: none; cursor: pointer; }
-.tabs { display: flex; border-bottom: 1px solid #e8e8e8; }
+.tabs { display: flex; border-bottom: 1px solid var(--sbx-gray-200); }
 .tabs button { padding: 10px 20px; background: none; border: none; cursor: pointer; font-size: 14px; border-bottom: 2px solid transparent; }
-.activeTab { border-bottom-color: #1890ff !important; color: #1890ff; }
+.activeTab { border-bottom-color: var(--sbx-primary) !important; color: var(--sbx-primary); }
 .body { padding: 16px; overflow-y: auto; flex: 1; }
 .searchRow { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; }
-.searchRow input { flex: 1; padding: 6px 10px; border: 1px solid #d9d9d9; border-radius: 4px; }
-.searchRow button { padding: 6px 14px; background: #1890ff; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+.searchRow input { flex: 1; padding: 6px 10px; border: 1px solid var(--sbx-gray-300); border-radius: var(--sbx-r-xs); }
+.searchRow button { padding: 6px 14px; background: var(--sbx-primary); color: #fff; border: none; border-radius: var(--sbx-r-xs); cursor: pointer; }
 .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
-.card { cursor: pointer; border: 1px solid #e8e8e8; border-radius: 6px; padding: 8px; text-align: center; font-size: 12px; &:hover { border-color: #1890ff; } }
-.card img { width: 100%; height: 80px; object-fit: cover; border-radius: 4px; margin-bottom: 4px; }
-.info { color: #888; text-align: center; }
-.uploadBtn { display: flex; align-items: center; gap: 8px; padding: 12px 20px; border: 2px dashed #d9d9d9; border-radius: 8px; background: none; cursor: pointer; font-size: 14px; width: 100%; justify-content: center; &:hover { border-color: #1890ff; } }
+.card { cursor: pointer; border: 1px solid var(--sbx-gray-200); border-radius: var(--sbx-r-sm); padding: 8px; text-align: center; font-size: 12px; &:hover { border-color: var(--sbx-primary); } }
+.card img { width: 100%; height: 80px; object-fit: cover; border-radius: var(--sbx-r-xs); margin-bottom: 4px; }
+.info { color: var(--sbx-gray-500); text-align: center; }
+.uploadBtn { display: flex; align-items: center; gap: 8px; padding: 12px 20px; border: 2px dashed var(--sbx-gray-300); border-radius: var(--sbx-r-md); background: none; cursor: pointer; font-size: 14px; width: 100%; justify-content: center; &:hover { border-color: var(--sbx-primary); } }

--- a/projects/collection-editor-react/src/components/AssetBrowser/AssetBrowser.module.scss
+++ b/projects/collection-editor-react/src/components/AssetBrowser/AssetBrowser.module.scss
@@ -1,0 +1,16 @@
+.overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; }
+.modal { background: #fff; border-radius: 8px; width: 640px; max-height: 80vh; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
+.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid #e8e8e8; }
+.header button { background: none; border: none; cursor: pointer; }
+.tabs { display: flex; border-bottom: 1px solid #e8e8e8; }
+.tabs button { padding: 10px 20px; background: none; border: none; cursor: pointer; font-size: 14px; border-bottom: 2px solid transparent; }
+.activeTab { border-bottom-color: #1890ff !important; color: #1890ff; }
+.body { padding: 16px; overflow-y: auto; flex: 1; }
+.searchRow { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; }
+.searchRow input { flex: 1; padding: 6px 10px; border: 1px solid #d9d9d9; border-radius: 4px; }
+.searchRow button { padding: 6px 14px; background: #1890ff; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+.grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+.card { cursor: pointer; border: 1px solid #e8e8e8; border-radius: 6px; padding: 8px; text-align: center; font-size: 12px; &:hover { border-color: #1890ff; } }
+.card img { width: 100%; height: 80px; object-fit: cover; border-radius: 4px; margin-bottom: 4px; }
+.info { color: #888; text-align: center; }
+.uploadBtn { display: flex; align-items: center; gap: 8px; padding: 12px 20px; border: 2px dashed #d9d9d9; border-radius: 8px; background: none; cursor: pointer; font-size: 14px; width: 100%; justify-content: center; &:hover { border-color: #1890ff; } }

--- a/projects/collection-editor-react/src/components/AssetBrowser/AssetBrowser.tsx
+++ b/projects/collection-editor-react/src/components/AssetBrowser/AssetBrowser.tsx
@@ -1,0 +1,107 @@
+import React, { useState, useCallback, useRef } from 'react';
+import { Search, Upload, X } from 'lucide-react';
+import { compositeSearch } from '../../api/content';
+import { apiClient } from '../../api/client';
+import type { IContent } from '../../types/content';
+import styles from './AssetBrowser.module.scss';
+
+interface AssetBrowserProps {
+  type?: 'image' | 'video' | 'audio' | 'all';
+  onSelect: (url: string, asset: Record<string, unknown>) => void;
+  onClose: () => void;
+}
+
+export const AssetBrowser: React.FC<AssetBrowserProps> = ({ type = 'all', onSelect, onClose }) => {
+  const [tab, setTab] = useState<'browse' | 'upload'>('browse');
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<IContent[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const mimeMap: Record<string, string[]> = {
+    image: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+    video: ['video/mp4', 'video/webm'],
+    audio: ['audio/mp3', 'audio/mpeg', 'audio/ogg'],
+    all: [],
+  };
+
+  const doSearch = useCallback(async (q: string) => {
+    setIsLoading(true);
+    try {
+      const mimes = mimeMap[type];
+      const filters: Record<string, unknown> = { status: ['Live'] };
+      if (mimes.length) filters['mimeType'] = mimes;
+      const { content } = await compositeSearch({ query: q, filters, limit: 30, fields: ['identifier','name','mimeType','artifactUrl','appIcon'] });
+      setResults(content);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [type]);
+
+  const handleUpload = useCallback(async (file: File) => {
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const resp = await apiClient.post(
+        `/action/content/v3/upload?fileType=${type === 'image' ? 'image' : 'asset'}`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } }
+      );
+      const url = resp.data?.result?.artifactUrl as string;
+      if (url) onSelect(url, { artifactUrl: url, name: file.name });
+    } finally {
+      setUploading(false);
+    }
+  }, [type, onSelect]);
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-label="Asset Browser">
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <span>Asset Browser</span>
+          <button onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+        <div className={styles.tabs}>
+          <button className={tab === 'browse' ? styles.activeTab : ''} onClick={() => setTab('browse')}>Browse</button>
+          <button className={tab === 'upload' ? styles.activeTab : ''} onClick={() => setTab('upload')}>Upload</button>
+        </div>
+        {tab === 'browse' ? (
+          <div className={styles.body}>
+            <div className={styles.searchRow}>
+              <Search size={14} />
+              <input
+                type="search"
+                placeholder="Search assets..."
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && doSearch(query)}
+              />
+              <button onClick={() => doSearch(query)}>Search</button>
+            </div>
+            {isLoading ? <p className={styles.info}>Loading...</p> : null}
+            <div className={styles.grid}>
+              {results.map(item => {
+                const thumb = (item as unknown as Record<string, unknown>).appIcon as string ?? (item as unknown as Record<string, unknown>).artifactUrl as string ?? '';
+                return (
+                  <div key={item.identifier} className={styles.card} onClick={() => onSelect((item as unknown as Record<string, unknown>).artifactUrl as string ?? '', item as unknown as Record<string, unknown>)}>
+                    {thumb && <img src={thumb} alt={item.name} />}
+                    <span>{item.name}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className={styles.body}>
+            <input ref={fileRef} type="file" style={{ display: 'none' }} onChange={e => { const f = e.target.files?.[0]; if (f) handleUpload(f); }} />
+            <button className={styles.uploadBtn} onClick={() => fileRef.current?.click()} disabled={uploading}>
+              <Upload size={16} /> {uploading ? 'Uploading...' : 'Choose file to upload'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/AssetBrowser/index.ts
+++ b/projects/collection-editor-react/src/components/AssetBrowser/index.ts
@@ -1,0 +1,1 @@
+export { AssetBrowser } from './AssetBrowser';

--- a/projects/collection-editor-react/src/components/AssignPageNumber/AssignPageNumber.module.scss
+++ b/projects/collection-editor-react/src/components/AssignPageNumber/AssignPageNumber.module.scss
@@ -1,13 +1,13 @@
 .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; }
-.modal { background: #fff; border-radius: 8px; width: 560px; max-height: 80vh; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
-.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid #e8e8e8; }
+.modal { background: #fff; border-radius: var(--sbx-r-md); width: 560px; max-height: 80vh; display: flex; flex-direction: column; box-shadow: var(--sbx-shadow-3); }
+.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid var(--sbx-gray-200); }
 .header button { background: none; border: none; cursor: pointer; }
 .body { padding: 16px; overflow-y: auto; flex: 1; }
 .table { width: 100%; border-collapse: collapse; }
-.table th, .table td { padding: 10px 12px; border-bottom: 1px solid #f0f0f0; text-align: left; font-size: 14px; }
-.table th { font-weight: 600; color: #555; background: #fafafa; }
-.pageInput { width: 80px; padding: 4px 8px; border: 1px solid #d9d9d9; border-radius: 4px; }
-.empty { color: #888; text-align: center; padding: 24px; }
-.footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid #e8e8e8; }
-.cancelBtn { padding: 8px 16px; background: none; border: 1px solid #d9d9d9; border-radius: 4px; cursor: pointer; }
-.saveBtn { display: flex; align-items: center; gap: 6px; padding: 8px 16px; background: #1890ff; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+.table th, .table td { padding: 10px 12px; border-bottom: 1px solid var(--sbx-gray-100); text-align: left; font-size: 14px; }
+.table th { font-weight: 600; color: var(--sbx-gray-600); background: var(--sbx-gray-50); }
+.pageInput { width: 80px; padding: 4px 8px; border: 1px solid var(--sbx-gray-300); border-radius: var(--sbx-r-xs); }
+.empty { color: var(--sbx-gray-500); text-align: center; padding: 24px; }
+.footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid var(--sbx-gray-200); }
+.cancelBtn { padding: 8px 16px; background: none; border: 1px solid var(--sbx-gray-300); border-radius: var(--sbx-r-xs); cursor: pointer; }
+.saveBtn { display: flex; align-items: center; gap: 6px; padding: 8px 16px; background: var(--sbx-primary); color: #fff; border: none; border-radius: var(--sbx-r-xs); cursor: pointer; }

--- a/projects/collection-editor-react/src/components/AssignPageNumber/AssignPageNumber.module.scss
+++ b/projects/collection-editor-react/src/components/AssignPageNumber/AssignPageNumber.module.scss
@@ -1,0 +1,13 @@
+.overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; }
+.modal { background: #fff; border-radius: 8px; width: 560px; max-height: 80vh; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
+.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid #e8e8e8; }
+.header button { background: none; border: none; cursor: pointer; }
+.body { padding: 16px; overflow-y: auto; flex: 1; }
+.table { width: 100%; border-collapse: collapse; }
+.table th, .table td { padding: 10px 12px; border-bottom: 1px solid #f0f0f0; text-align: left; font-size: 14px; }
+.table th { font-weight: 600; color: #555; background: #fafafa; }
+.pageInput { width: 80px; padding: 4px 8px; border: 1px solid #d9d9d9; border-radius: 4px; }
+.empty { color: #888; text-align: center; padding: 24px; }
+.footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid #e8e8e8; }
+.cancelBtn { padding: 8px 16px; background: none; border: 1px solid #d9d9d9; border-radius: 4px; cursor: pointer; }
+.saveBtn { display: flex; align-items: center; gap: 6px; padding: 8px 16px; background: #1890ff; color: #fff; border: none; border-radius: 4px; cursor: pointer; }

--- a/projects/collection-editor-react/src/components/AssignPageNumber/AssignPageNumber.tsx
+++ b/projects/collection-editor-react/src/components/AssignPageNumber/AssignPageNumber.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useCallback } from 'react';
+import { X, Save } from 'lucide-react';
+import { useTreeStore } from '../../store/tree.store';
+import type { INode } from '../../types/editor';
+import styles from './AssignPageNumber.module.scss';
+
+interface AssignPageNumberProps {
+  contentId: string;
+  onClose: () => void;
+}
+
+function collectLeafNodes(nodes: INode[]): INode[] {
+  const leaves: INode[] = [];
+  const walk = (ns: INode[]) => {
+    for (const n of ns) {
+      if (!n.isFolder && (!n.children || n.children.length === 0)) {
+        leaves.push(n);
+      } else if (n.children?.length) {
+        walk(n.children);
+      }
+    }
+  };
+  walk(nodes);
+  return leaves;
+}
+
+export const AssignPageNumber: React.FC<AssignPageNumberProps> = ({ onClose }) => {
+  const { treeData, updateNode } = useTreeStore();
+  const leaves = collectLeafNodes(treeData);
+  const [pageNumbers, setPageNumbers] = useState<Record<string, string>>(() =>
+    Object.fromEntries(leaves.map(n => [n.id, String(n.metadata?.pageNumber ?? '')]))
+  );
+
+  const handleSave = useCallback(() => {
+    for (const [id, val] of Object.entries(pageNumbers)) {
+      if (val !== '') {
+        updateNode(id, { pageNumber: parseInt(val, 10) || undefined });
+      }
+    }
+    onClose();
+  }, [pageNumbers, updateNode, onClose]);
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-label="Assign Page Numbers">
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <span>Assign Page Numbers</span>
+          <button onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+        <div className={styles.body}>
+          {leaves.length === 0 ? (
+            <p className={styles.empty}>No content items found in this collection.</p>
+          ) : (
+            <table className={styles.table}>
+              <thead><tr><th>Content</th><th>Page Number</th></tr></thead>
+              <tbody>
+                {leaves.map(n => (
+                  <tr key={n.id}>
+                    <td>{n.name}</td>
+                    <td>
+                      <input
+                        type="number"
+                        min={1}
+                        value={pageNumbers[n.id] ?? ''}
+                        onChange={e => setPageNumbers(prev => ({ ...prev, [n.id]: e.target.value }))}
+                        className={styles.pageInput}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+        <div className={styles.footer}>
+          <button className={styles.cancelBtn} onClick={onClose}>Cancel</button>
+          <button className={styles.saveBtn} onClick={handleSave}><Save size={14} /> Save</button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/AssignPageNumber/index.ts
+++ b/projects/collection-editor-react/src/components/AssignPageNumber/index.ts
@@ -1,0 +1,1 @@
+export { AssignPageNumber } from './AssignPageNumber';

--- a/projects/collection-editor-react/src/components/BulkUpload/BulkUpload.module.scss
+++ b/projects/collection-editor-react/src/components/BulkUpload/BulkUpload.module.scss
@@ -158,21 +158,21 @@
 
   &.status_uploading,
   &.status_processing {
-    background: #EFF6FF;
+    background: var(--sbx-status-info-bg);
     color: var(--sbx-primary);
-    border: 1px solid #BFDBFE;
+    border: 1px solid var(--sbx-status-info-border);
   }
 
   &.status_done {
-    background: #F0FDF4;
+    background: var(--sbx-status-ok-bg);
     color: var(--sbx-success);
-    border: 1px solid #BBF7D0;
+    border: 1px solid var(--sbx-status-ok-border);
   }
 
   &.status_error {
-    background: #FEF2F2;
+    background: var(--sbx-status-err-bg);
     color: var(--sbx-error);
-    border: 1px solid #FECACA;
+    border: 1px solid var(--sbx-status-err-border);
   }
 }
 
@@ -203,7 +203,7 @@
 }
 
 .failedSection {
-  border: 1px solid #FECACA;
+  border: 1px solid var(--sbx-status-err-border);
   border-radius: var(--sbx-r-sm);
   overflow: hidden;
 }
@@ -214,8 +214,8 @@
   color: var(--sbx-error);
   margin: 0;
   padding: 10px 14px;
-  background: #FEF2F2;
-  border-bottom: 1px solid #FECACA;
+  background: var(--sbx-status-err-bg);
+  border-bottom: 1px solid var(--sbx-status-err-border);
 }
 
 .tableWrap {

--- a/projects/collection-editor-react/src/components/BulkUpload/BulkUpload.module.scss
+++ b/projects/collection-editor-react/src/components/BulkUpload/BulkUpload.module.scss
@@ -1,0 +1,266 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: var(--sbx-r-lg);
+  box-shadow: var(--sbx-shadow-3);
+  width: 560px;
+  max-width: 95vw;
+  max-height: 90vh;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--sbx-gray-200);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--sbx-gray-900);
+  margin: 0;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  color: var(--sbx-gray-500);
+  padding: 4px 8px;
+  border-radius: var(--sbx-r-sm);
+  line-height: 1;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-800);
+  }
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dropZone {
+  border: 2px dashed var(--sbx-gray-300);
+  border-radius: var(--sbx-r-md);
+  padding: 32px 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.15s;
+  background: var(--sbx-gray-50);
+
+  &:hover {
+    border-color: var(--sbx-primary);
+    background: var(--sbx-primary-light);
+  }
+
+  &.dragOver {
+    border-color: var(--sbx-primary);
+    background: var(--sbx-primary-light);
+    transform: scale(1.01);
+  }
+
+  &.hasFile {
+    border-style: solid;
+    border-color: var(--sbx-primary);
+    background: var(--sbx-primary-light);
+  }
+}
+
+.hiddenInput {
+  display: none;
+}
+
+.fileInfo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.fileIcon {
+  font-size: 24px;
+}
+
+.fileName {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sbx-gray-800);
+  word-break: break-all;
+}
+
+.fileSize {
+  font-size: 12px;
+  color: var(--sbx-gray-500);
+}
+
+.dropHint {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.dropIcon {
+  font-size: 32px;
+  margin-bottom: 4px;
+}
+
+.dropText {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sbx-gray-700);
+  margin: 0;
+}
+
+.dropSubtext {
+  font-size: 12px;
+  color: var(--sbx-gray-500);
+  margin: 0;
+}
+
+.sampleLink {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--sbx-primary);
+  font-size: 13px;
+  text-decoration: underline;
+  padding: 0;
+  align-self: flex-start;
+  transition: color 0.15s;
+
+  &:hover {
+    color: var(--sbx-primary-dark);
+  }
+}
+
+.statusBar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: var(--sbx-r-sm);
+  font-size: 13px;
+  font-weight: 600;
+
+  &.status_uploading,
+  &.status_processing {
+    background: #EFF6FF;
+    color: var(--sbx-primary);
+    border: 1px solid #BFDBFE;
+  }
+
+  &.status_done {
+    background: #F0FDF4;
+    color: var(--sbx-success);
+    border: 1px solid #BBF7D0;
+  }
+
+  &.status_error {
+    background: #FEF2F2;
+    color: var(--sbx-error);
+    border: 1px solid #FECACA;
+  }
+}
+
+.successDetail {
+  font-weight: 400;
+  color: var(--sbx-success);
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.errorMsg {
+  font-size: 13px;
+  color: var(--sbx-error);
+  margin: 0;
+}
+
+.failedSection {
+  border: 1px solid #FECACA;
+  border-radius: var(--sbx-r-sm);
+  overflow: hidden;
+}
+
+.failedTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sbx-error);
+  margin: 0;
+  padding: 10px 14px;
+  background: #FEF2F2;
+  border-bottom: 1px solid #FECACA;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.failedTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+
+  th {
+    padding: 8px 12px;
+    text-align: left;
+    font-weight: 600;
+    color: var(--sbx-gray-600);
+    background: var(--sbx-gray-50);
+    border-bottom: 1px solid var(--sbx-gray-200);
+    position: sticky;
+    top: 0;
+  }
+
+  td {
+    padding: 8px 12px;
+    color: var(--sbx-gray-700);
+    border-bottom: 1px solid var(--sbx-gray-100);
+    vertical-align: top;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.reasonCell {
+  color: var(--sbx-error) !important;
+}
+
+.footer {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding: 16px 24px;
+  border-top: 1px solid var(--sbx-gray-200);
+  flex-shrink: 0;
+}

--- a/projects/collection-editor-react/src/components/BulkUpload/CsvUpload.tsx
+++ b/projects/collection-editor-react/src/components/BulkUpload/CsvUpload.tsx
@@ -52,8 +52,8 @@ export const CsvUpload: React.FC<CsvUploadProps> = ({
       setErrorMsg('Only .csv files are accepted.');
       return false;
     }
-    if (file.size > 10 * 1024 * 1024) {
-      setErrorMsg('File size must not exceed 10 MB.');
+    if (file.size > 50 * 1024 * 1024) {
+      setErrorMsg('File size must not exceed 50 MB.');
       return false;
     }
     return true;

--- a/projects/collection-editor-react/src/components/BulkUpload/CsvUpload.tsx
+++ b/projects/collection-editor-react/src/components/BulkUpload/CsvUpload.tsx
@@ -91,17 +91,17 @@ export const CsvUpload: React.FC<CsvUploadProps> = ({
 
   const handleDownloadSample = useCallback(async () => {
     try {
-      const blob = await downloadSampleCsv(contentId);
-      const url = URL.createObjectURL(blob);
+      // Returns a pre-signed URL to the current hierarchy CSV (used as a template).
+      const url = await downloadSampleCsv(contentId);
       const a = document.createElement('a');
       a.href = url;
       a.download = 'sample_hierarchy.csv';
+      a.target = '_blank';
       a.click();
-      URL.revokeObjectURL(url);
     } catch {
       setErrorMsg('Failed to download sample CSV.');
     }
-  }, []);
+  }, [contentId]);
 
   const handleUpload = useCallback(async () => {
     if (!selectedFile) return;
@@ -112,6 +112,15 @@ export const CsvUpload: React.FC<CsvUploadProps> = ({
 
     try {
       const { processId } = await uploadCsvHierarchy(contentId, selectedFile);
+
+      // Synchronous import (no async process id) — treat as immediate success.
+      if (!processId) {
+        setStatus('done');
+        setSuccessCount(null);
+        setTimeout(onComplete, 1500);
+        return;
+      }
+
       setStatus('processing');
 
       pollRef.current = setInterval(async () => {

--- a/projects/collection-editor-react/src/components/BulkUpload/CsvUpload.tsx
+++ b/projects/collection-editor-react/src/components/BulkUpload/CsvUpload.tsx
@@ -1,0 +1,282 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { Button } from '../shared/Button';
+import {
+  uploadCsvHierarchy,
+  getCsvUploadStatus,
+  downloadSampleCsv,
+} from '../../api/bulkUpload';
+import styles from './BulkUpload.module.scss';
+
+interface CsvUploadProps {
+  contentId: string;
+  onComplete: () => void;
+  onClose: () => void;
+  mode?: 'create' | 'update';
+}
+
+type UploadStatus = 'idle' | 'uploading' | 'processing' | 'done' | 'error';
+
+interface FailedRecord {
+  rowNumber?: number;
+  name?: string;
+  reason?: string;
+  [key: string]: unknown;
+}
+
+export const CsvUpload: React.FC<CsvUploadProps> = ({
+  contentId,
+  onComplete,
+  onClose,
+  mode = 'create',
+}) => {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [status, setStatus] = useState<UploadStatus>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [failedRecords, setFailedRecords] = useState<FailedRecord[]>([]);
+  const [successCount, setSuccessCount] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => stopPolling(), [stopPolling]);
+
+  const validateFile = (file: File): boolean => {
+    if (!file.name.toLowerCase().endsWith('.csv')) {
+      setErrorMsg('Only .csv files are accepted.');
+      return false;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      setErrorMsg('File size must not exceed 10 MB.');
+      return false;
+    }
+    return true;
+  };
+
+  const handleFileSelect = useCallback((file: File) => {
+    setErrorMsg('');
+    setFailedRecords([]);
+    setSuccessCount(null);
+    setStatus('idle');
+    if (validateFile(file)) {
+      setSelectedFile(file);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) handleFileSelect(file);
+    },
+    [handleFileSelect],
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFileSelect(file);
+      // reset input so same file can be re-selected
+      e.target.value = '';
+    },
+    [handleFileSelect],
+  );
+
+  const handleDownloadSample = useCallback(async () => {
+    try {
+      const blob = await downloadSampleCsv(contentId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'sample_hierarchy.csv';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setErrorMsg('Failed to download sample CSV.');
+    }
+  }, []);
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile) return;
+
+    setStatus('uploading');
+    setErrorMsg('');
+    setFailedRecords([]);
+
+    try {
+      const { processId } = await uploadCsvHierarchy(contentId, selectedFile);
+      setStatus('processing');
+
+      pollRef.current = setInterval(async () => {
+        try {
+          const result = await getCsvUploadStatus(processId);
+          if (result.status === 'COMPLETED') {
+            stopPolling();
+            setStatus('done');
+            setSuccessCount(result.successCount ?? null);
+            if (result.failedRecords && result.failedRecords.length > 0) {
+              setFailedRecords(result.failedRecords as FailedRecord[]);
+            } else {
+              // Auto-close after short delay when fully successful
+              setTimeout(onComplete, 1500);
+            }
+          } else if (result.status === 'FAILED') {
+            stopPolling();
+            setStatus('error');
+            setErrorMsg('Upload processing failed. Please check the error rows below.');
+            if (result.failedRecords) {
+              setFailedRecords(result.failedRecords as FailedRecord[]);
+            }
+          }
+        } catch {
+          stopPolling();
+          setStatus('error');
+          setErrorMsg('Lost connection while checking status. Please try again.');
+        }
+      }, 2000);
+    } catch {
+      setStatus('error');
+      setErrorMsg('Upload failed. Please check your file and try again.');
+    }
+  }, [contentId, selectedFile, onComplete, stopPolling]);
+
+  const statusLabel: Record<UploadStatus, string> = {
+    idle: '',
+    uploading: 'Uploading...',
+    processing: 'Processing...',
+    done: 'Done!',
+    error: 'Error',
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>
+          {mode === 'update' ? 'Update Folder Metadata via CSV' : 'Create Folders via CSV'}
+        </h2>
+        <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+          ✕
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        {/* Drag-and-drop zone */}
+        <div
+          className={`${styles.dropZone} ${isDragOver ? styles.dragOver : ''} ${selectedFile ? styles.hasFile : ''}`}
+          onDragEnter={(e) => { e.preventDefault(); setIsDragOver(true); }}
+          onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+          onDragLeave={(e) => { e.preventDefault(); setIsDragOver(false); }}
+          onDrop={handleDrop}
+          onClick={() => fileInputRef.current?.click()}
+          role="button"
+          tabIndex={0}
+          aria-label="Drop CSV file here or click to browse"
+          onKeyDown={(e) => e.key === 'Enter' && fileInputRef.current?.click()}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv"
+            className={styles.hiddenInput}
+            onChange={handleInputChange}
+            aria-hidden="true"
+          />
+          {selectedFile ? (
+            <div className={styles.fileInfo}>
+              <span className={styles.fileIcon}>📄</span>
+              <span className={styles.fileName}>{selectedFile.name}</span>
+              <span className={styles.fileSize}>
+                ({(selectedFile.size / 1024).toFixed(1)} KB)
+              </span>
+            </div>
+          ) : (
+            <div className={styles.dropHint}>
+              <span className={styles.dropIcon}>⬆️</span>
+              <p className={styles.dropText}>Drag &amp; drop your CSV here</p>
+              <p className={styles.dropSubtext}>or click to browse</p>
+            </div>
+          )}
+        </div>
+
+        {/* Download sample link */}
+        <button
+          className={styles.sampleLink}
+          onClick={handleDownloadSample}
+          type="button"
+        >
+          Download Sample CSV
+        </button>
+
+        {/* Status indicator */}
+        {status !== 'idle' && (
+          <div
+            className={`${styles.statusBar} ${styles[`status_${status}`]}`}
+            role="status"
+            aria-live="polite"
+          >
+            {status === 'processing' && (
+              <span className={styles.spinner} aria-hidden="true" />
+            )}
+            {statusLabel[status]}
+            {status === 'done' && successCount !== null && (
+              <span className={styles.successDetail}> — {successCount} item(s) imported</span>
+            )}
+          </div>
+        )}
+
+        {/* Inline error */}
+        {errorMsg && (
+          <p className={styles.errorMsg} role="alert">{errorMsg}</p>
+        )}
+
+        {/* Failed records table */}
+        {failedRecords.length > 0 && (
+          <div className={styles.failedSection}>
+            <h4 className={styles.failedTitle}>Failed Rows ({failedRecords.length})</h4>
+            <div className={styles.tableWrap}>
+              <table className={styles.failedTable}>
+                <thead>
+                  <tr>
+                    <th>Row</th>
+                    <th>Name</th>
+                    <th>Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {failedRecords.map((row, idx) => (
+                    <tr key={idx}>
+                      <td>{row.rowNumber ?? idx + 1}</td>
+                      <td>{row.name ?? '—'}</td>
+                      <td className={styles.reasonCell}>{row.reason ?? 'Unknown error'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        <Button variant="ghost" onClick={onClose} disabled={status === 'uploading' || status === 'processing'}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          isLoading={status === 'uploading' || status === 'processing'}
+          disabled={!selectedFile || status === 'done'}
+          onClick={handleUpload}
+        >
+          {status === 'done' ? 'Uploaded' : 'Upload'}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/BulkUpload/index.ts
+++ b/projects/collection-editor-react/src/components/BulkUpload/index.ts
@@ -1,0 +1,1 @@
+export { CsvUpload } from './CsvUpload';

--- a/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.module.scss
+++ b/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.module.scss
@@ -158,6 +158,15 @@
   text-overflow: ellipsis;
 }
 
+.userOrg {
+  font-size: 11px;
+  color: var(--sbx-gray-400);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: italic;
+}
+
 .noResults {
   font-size: 13px;
   color: var(--sbx-gray-500);

--- a/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.module.scss
+++ b/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.module.scss
@@ -1,0 +1,265 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: var(--sbx-r-lg);
+  box-shadow: var(--sbx-shadow-3);
+  width: 520px;
+  max-width: 95vw;
+  max-height: 85vh;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--sbx-gray-200);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--sbx-gray-900);
+  margin: 0;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  color: var(--sbx-gray-500);
+  padding: 4px 8px;
+  border-radius: var(--sbx-r-sm);
+  line-height: 1;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-800);
+  }
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sbx-gray-700);
+  margin-bottom: 8px;
+}
+
+.searchSection {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.searchRow {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.searchInput {
+  width: 100%;
+  height: 38px;
+  padding: 0 40px 0 12px;
+  border: 1.5px solid var(--sbx-gray-300);
+  border-radius: var(--sbx-r-sm);
+  font-size: 14px;
+  color: var(--sbx-gray-900);
+  transition: border-color 0.15s;
+
+  &:focus {
+    outline: none;
+    border-color: var(--sbx-primary);
+  }
+}
+
+.searchSpinner {
+  position: absolute;
+  right: 12px;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--sbx-gray-300);
+  border-top-color: var(--sbx-primary);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.resultsList {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-sm);
+  overflow: hidden;
+  background: white;
+  box-shadow: var(--sbx-shadow-2);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.resultItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  gap: 12px;
+  transition: background 0.1s;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--sbx-gray-100);
+  }
+
+  &:hover {
+    background: var(--sbx-gray-50);
+  }
+}
+
+.userInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.userName {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sbx-gray-800);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.userEmail {
+  font-size: 12px;
+  color: var(--sbx-gray-500);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.noResults {
+  font-size: 13px;
+  color: var(--sbx-gray-500);
+  margin: 8px 0 0;
+  padding: 10px 0;
+}
+
+.collabSection {
+  display: flex;
+  flex-direction: column;
+}
+
+.sectionTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sbx-gray-700);
+  margin: 0 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: var(--sbx-primary);
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.emptyCollab {
+  font-size: 13px;
+  color: var(--sbx-gray-500);
+  margin: 0;
+  padding: 16px;
+  text-align: center;
+  background: var(--sbx-gray-50);
+  border-radius: var(--sbx-r-sm);
+  border: 1px dashed var(--sbx-gray-300);
+}
+
+.collabList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.collabItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-sm);
+  background: var(--sbx-gray-50);
+  transition: background 0.1s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+  }
+}
+
+.userAvatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--sbx-primary-light);
+  color: var(--sbx-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 15px;
+  flex-shrink: 0;
+}
+
+.error {
+  font-size: 13px;
+  color: var(--sbx-error);
+  margin: 0;
+}
+
+.success {
+  font-size: 13px;
+  color: var(--sbx-success);
+  margin: 0;
+}
+
+.footer {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding: 16px 24px;
+  border-top: 1px solid var(--sbx-gray-200);
+  flex-shrink: 0;
+}

--- a/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.tsx
+++ b/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Button } from '../shared/Button';
-import { searchUsers } from '../../api/user';
-import { updateCollaborators } from '../../api/hierarchy';
+import { searchUsers, getUsersByIds } from '../../api/user';
+import { updateCollaborators, readContent } from '../../api/hierarchy';
 import type { IUser } from '../../api/user';
 import styles from './ManageCollaborators.module.scss';
 
@@ -22,6 +22,28 @@ export const ManageCollaborators: React.FC<ManageCollaboratorsProps> = ({
   const [saveError, setSaveError] = useState('');
   const [saveSuccess, setSaveSuccess] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Load the content's existing collaborators on open so they can be viewed/removed.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const content = await readContent(contentId);
+        const ids = (content?.collaborators as string[] | undefined) ?? [];
+        if (!ids.length) return;
+        const users = await getUsersByIds(ids);
+        if (cancelled) return;
+        // Fall back to a bare record for any id the search couldn't resolve.
+        const resolved = ids.map(
+          (id) => users.find((u) => u.identifier === id) ?? { identifier: id, firstName: id },
+        );
+        setCollaborators(resolved);
+      } catch {
+        // ignore — start with an empty list
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [contentId]);
 
   // Debounced search
   useEffect(() => {

--- a/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.tsx
+++ b/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { Button } from '../shared/Button';
+import { searchUsers } from '../../api/user';
+import { updateCollaborators } from '../../api/hierarchy';
+import type { IUser } from '../../api/user';
+import styles from './ManageCollaborators.module.scss';
+
+interface ManageCollaboratorsProps {
+  contentId: string;
+  onClose: () => void;
+}
+
+export const ManageCollaborators: React.FC<ManageCollaboratorsProps> = ({
+  contentId,
+  onClose,
+}) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<IUser[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [collaborators, setCollaborators] = useState<IUser[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    const q = searchQuery.trim();
+    if (q.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const results = await searchUsers(q);
+        // Exclude already-added collaborators
+        const collabIds = new Set(collaborators.map((c) => c.identifier));
+        setSearchResults(results.filter((u) => !collabIds.has(u.identifier)));
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchQuery, collaborators]);
+
+  const handleAdd = useCallback(
+    (user: IUser) => {
+      setCollaborators((prev) => {
+        if (prev.find((c) => c.identifier === user.identifier)) return prev;
+        return [...prev, user];
+      });
+      setSearchResults((prev) => prev.filter((u) => u.identifier !== user.identifier));
+      setSaveSuccess(false);
+    },
+    [],
+  );
+
+  const handleRemove = useCallback((userId: string) => {
+    setCollaborators((prev) => prev.filter((c) => c.identifier !== userId));
+    setSaveSuccess(false);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
+    setSaveError('');
+    setSaveSuccess(false);
+    try {
+      await updateCollaborators(
+        contentId,
+        collaborators.map((c) => c.identifier),
+      );
+      setSaveSuccess(true);
+    } catch {
+      setSaveError('Failed to save collaborators. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [contentId, collaborators]);
+
+  const displayName = (user: IUser) =>
+    `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>Manage Collaborators</h2>
+        <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+          ✕
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        {/* Search */}
+        <div className={styles.searchSection}>
+          <label className={styles.label} htmlFor="collab-search">
+            Search users
+          </label>
+          <div className={styles.searchRow}>
+            <input
+              id="collab-search"
+              type="text"
+              className={styles.searchInput}
+              placeholder="Search by name or email..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            {isSearching && <span className={styles.searchSpinner} aria-label="Searching..." />}
+          </div>
+
+          {searchResults.length > 0 && (
+            <ul className={styles.resultsList} role="listbox" aria-label="Search results">
+              {searchResults.map((user) => (
+                <li key={user.identifier} className={styles.resultItem} role="option" aria-selected="false">
+                  <div className={styles.userInfo}>
+                    <span className={styles.userName}>{displayName(user)}</span>
+                    {user.email && (
+                      <span className={styles.userEmail}>{user.email}</span>
+                    )}
+                  </div>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => handleAdd(user)}
+                  >
+                    Add
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {searchQuery.trim().length >= 2 && !isSearching && searchResults.length === 0 && (
+            <p className={styles.noResults}>No users found.</p>
+          )}
+        </div>
+
+        {/* Current collaborators */}
+        <div className={styles.collabSection}>
+          <h3 className={styles.sectionTitle}>
+            Current Collaborators
+            {collaborators.length > 0 && (
+              <span className={styles.badge}>{collaborators.length}</span>
+            )}
+          </h3>
+
+          {collaborators.length === 0 ? (
+            <p className={styles.emptyCollab}>No collaborators added yet.</p>
+          ) : (
+            <ul className={styles.collabList}>
+              {collaborators.map((user) => (
+                <li key={user.identifier} className={styles.collabItem}>
+                  <div className={styles.userAvatar} aria-hidden="true">
+                    {displayName(user).charAt(0).toUpperCase()}
+                  </div>
+                  <div className={styles.userInfo}>
+                    <span className={styles.userName}>{displayName(user)}</span>
+                    {user.email && (
+                      <span className={styles.userEmail}>{user.email}</span>
+                    )}
+                  </div>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={() => handleRemove(user.identifier)}
+                  >
+                    Remove
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {saveError && <p className={styles.error} role="alert">{saveError}</p>}
+        {saveSuccess && (
+          <p className={styles.success} role="status">Collaborators saved successfully.</p>
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        <Button variant="ghost" onClick={onClose} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          isLoading={isSaving}
+          onClick={handleSave}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.tsx
+++ b/projects/collection-editor-react/src/components/Collaborators/ManageCollaborators.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Button } from '../shared/Button';
 import { searchUsers, getUsersByIds } from '../../api/user';
 import { updateCollaborators, readContent } from '../../api/hierarchy';
+import { useEditorStore } from '../../store/editor.store';
 import type { IUser } from '../../api/user';
 import styles from './ManageCollaborators.module.scss';
 
@@ -14,6 +15,10 @@ export const ManageCollaborators: React.FC<ManageCollaboratorsProps> = ({
   contentId,
   onClose,
 }) => {
+  const editorConfig = useEditorStore((s) => s.editorConfig);
+  const rootOrgId = editorConfig?.context?.channel;
+  const objectType = editorConfig?.config?.objectType;
+
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<IUser[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -58,7 +63,7 @@ export const ManageCollaborators: React.FC<ManageCollaboratorsProps> = ({
     debounceRef.current = setTimeout(async () => {
       setIsSearching(true);
       try {
-        const results = await searchUsers(q);
+        const results = await searchUsers(q, { rootOrgId, objectType });
         // Exclude already-added collaborators
         const collabIds = new Set(collaborators.map((c) => c.identifier));
         setSearchResults(results.filter((u) => !collabIds.has(u.identifier)));
@@ -72,7 +77,7 @@ export const ManageCollaborators: React.FC<ManageCollaboratorsProps> = ({
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [searchQuery, collaborators]);
+  }, [searchQuery, collaborators, rootOrgId, objectType]);
 
   const handleAdd = useCallback(
     (user: IUser) => {
@@ -147,6 +152,11 @@ export const ManageCollaborators: React.FC<ManageCollaboratorsProps> = ({
                     {user.email && (
                       <span className={styles.userEmail}>{user.email}</span>
                     )}
+                    {(user.organisations?.[0]?.orgName ?? user.rootOrgName) && (
+                      <span className={styles.userOrg}>
+                        {user.organisations?.[0]?.orgName ?? user.rootOrgName}
+                      </span>
+                    )}
                   </div>
                   <Button
                     variant="primary"
@@ -187,6 +197,11 @@ export const ManageCollaborators: React.FC<ManageCollaboratorsProps> = ({
                     <span className={styles.userName}>{displayName(user)}</span>
                     {user.email && (
                       <span className={styles.userEmail}>{user.email}</span>
+                    )}
+                    {(user.organisations?.[0]?.orgName ?? user.rootOrgName) && (
+                      <span className={styles.userOrg}>
+                        {user.organisations?.[0]?.orgName ?? user.rootOrgName}
+                      </span>
                     )}
                   </div>
                   <Button

--- a/projects/collection-editor-react/src/components/Collaborators/index.ts
+++ b/projects/collection-editor-react/src/components/Collaborators/index.ts
@@ -1,0 +1,1 @@
+export { ManageCollaborators } from './ManageCollaborators';

--- a/projects/collection-editor-react/src/components/CollectionEditor/CollectionEditor.module.scss
+++ b/projects/collection-editor-react/src/components/CollectionEditor/CollectionEditor.module.scss
@@ -1,0 +1,70 @@
+.root {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--sbx-gray-50);
+}
+
+.loadingState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 16px;
+  color: var(--sbx-gray-500);
+  font-family: var(--sbx-font);
+
+  .loadingSpinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--sbx-gray-200);
+    border-top-color: var(--sbx-primary);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+}
+
+.errorState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 12px;
+  font-family: var(--sbx-font);
+  color: var(--sbx-error);
+
+  h3 {
+    margin: 0;
+    font-size: 18px;
+  }
+
+  p {
+    margin: 0;
+    color: var(--sbx-gray-600);
+    font-size: 14px;
+  }
+
+  button {
+    margin-top: 8px;
+    padding: 8px 20px;
+    border: 1.5px solid var(--sbx-gray-300);
+    border-radius: var(--sbx-r-sm);
+    background: white;
+    color: var(--sbx-gray-700);
+    font-size: 14px;
+    cursor: pointer;
+
+    &:hover {
+      border-color: var(--sbx-primary);
+      color: var(--sbx-primary);
+    }
+  }
+}

--- a/projects/collection-editor-react/src/components/CollectionEditor/CollectionEditor.tsx
+++ b/projects/collection-editor-react/src/components/CollectionEditor/CollectionEditor.tsx
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'react-hot-toast';
+import type { IEditorConfig, IEditorEvents } from '../../types/editor';
+import { SplitBuilderShell } from '../SplitBuilderShell';
+import { useEditorInit } from '../../hooks/useEditorInit';
+import { useEditorStore } from '../../store/editor.store';
+import '../../styles/global.scss';
+import styles from './CollectionEditor.module.scss';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: 1, refetchOnWindowFocus: false } },
+});
+
+// ---------------------------------------------------------------------------
+// Error boundary (class component required by React error boundary API)
+// ---------------------------------------------------------------------------
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  onError?: (e: Error) => void;
+}
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+class EditorErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error): void {
+    this.props.onError?.(error);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className={styles.errorState}>
+          <h3>Something went wrong</h3>
+          <p>{this.state.error.message}</p>
+          <button onClick={() => this.setState({ error: null })}>Retry</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inner component — uses hooks (must live inside QueryClientProvider)
+// ---------------------------------------------------------------------------
+interface CollectionEditorInnerProps extends IEditorConfig, IEditorEvents {}
+
+function CollectionEditorInner(props: CollectionEditorInnerProps) {
+  const { isLoading, error } = useEditorInit({
+    config: props as IEditorConfig,
+    onError: props.onError,
+  });
+  const editorMode = useEditorStore((s) => s.editorMode);
+
+  if (isLoading) {
+    return (
+      <div className={styles.loadingState}>
+        <div className={styles.loadingSpinner} />
+        <p>Loading editor...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.errorState}>
+        <h3>Failed to load editor</h3>
+        <p>{error.message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`sb-split-builder ${styles.root}`}>
+      <SplitBuilderShell
+        editorMode={editorMode}
+        onToolbarEvent={props.onToolbarEvent}
+        onContentAdded={props.onContentAdded}
+        onHierarchySaved={props.onHierarchySaved}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API component
+// ---------------------------------------------------------------------------
+export type CollectionEditorProps = IEditorConfig & IEditorEvents;
+
+export const CollectionEditor: React.FC<CollectionEditorProps> = (props) => {
+  return (
+    <EditorErrorBoundary onError={props.onError}>
+      <QueryClientProvider client={queryClient}>
+        <CollectionEditorInner {...props} />
+        <Toaster position="top-right" toastOptions={{ duration: 3000 }} />
+      </QueryClientProvider>
+    </EditorErrorBoundary>
+  );
+};

--- a/projects/collection-editor-react/src/components/CollectionEditor/index.ts
+++ b/projects/collection-editor-react/src/components/CollectionEditor/index.ts
@@ -1,0 +1,2 @@
+export { CollectionEditor } from './CollectionEditor';
+export type { CollectionEditorProps } from './CollectionEditor';

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
@@ -1,0 +1,77 @@
+// ── Outer container ──────────────────────────────────────────────────────────
+.contentPlayerRoot {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+// ── 16:9 aspect-ratio player box (mirrors Angular's .aspectratio[data-ratio="16:9"]) ──
+.aspectRatio {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%; // 16:9
+
+  > * {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.playerWrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  overflow: hidden;
+}
+
+.playerFrame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+}
+
+// ── Metadata grid (mirrors Angular's .ui.grid below the player) ──────────────
+.metaGrid {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 12px 16px 8px;
+  background: #fff;
+  border-top: 1px solid var(--sbx-gray-200, #e8e8e8);
+  gap: 0;
+}
+
+// Column width cycle: 50% → 33% → 17% (approximates Angular's 6/4/2 wide columns)
+.metaColWide   { width: 50%; padding: 6px 8px; }
+.metaColMed    { width: 33.33%; padding: 6px 8px; }
+.metaColNarrow { width: 16.67%; padding: 6px 8px; }
+
+.metaField {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.metaLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--sbx-gray-500, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.metaValue {
+  font-size: 13px;
+  color: var(--sbx-gray-800, #333);
+  word-break: break-word;
+}

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
@@ -1,29 +1,209 @@
-// ── Outer container ──────────────────────────────────────────────────────────
+// ── Content-type accent colours ───────────────────────────────────────────────
+// Each mime-family gets a signature hue used on badge + stage border glow.
+$type-video : #e63946;
+$type-pdf   : #2563eb;
+$type-epub  : #7c3aed;
+$type-ecml  : #059669;
+$type-h5p   : #d97706;
+$type-scorm : #0891b2;
+$type-audio : #7c3aed;
+$type-other : #64748b;
+
+// ── Root wrapper ──────────────────────────────────────────────────────────────
+// Takes all available height from the leafContentLayout column.
 .contentPlayerRoot {
-  width: 100%;
   display: flex;
   flex-direction: column;
-  background: #fff;
-  overflow-y: auto;
-  flex: 1;
+  flex: 1 1 auto;
   min-height: 0;
+  overflow: hidden;
 }
 
-// ── 16:9 aspect-ratio player box (mirrors Angular's .aspectratio[data-ratio="16:9"]) ──
+// ── Stage  ────────────────────────────────────────────────────────────────────
+// Dark "cinema" frame around the player.
+.stage {
+  position: relative;
+  background: #0d1117;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+// ── Player header bar ─────────────────────────────────────────────────────────
+.playerHeader {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px 24px;
+  background: linear-gradient(to bottom, rgba(0,0,0,.72) 0%, transparent 100%);
+  pointer-events: none; // clicks pass through to player
+}
+
+.playerHeaderThumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  object-fit: cover;
+  flex-shrink: 0;
+  opacity: .9;
+  border: 1.5px solid rgba(255,255,255,.2);
+}
+
+.playerHeaderTitle {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255,255,255,.92);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// ── Content-type badge ────────────────────────────────────────────────────────
+.typeBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  color: #fff;
+  flex-shrink: 0;
+  pointer-events: auto;
+
+  // per-type colours
+  &[data-type="video"]  { background: $type-video; }
+  &[data-type="pdf"]    { background: $type-pdf;   }
+  &[data-type="epub"]   { background: $type-epub;  }
+  &[data-type="ecml"]   { background: $type-ecml;  }
+  &[data-type="h5p"]    { background: $type-h5p;   }
+  &[data-type="scorm"]  { background: $type-scorm; }
+  &[data-type="audio"]  { background: $type-audio; }
+  &[data-type="other"]  { background: $type-other; }
+}
+
+.typeDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(255,255,255,.7);
+}
+
+// ── 16:9 player area ──────────────────────────────────────────────────────────
 .aspectRatio {
   position: relative;
   width: 100%;
-  padding-top: 56.25%; // 16:9
+  // Use padding-top trick only as fallback; flex:1 handles most layouts
+  flex: 1 1 auto;
+  min-height: 0;
 
   > * {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
     width: 100%;
     height: 100%;
   }
 }
 
+.playerFrame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+  background: #000;
+}
+
+// ── Thumbnail cover (shown while player loads) ────────────────────────────────
+.coverOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: #0d1117;
+  z-index: 5;
+  transition: opacity .4s ease;
+
+  &.coverHidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.coverThumb {
+  width: 80px;
+  height: 80px;
+  border-radius: 12px;
+  object-fit: cover;
+  opacity: .85;
+  border: 2px solid rgba(255,255,255,.15);
+}
+
+.coverPlayRing {
+  position: relative;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255,255,255,.08);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.coverPlayIcon {
+  width: 0;
+  height: 0;
+  border-top: 11px solid transparent;
+  border-bottom: 11px solid transparent;
+  border-left: 18px solid rgba(255,255,255,.85);
+  margin-left: 4px;
+}
+
+.coverLabel {
+  font-size: 12px;
+  color: rgba(255,255,255,.45);
+  letter-spacing: .5px;
+}
+
+// Skeleton shimmer — shown when there's no thumbnail
+.coverSkeleton {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    #1a1f2e 25%,
+    #242938 50%,
+    #1a1f2e 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.6s infinite;
+}
+
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1);    opacity: .8; }
+  50%       { transform: scale(1.1); opacity: 1;  }
+}
+
+// ── Player wrapper (web components) ──────────────────────────────────────────
 .playerWrapper {
   width: 100%;
   height: 100%;
@@ -34,44 +214,65 @@
   overflow: hidden;
 }
 
-.playerFrame {
-  width: 100%;
-  height: 100%;
-  border: none;
-  display: block;
-}
-
-// ── Metadata grid (mirrors Angular's .ui.grid below the player) ──────────────
-.metaGrid {
+// ── Bottom info strip ─────────────────────────────────────────────────────────
+// Compact dark strip below the player — replaces the old raw metadata grid.
+.infoStrip {
   display: flex;
-  flex-wrap: wrap;
-  padding: 12px 16px 8px;
-  background: #fff;
-  border-top: 1px solid var(--sbx-gray-200, #e8e8e8);
+  align-items: center;
   gap: 0;
+  padding: 0 4px;
+  background: #161b27;
+  border-top: 1px solid rgba(255,255,255,.07);
+  overflow-x: auto;
+  flex-shrink: 0;
+  min-height: 38px;
+
+  // hide scrollbar but keep scroll
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
 }
 
-// Column width cycle: 50% → 33% → 17% (approximates Angular's 6/4/2 wide columns)
-.metaColWide   { width: 50%; padding: 6px 8px; }
-.metaColMed    { width: 33.33%; padding: 6px 8px; }
-.metaColNarrow { width: 16.67%; padding: 6px 8px; }
+.infoChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 12px;
+  height: 38px;
+  flex-shrink: 0;
+  border-right: 1px solid rgba(255,255,255,.07);
+  font-size: 12px;
+  color: rgba(255,255,255,.6);
+  transition: color .15s;
 
-.metaField {
+  &:hover { color: rgba(255,255,255,.9); }
+  &:last-child { border-right: none; }
+}
+
+.infoChipLabel {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .4px;
+  color: rgba(255,255,255,.35);
+  margin-right: 2px;
+}
+
+.infoChipIcon {
+  font-size: 13px;
+  opacity: .6;
+  flex-shrink: 0;
+}
+
+// ── QuML player ───────────────────────────────────────────────────────────────
+.qumlRoot {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-}
+  flex: 1 1 auto;
+  min-height: 0;
+  background: #0d1117;
 
-.metaLabel {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--sbx-gray-500, #888);
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-}
-
-.metaValue {
-  font-size: 13px;
-  color: var(--sbx-gray-800, #333);
-  word-break: break-word;
+  .playerWrapper {
+    flex: 1;
+    min-height: 0;
+  }
 }

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
@@ -292,15 +292,28 @@ $type-other : #64748b;
 }
 
 // ── QuML player ───────────────────────────────────────────────────────────────
+// Light background: the React QuML player draws its own light UI at content
+// height, so a dark wrapper would show as a black band below short content
+// (video/pdf keep their black letterboxing via the default .playerWrapper).
 .qumlRoot {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
-  background: #0d1117;
+  background: #fff;
 
   .playerWrapper {
     flex: 1;
     min-height: 0;
+    background: #fff;
+    // Stretch the custom element to fill the area instead of centering it.
+    align-items: stretch;
+    justify-content: stretch;
+
+    :global(sunbird-quml-player) {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
   }
 }

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.module.scss
@@ -263,6 +263,34 @@ $type-other : #64748b;
   flex-shrink: 0;
 }
 
+// ── Player error state ────────────────────────────────────────────────────────
+// Shown instead of the cover overlay when the player fails to load.
+.playerError {
+  position: absolute;
+  inset: 0;
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: #0d1117;
+  padding: 24px;
+  text-align: center;
+}
+
+.playerErrorIcon {
+  font-size: 28px;
+  opacity: .7;
+}
+
+.playerErrorMsg {
+  font-size: 13px;
+  color: rgba(255, 255, 255, .5);
+  max-width: 260px;
+  line-height: 1.5;
+}
+
 // ── QuML player ───────────────────────────────────────────────────────────────
 .qumlRoot {
   display: flex;

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
@@ -3,7 +3,22 @@ import type { INode, EditorMode } from '../../types/editor';
 import { useEditorStore } from '../../store/editor.store';
 import styles from './ContentPlayer.module.scss';
 
-// ── MIME-type → player type mapping (mirrors player.config.json) ─────────────
+// ── MIME-type classification ──────────────────────────────────────────────────
+const MIME_GROUPS: Array<{ key: string; mimes: string[]; label: string; icon: string }> = [
+  { key: 'video',  mimes: ['video/mp4','video/webm','video/ogg'],               label: 'Video',  icon: '🎬' },
+  { key: 'audio',  mimes: ['audio/mp3','audio/mpeg','audio/ogg','audio/wav'],    label: 'Audio',  icon: '🎵' },
+  { key: 'pdf',    mimes: ['application/pdf'],                                   label: 'PDF',    icon: '📄' },
+  { key: 'epub',   mimes: ['application/epub'],                                  label: 'ePub',   icon: '📖' },
+  { key: 'ecml',   mimes: ['application/vnd.ekstep.ecml-archive'],               label: 'ECML',   icon: '✏️'  },
+  { key: 'h5p',    mimes: ['application/vnd.ekstep.h5p-archive'],                label: 'H5P',    icon: '🎮'  },
+  { key: 'scorm',  mimes: ['application/vnd.ekstep.content-collection'],         label: 'SCORM',  icon: '📦'  },
+];
+
+function getMimeGroup(mimeType: string) {
+  return MIME_GROUPS.find(g => g.mimes.includes(mimeType)) ?? { key: 'other', label: 'Content', icon: '📱' };
+}
+
+// ── Player type resolution ────────────────────────────────────────────────────
 const PLAYER_TYPE_MAP: Record<string, string[]> = {
   'pdf-player':   ['application/pdf'],
   'video-player': ['video/mp4', 'video/webm'],
@@ -32,7 +47,7 @@ function resolvePlayerType(mimeType: string): string {
   return 'default-player';
 }
 
-// ── Build playerConfig the same way as Angular's PlayerService ───────────────
+// ── Player config builder ─────────────────────────────────────────────────────
 function buildPlayerConfig(
   node: INode,
   editorConfig: ReturnType<typeof useEditorStore.getState>['editorConfig'],
@@ -45,11 +60,7 @@ function buildPlayerConfig(
     context: {
       mode: 'play',
       partner: [],
-      pdata: {
-        id: ctx?.pdata?.id ?? 'sunbird.portal',
-        ver: 1.0,
-        pid: 'sunbird-portal',
-      },
+      pdata: { id: ctx?.pdata?.id ?? 'sunbird.portal', ver: 1.0, pid: 'sunbird-portal' },
       contentId: node.identifier,
       sid: ctx?.sid ?? '',
       uid: ctx?.uid ?? '',
@@ -78,14 +89,11 @@ function buildPlayerConfig(
       previewCdnUrl: undefined,
     },
     metadata,
-    // For ECML content include body; otherwise empty object
-    data: mimeType === 'application/vnd.ekstep.ecml-archive'
-      ? (metadata.body ?? {})
-      : {},
+    data: mimeType === 'application/vnd.ekstep.ecml-archive' ? (metadata.body ?? {}) : {},
   };
 }
 
-// ── Script loader (idempotent) ───────────────────────────────────────────────
+// ── Script loader ─────────────────────────────────────────────────────────────
 function loadScript(src: string): Promise<void> {
   if (document.querySelector(`script[src="${src}"]`)) return Promise.resolve();
   return new Promise((resolve, reject) => {
@@ -99,121 +107,139 @@ function loadScript(src: string): Promise<void> {
 
 function waitForCustomElement(tag: string, playerType: string, maxAttempts = 100): Promise<void> {
   return loadScript(PLAYER_SCRIPTS[playerType] ?? '').then(
-    () =>
-      new Promise((resolve) => {
-        if (customElements.get(tag)) { resolve(); return; }
-        let attempts = 0;
-        const id = setInterval(() => {
-          attempts++;
-          if (customElements.get(tag) || attempts >= maxAttempts) {
-            clearInterval(id);
-            resolve();
-          }
-        }, 100);
-      }),
+    () => new Promise((resolve) => {
+      if (customElements.get(tag)) { resolve(); return; }
+      let attempts = 0;
+      const id = setInterval(() => {
+        attempts++;
+        if (customElements.get(tag) || attempts >= maxAttempts) { clearInterval(id); resolve(); }
+      }, 100);
+    }),
   );
 }
 
-// ── Props ────────────────────────────────────────────────────────────────────
-interface ContentPlayerProps {
-  node: INode;
-  editorMode: EditorMode;
-  type: 'content' | 'quml';
-}
-
-// ── Metadata labels (mirrors label.config.json lbl section) ─────────────────
-const META_LABELS: Record<string, string> = {
-  name:         'Name',
-  author:       'Author',
-  license:      'License',
-  copyright:    'Copyright',
-  attributions: 'Attributions',
-  audience:     'Audience',
-  board:        'Board',
-  medium:       'Medium',
-  gradeLevel:   'Class',
-  subject:      'Subject',
-  topic:        'Topic',
-  contentType:  'Content Type',
-  language:     'Language',
-};
-
-// Fields shown below the player (same order as Angular's sessionContext)
-const META_FIELDS = [
-  'name', 'author', 'license', 'copyright',
-  'board', 'medium', 'gradeLevel', 'subject',
-  'topic', 'audience', 'attributions', 'contentType', 'language',
+// ── Info strip ────────────────────────────────────────────────────────────────
+const INFO_FIELDS: Array<{ key: string; label: string; icon: string }> = [
+  { key: 'author',      label: 'Author',   icon: '👤' },
+  { key: 'license',     label: 'License',  icon: '⚖️'  },
+  { key: 'copyright',   label: '©',        icon: ''   },
+  { key: 'language',    label: 'Language', icon: '🌐'  },
+  { key: 'gradeLevel',  label: 'Class',    icon: '🏫'  },
+  { key: 'subject',     label: 'Subject',  icon: '📚'  },
+  { key: 'contentType', label: 'Type',     icon: '🏷️'  },
 ];
 
-interface MetaField { key: string; label: string; value: string }
-
-function buildMetaFields(node: INode): MetaField[] {
+function InfoStrip({ node }: { node: INode }) {
   const meta = (node.metadata ?? {}) as Record<string, unknown>;
-  const fields: MetaField[] = [];
-
-  for (const key of META_FIELDS) {
-    const raw = meta[key] ?? (node as unknown as Record<string, unknown>)[key];
-    if (raw === undefined || raw === null || raw === '') continue;
-    const value = Array.isArray(raw) ? raw.join(', ') : String(raw);
-    if (!value) continue;
-    fields.push({ key, label: META_LABELS[key] ?? key, value });
-  }
-  return fields;
-}
-
-// ── Content metadata strip (mirrors Angular's contentInfoArray grid) ──────────
-function ContentMetaInfo({ node }: { node: INode }) {
-  const fields = buildMetaFields(node);
-  if (!fields.length) return null;
-
-  // Column width cycle: wide → medium → narrow (mirrors Angular's 6/4/2 column pattern)
-  const colStyles = [styles.metaColWide, styles.metaColMed, styles.metaColNarrow];
+  const chips = INFO_FIELDS.flatMap(f => {
+    const raw = meta[f.key];
+    if (!raw) return [];
+    const val = Array.isArray(raw) ? raw.join(', ') : String(raw);
+    if (!val) return [];
+    return [{ ...f, val }];
+  });
+  if (!chips.length) return null;
 
   return (
-    <div className={styles.metaGrid}>
-      {fields.map((f, i) => (
-        <div key={f.key} className={colStyles[i % colStyles.length]}>
-          <div className={styles.metaField}>
-            <span className={styles.metaLabel}>{f.label}</span>
-            <span className={styles.metaValue}>{f.value}</span>
-          </div>
+    <div className={styles.infoStrip}>
+      {chips.map(c => (
+        <div key={c.key} className={styles.infoChip}>
+          {c.icon && <span className={styles.infoChipIcon}>{c.icon}</span>}
+          <span className={styles.infoChipLabel}>{c.label}</span>
+          {c.val}
         </div>
       ))}
     </div>
   );
 }
 
-// ── Root component ───────────────────────────────────────────────────────────
+// ── Cover overlay (shown while player initialises) ────────────────────────────
+function CoverOverlay({ node, hidden }: { node: INode; hidden: boolean }) {
+  const thumb = node.appIcon ?? (node.metadata?.appIcon as string | undefined);
+  return (
+    <div className={`${styles.coverOverlay} ${hidden ? styles.coverHidden : ''}`}>
+      {thumb ? (
+        <>
+          <img src={thumb} alt={node.name} className={styles.coverThumb} />
+          <div className={styles.coverPlayRing}>
+            <div className={styles.coverPlayIcon} />
+          </div>
+          <span className={styles.coverLabel}>Loading preview…</span>
+        </>
+      ) : (
+        <div className={styles.coverSkeleton} />
+      )}
+    </div>
+  );
+}
+
+// ── Type badge ────────────────────────────────────────────────────────────────
+function TypeBadge({ mimeType }: { mimeType: string }) {
+  const group = getMimeGroup(mimeType);
+  return (
+    <span className={styles.typeBadge} data-type={group.key}>
+      <span className={styles.typeDot} />
+      {group.label}
+    </span>
+  );
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+interface ContentPlayerProps {
+  node: INode;
+  editorMode: EditorMode;
+  type: 'content' | 'quml';
+}
+
+// ── Root ──────────────────────────────────────────────────────────────────────
 export const ContentPlayer: React.FC<ContentPlayerProps> = ({ node, editorMode, type }) => {
   if (type === 'quml') return <QumlPlayer node={node} editorMode={editorMode} />;
+
+  const thumb = node.appIcon ?? (node.metadata?.appIcon as string | undefined);
+
   return (
     <div className={styles.contentPlayerRoot}>
-      <SunbirdContentPlayer node={node} />
-      <ContentMetaInfo node={node} />
+      {/* Dark cinema stage */}
+      <div className={styles.stage}>
+        {/* Header gradient bar */}
+        <div className={styles.playerHeader}>
+          {thumb && (
+            <img src={thumb} alt="" className={styles.playerHeaderThumb} />
+          )}
+          <span className={styles.playerHeaderTitle}>{node.name}</span>
+          <TypeBadge mimeType={node.mimeType ?? ''} />
+        </div>
+
+        {/* Actual player */}
+        <SunbirdContentPlayer node={node} />
+      </div>
+
+      {/* Compact info strip below the stage */}
+      <InfoStrip node={node} />
     </div>
   );
 };
 
-// ── Sunbird content player (mirrors ContentplayerPageComponent) ───────────────
+// ── Sunbird content player ────────────────────────────────────────────────────
 function SunbirdContentPlayer({ node }: { node: INode }) {
   const editorConfig = useEditorStore((s) => s.editorConfig);
-  const [playerType, setPlayerType] = useState<string>(() => resolvePlayerType(node.mimeType ?? ''));
+  const [playerType, setPlayerType] = useState(() => resolvePlayerType(node.mimeType ?? ''));
+  const [coverHidden, setCoverHidden] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const webComponentRef = useRef<HTMLDivElement>(null);
 
   const playerConfig = buildPlayerConfig(node, { editorConfig } as any);
 
-  // ── When content changes, re-resolve player type ─────────────────────────
   useEffect(() => {
+    setCoverHidden(false);
     setPlayerType(resolvePlayerType(node.mimeType ?? ''));
   }, [node.identifier, node.mimeType]);
 
-  // ── Default player — iframe + initializePreview() ────────────────────────
+  // Default player — iframe
   useEffect(() => {
     if (playerType !== 'default-player') return;
     const iframe = iframeRef.current;
     if (!iframe) return;
-
     iframe.src = DEFAULT_PLAYER_URL;
     iframe.onload = () => {
       try {
@@ -221,43 +247,32 @@ function SunbirdContentPlayer({ node }: { node: INode }) {
       } catch (err) {
         console.error('initializePreview failed', err);
       }
+      setTimeout(() => setCoverHidden(true), 300);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [node.identifier, playerType]);
 
-  // ── Web component players (pdf / video / epub) ────────────────────────────
+  // Web-component players (pdf / video / epub)
   useEffect(() => {
     if (playerType === 'default-player') return;
     const container = webComponentRef.current;
     if (!container) return;
-
     const tag = PLAYER_TAGS[playerType];
     if (!tag) return;
 
     waitForCustomElement(tag, playerType).then(() => {
-      if (!webComponentRef.current) return; // unmounted
-
-      if (!customElements.get(tag)) {
-        // Web component script unavailable — fall back to default player
-        setPlayerType('default-player');
-        return;
-      }
+      if (!webComponentRef.current) return;
+      if (!customElements.get(tag)) { setPlayerType('default-player'); return; }
 
       const el = document.createElement(tag) as any;
       el.setAttribute('player-config', JSON.stringify(playerConfig));
       el.addEventListener('playerEvent', () => {});
       el.addEventListener('telemetryEvent', () => {});
-
       container.innerHTML = '';
       container.appendChild(el);
-
-      // Give web component a tick to upgrade, then push config via property
       setTimeout(() => {
-        try {
-          el.playerConfig = playerConfig;
-        } catch {
-          // some players only use the attribute
-        }
+        try { el.playerConfig = playerConfig; } catch { /* attribute-only player */ }
+        setCoverHidden(true);
       }, 200);
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -265,6 +280,7 @@ function SunbirdContentPlayer({ node }: { node: INode }) {
 
   return (
     <div className={styles.aspectRatio}>
+      <CoverOverlay node={node} hidden={coverHidden} />
       {playerType === 'default-player' ? (
         <iframe
           ref={iframeRef}
@@ -281,7 +297,7 @@ function SunbirdContentPlayer({ node }: { node: INode }) {
   );
 }
 
-// ── QuML player (web component) ───────────────────────────────────────────────
+// ── QuML player ───────────────────────────────────────────────────────────────
 function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode }) {
   const editorConfig = useEditorStore((s) => s.editorConfig);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -299,13 +315,7 @@ function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode 
         channel: ctx?.channel ?? '',
         did: ctx?.did ?? '',
       },
-      config: {
-        enable: false,
-        showShare: false,
-        showDownload: false,
-        showReplay: true,
-        showExit: false,
-      },
+      config: { enable: false, showShare: false, showDownload: false, showReplay: true, showExit: false },
       metadata: node.metadata ?? {},
       data: {},
     };
@@ -316,5 +326,9 @@ function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode 
     containerRef.current.appendChild(el);
   }, [node.identifier, editorMode]);
 
-  return <div ref={containerRef} className={styles.playerWrapper} />;
+  return (
+    <div className={styles.qumlRoot}>
+      <div ref={containerRef} className={styles.playerWrapper} />
+    </div>
+  );
 }

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
@@ -1,10 +1,37 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { INode, EditorMode } from '../../types/editor';
 import { useEditorStore } from '../../store/editor.store';
+import { useTreeStore } from '../../store/tree.store';
 import { fetchContentDetails } from '../../api/content';
-import { useQumlContent } from '../../hooks/useQumlContent';
+import { useQumlContent, buildSingleQuestionHierarchy } from '../../hooks/useQumlContent';
 import { qumlPlayerService, QumlPlayerService } from '../../services/quml/QumlPlayerService';
 import styles from './ContentPlayer.module.scss';
+
+const QUESTIONSET_MIME = 'application/vnd.sunbird.questionset';
+
+/**
+ * Walks the tree from a question node up to the nearest ancestor QuestionSet —
+ * the base hierarchy for a single-question preview. The QuestionSet may be the
+ * editor root or a leaf inside a Collection, so we resolve it from the tree
+ * rather than the editor context.
+ */
+function findAncestorQuestionSetId(nodes: INode[], nodeId: string): string | null {
+  const byId = new Map<string, INode>();
+  const index = (list: INode[]) => {
+    for (const n of list) {
+      byId.set(n.id, n);
+      if (n.children) index(n.children);
+    }
+  };
+  index(nodes);
+
+  let current = byId.get(nodeId);
+  while (current) {
+    if (current.mimeType === QUESTIONSET_MIME) return current.identifier;
+    current = current.parent ? byId.get(current.parent) : undefined;
+  }
+  return null;
+}
 
 // ── MIME-type classification ──────────────────────────────────────────────────
 const MIME_GROUPS: Array<{ key: string; mimes: string[]; label: string; icon: string }> = [
@@ -209,11 +236,13 @@ interface ContentPlayerProps {
   node: INode;
   editorMode: EditorMode;
   type: 'content' | 'quml';
+  /** For type='quml': render a single question rather than the whole set. */
+  singleQuestion?: boolean;
 }
 
 // ── Root ──────────────────────────────────────────────────────────────────────
-export const ContentPlayer: React.FC<ContentPlayerProps> = ({ node, editorMode, type }) => {
-  if (type === 'quml') return <QumlPlayer node={node} editorMode={editorMode} />;
+export const ContentPlayer: React.FC<ContentPlayerProps> = ({ node, editorMode, type, singleQuestion }) => {
+  if (type === 'quml') return <QumlPlayer node={node} editorMode={editorMode} singleQuestion={!!singleQuestion} />;
 
   const thumb = node.appIcon ?? (node.metadata?.appIcon as string | undefined);
 
@@ -377,13 +406,40 @@ function SunbirdContentPlayer({ node }: { node: INode }) {
 }
 
 // ── QuML player ───────────────────────────────────────────────────────────────
-// Loads a full QuestionSet: fetches the hierarchy + inlines every question's
-// body, then renders it through the <sunbird-quml-player> web component.
-function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode }) {
+// Renders through the <sunbird-quml-player> web component. Two modes:
+//  • whole set   — fetch the questionset hierarchy (questions inlined) for the node.
+//  • single question — fetch the ancestor questionset, then expose only the one
+//    selected question (mirrors Angular's isSingleQuestionPreview).
+function QumlPlayer({
+  node,
+  editorMode,
+  singleQuestion,
+}: {
+  node: INode;
+  editorMode: EditorMode;
+  singleQuestion: boolean;
+}) {
   const editorConfig = useEditorStore((s) => s.editorConfig);
+  const treeData = useTreeStore((s) => s.treeData);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { data: metadata, isLoading, error } = useQumlContent(node.identifier);
+  // Base questionset id: the node itself for a set, or its nearest ancestor
+  // questionset when previewing a single question.
+  const baseQuestionSetId = singleQuestion
+    ? findAncestorQuestionSetId(treeData, node.id)
+    : node.identifier;
+
+  const { data: baseHierarchy, isLoading, error } = useQumlContent(
+    baseQuestionSetId ?? '',
+    { enabled: !!baseQuestionSetId },
+  );
+
+  // For single-question mode, derive a one-question hierarchy from the set.
+  const metadata = React.useMemo(() => {
+    if (!baseHierarchy) return null;
+    if (!singleQuestion) return baseHierarchy;
+    return buildSingleQuestionHierarchy(baseHierarchy, node.identifier);
+  }, [baseHierarchy, singleQuestion, node.identifier]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -397,7 +453,7 @@ function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode 
         const config = await qumlPlayerService.createConfig(
           metadata,
           editorConfig?.context,
-          { mode: editorMode === 'edit' ? 'edit' : 'play' },
+          { mode: editorMode === 'edit' ? 'edit' : 'play', singleQuestion },
         );
         if (cancelled || !containerRef.current) return;
         const element = qumlPlayerService.createElement(config);
@@ -422,12 +478,20 @@ function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode 
       }
       QumlPlayerService.unloadStyles();
     };
-  }, [metadata, editorConfig, editorMode]);
+  }, [metadata, editorConfig, editorMode, singleQuestion]);
+
+  const errorMessage = error
+    ? `Unable to load questionset: ${error.message}`
+    : singleQuestion && !baseQuestionSetId
+      ? 'Could not resolve the parent questionset for this question.'
+      : singleQuestion && baseHierarchy && !metadata
+        ? 'Question not found in the questionset.'
+        : null;
 
   return (
     <div className={styles.qumlRoot}>
-      {error ? (
-        <PlayerError message={`Unable to load questionset: ${error.message}`} />
+      {errorMessage ? (
+        <PlayerError message={errorMessage} />
       ) : isLoading || !metadata ? (
         <CoverOverlay node={node} hidden={false} />
       ) : null}

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import type { INode, EditorMode } from '../../types/editor';
 import { useEditorStore } from '../../store/editor.store';
 import { fetchContentDetails } from '../../api/content';
+import { useQumlContent } from '../../hooks/useQumlContent';
+import { qumlPlayerService, QumlPlayerService } from '../../services/quml/QumlPlayerService';
 import styles from './ContentPlayer.module.scss';
 
 // ── MIME-type classification ──────────────────────────────────────────────────
@@ -375,36 +377,60 @@ function SunbirdContentPlayer({ node }: { node: INode }) {
 }
 
 // ── QuML player ───────────────────────────────────────────────────────────────
+// Loads a full QuestionSet: fetches the hierarchy + inlines every question's
+// body, then renders it through the <sunbird-quml-player> web component.
 function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode }) {
   const editorConfig = useEditorStore((s) => s.editorConfig);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!containerRef.current) return;
-    const ctx = editorConfig?.context;
-    const qumlConfig = {
-      context: {
-        mode: editorMode === 'edit' ? 'edit' : 'play',
-        pdata: { id: ctx?.pdata?.id ?? 'sunbird.portal', ver: '1.0', pid: 'sunbird-portal' },
-        contentId: node.identifier,
-        sid: ctx?.sid ?? '',
-        uid: ctx?.uid ?? '',
-        channel: ctx?.channel ?? '',
-        did: ctx?.did ?? '',
-      },
-      config: { enable: false, showShare: false, showDownload: false, showReplay: true, showExit: false },
-      metadata: node.metadata ?? {},
-      data: {},
-    };
+  const { data: metadata, isLoading, error } = useQumlContent(node.identifier);
 
-    const el = document.createElement('sunbird-quml-player') as HTMLElement & Record<string, unknown>;
-    el.setAttribute('player-config', JSON.stringify(qumlConfig));
-    containerRef.current.innerHTML = '';
-    containerRef.current.appendChild(el);
-  }, [node.identifier, editorMode]);
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !metadata) return;
+
+    let el: HTMLElement | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const config = await qumlPlayerService.createConfig(
+          metadata,
+          editorConfig?.context,
+          { mode: editorMode === 'edit' ? 'edit' : 'play' },
+        );
+        if (cancelled || !containerRef.current) return;
+        const element = qumlPlayerService.createElement(config);
+        el = element;
+        qumlPlayerService.attachEventListeners(
+          element,
+          (e: CustomEvent) => console.debug('[QumlPlayer] playerEvent', e.detail),
+          (detail: unknown) => console.debug('[QumlPlayer] telemetryEvent', detail),
+        );
+        container.innerHTML = '';
+        container.appendChild(element);
+      } catch (err) {
+        console.error('[QumlPlayer] failed to initialize', err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (el) {
+        qumlPlayerService.removeEventListeners(el);
+        el.remove();
+      }
+      QumlPlayerService.unloadStyles();
+    };
+  }, [metadata, editorConfig, editorMode]);
 
   return (
     <div className={styles.qumlRoot}>
+      {error ? (
+        <PlayerError message={`Unable to load questionset: ${error.message}`} />
+      ) : isLoading || !metadata ? (
+        <CoverOverlay node={node} hidden={false} />
+      ) : null}
       <div ref={containerRef} className={styles.playerWrapper} />
     </div>
   );

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
@@ -450,10 +450,12 @@ function QumlPlayer({
 
     (async () => {
       try {
+        // Single-question preview needs no player flags: metadata is already a
+        // one-question hierarchy, so the derived inline section has one entry.
         const config = await qumlPlayerService.createConfig(
           metadata,
           editorConfig?.context,
-          { mode: editorMode === 'edit' ? 'edit' : 'play', singleQuestion },
+          { mode: editorMode === 'edit' ? 'edit' : 'play' },
         );
         if (cancelled || !containerRef.current) return;
         const element = qumlPlayerService.createElement(config);

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
@@ -1,0 +1,320 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { INode, EditorMode } from '../../types/editor';
+import { useEditorStore } from '../../store/editor.store';
+import styles from './ContentPlayer.module.scss';
+
+// ── MIME-type → player type mapping (mirrors player.config.json) ─────────────
+const PLAYER_TYPE_MAP: Record<string, string[]> = {
+  'pdf-player':   ['application/pdf'],
+  'video-player': ['video/mp4', 'video/webm'],
+  'epub-player':  ['application/epub'],
+};
+
+const PLAYER_SCRIPTS: Record<string, string> = {
+  'pdf-player':   '/assets/sunbird-pdf-player.js',
+  'video-player': '/assets/sunbird-video-player.js',
+  'epub-player':  '/assets/sunbird-epub-player.js',
+};
+
+const PLAYER_TAGS: Record<string, string> = {
+  'pdf-player':   'sunbird-pdf-player',
+  'video-player': 'sunbird-video-player',
+  'epub-player':  'sunbird-epub-player',
+};
+
+const DEFAULT_PLAYER_URL =
+  '/content/preview/preview.html?webview=true&build_number=2.8.0.e552fcd';
+
+function resolvePlayerType(mimeType: string): string {
+  for (const [type, mimes] of Object.entries(PLAYER_TYPE_MAP)) {
+    if (mimes.includes(mimeType)) return type;
+  }
+  return 'default-player';
+}
+
+// ── Build playerConfig the same way as Angular's PlayerService ───────────────
+function buildPlayerConfig(
+  node: INode,
+  editorConfig: ReturnType<typeof useEditorStore.getState>['editorConfig'],
+) {
+  const ctx = editorConfig?.context;
+  const metadata = (node.metadata ?? {}) as Record<string, unknown>;
+  const mimeType = node.mimeType ?? '';
+
+  return {
+    context: {
+      mode: 'play',
+      partner: [],
+      pdata: {
+        id: ctx?.pdata?.id ?? 'sunbird.portal',
+        ver: 1.0,
+        pid: 'sunbird-portal',
+      },
+      contentId: node.identifier,
+      sid: ctx?.sid ?? '',
+      uid: ctx?.uid ?? '',
+      channel: ctx?.channel ?? '',
+      did: ctx?.did ?? '',
+      timeDiff: 0,
+      contextRollup: {},
+      tags: [],
+      app: [ctx?.channel ?? ''],
+      dims: '',
+    },
+    config: {
+      showEndPage: false,
+      showStartPage: true,
+      host: '',
+      overlay: { showUser: false },
+      splash: { text: '', icon: '', bgImage: '', webLink: '' },
+      sideMenu: { showDownload: true, showExit: false, showShare: true },
+      apislug: '/action',
+      repos: ['/sunbird-plugins/renderer'],
+      plugins: [
+        { id: 'org.sunbird.iframeEvent', ver: 1.0, type: 'plugin' },
+        { id: 'org.sunbird.player.endpage', ver: 1.1, type: 'plugin' },
+      ],
+      enableTelemetryValidation: false,
+      previewCdnUrl: undefined,
+    },
+    metadata,
+    // For ECML content include body; otherwise empty object
+    data: mimeType === 'application/vnd.ekstep.ecml-archive'
+      ? (metadata.body ?? {})
+      : {},
+  };
+}
+
+// ── Script loader (idempotent) ───────────────────────────────────────────────
+function loadScript(src: string): Promise<void> {
+  if (document.querySelector(`script[src="${src}"]`)) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.head.appendChild(s);
+  });
+}
+
+function waitForCustomElement(tag: string, playerType: string, maxAttempts = 100): Promise<void> {
+  return loadScript(PLAYER_SCRIPTS[playerType] ?? '').then(
+    () =>
+      new Promise((resolve) => {
+        if (customElements.get(tag)) { resolve(); return; }
+        let attempts = 0;
+        const id = setInterval(() => {
+          attempts++;
+          if (customElements.get(tag) || attempts >= maxAttempts) {
+            clearInterval(id);
+            resolve();
+          }
+        }, 100);
+      }),
+  );
+}
+
+// ── Props ────────────────────────────────────────────────────────────────────
+interface ContentPlayerProps {
+  node: INode;
+  editorMode: EditorMode;
+  type: 'content' | 'quml';
+}
+
+// ── Metadata labels (mirrors label.config.json lbl section) ─────────────────
+const META_LABELS: Record<string, string> = {
+  name:         'Name',
+  author:       'Author',
+  license:      'License',
+  copyright:    'Copyright',
+  attributions: 'Attributions',
+  audience:     'Audience',
+  board:        'Board',
+  medium:       'Medium',
+  gradeLevel:   'Class',
+  subject:      'Subject',
+  topic:        'Topic',
+  contentType:  'Content Type',
+  language:     'Language',
+};
+
+// Fields shown below the player (same order as Angular's sessionContext)
+const META_FIELDS = [
+  'name', 'author', 'license', 'copyright',
+  'board', 'medium', 'gradeLevel', 'subject',
+  'topic', 'audience', 'attributions', 'contentType', 'language',
+];
+
+interface MetaField { key: string; label: string; value: string }
+
+function buildMetaFields(node: INode): MetaField[] {
+  const meta = (node.metadata ?? {}) as Record<string, unknown>;
+  const fields: MetaField[] = [];
+
+  for (const key of META_FIELDS) {
+    const raw = meta[key] ?? (node as unknown as Record<string, unknown>)[key];
+    if (raw === undefined || raw === null || raw === '') continue;
+    const value = Array.isArray(raw) ? raw.join(', ') : String(raw);
+    if (!value) continue;
+    fields.push({ key, label: META_LABELS[key] ?? key, value });
+  }
+  return fields;
+}
+
+// ── Content metadata strip (mirrors Angular's contentInfoArray grid) ──────────
+function ContentMetaInfo({ node }: { node: INode }) {
+  const fields = buildMetaFields(node);
+  if (!fields.length) return null;
+
+  // Column width cycle: wide → medium → narrow (mirrors Angular's 6/4/2 column pattern)
+  const colStyles = [styles.metaColWide, styles.metaColMed, styles.metaColNarrow];
+
+  return (
+    <div className={styles.metaGrid}>
+      {fields.map((f, i) => (
+        <div key={f.key} className={colStyles[i % colStyles.length]}>
+          <div className={styles.metaField}>
+            <span className={styles.metaLabel}>{f.label}</span>
+            <span className={styles.metaValue}>{f.value}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Root component ───────────────────────────────────────────────────────────
+export const ContentPlayer: React.FC<ContentPlayerProps> = ({ node, editorMode, type }) => {
+  if (type === 'quml') return <QumlPlayer node={node} editorMode={editorMode} />;
+  return (
+    <div className={styles.contentPlayerRoot}>
+      <SunbirdContentPlayer node={node} />
+      <ContentMetaInfo node={node} />
+    </div>
+  );
+};
+
+// ── Sunbird content player (mirrors ContentplayerPageComponent) ───────────────
+function SunbirdContentPlayer({ node }: { node: INode }) {
+  const editorConfig = useEditorStore((s) => s.editorConfig);
+  const [playerType, setPlayerType] = useState<string>(() => resolvePlayerType(node.mimeType ?? ''));
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const webComponentRef = useRef<HTMLDivElement>(null);
+
+  const playerConfig = buildPlayerConfig(node, { editorConfig } as any);
+
+  // ── When content changes, re-resolve player type ─────────────────────────
+  useEffect(() => {
+    setPlayerType(resolvePlayerType(node.mimeType ?? ''));
+  }, [node.identifier, node.mimeType]);
+
+  // ── Default player — iframe + initializePreview() ────────────────────────
+  useEffect(() => {
+    if (playerType !== 'default-player') return;
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    iframe.src = DEFAULT_PLAYER_URL;
+    iframe.onload = () => {
+      try {
+        (iframe.contentWindow as any)?.initializePreview(playerConfig);
+      } catch (err) {
+        console.error('initializePreview failed', err);
+      }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node.identifier, playerType]);
+
+  // ── Web component players (pdf / video / epub) ────────────────────────────
+  useEffect(() => {
+    if (playerType === 'default-player') return;
+    const container = webComponentRef.current;
+    if (!container) return;
+
+    const tag = PLAYER_TAGS[playerType];
+    if (!tag) return;
+
+    waitForCustomElement(tag, playerType).then(() => {
+      if (!webComponentRef.current) return; // unmounted
+
+      if (!customElements.get(tag)) {
+        // Web component script unavailable — fall back to default player
+        setPlayerType('default-player');
+        return;
+      }
+
+      const el = document.createElement(tag) as any;
+      el.setAttribute('player-config', JSON.stringify(playerConfig));
+      el.addEventListener('playerEvent', () => {});
+      el.addEventListener('telemetryEvent', () => {});
+
+      container.innerHTML = '';
+      container.appendChild(el);
+
+      // Give web component a tick to upgrade, then push config via property
+      setTimeout(() => {
+        try {
+          el.playerConfig = playerConfig;
+        } catch {
+          // some players only use the attribute
+        }
+      }, 200);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node.identifier, playerType]);
+
+  return (
+    <div className={styles.aspectRatio}>
+      {playerType === 'default-player' ? (
+        <iframe
+          ref={iframeRef}
+          id="contentPlayer"
+          title={node.name}
+          className={styles.playerFrame}
+          name="contentPlayer"
+          allowFullScreen
+        />
+      ) : (
+        <div ref={webComponentRef} className={styles.playerFrame} />
+      )}
+    </div>
+  );
+}
+
+// ── QuML player (web component) ───────────────────────────────────────────────
+function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode }) {
+  const editorConfig = useEditorStore((s) => s.editorConfig);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ctx = editorConfig?.context;
+    const qumlConfig = {
+      context: {
+        mode: editorMode === 'edit' ? 'edit' : 'play',
+        pdata: { id: ctx?.pdata?.id ?? 'sunbird.portal', ver: '1.0', pid: 'sunbird-portal' },
+        contentId: node.identifier,
+        sid: ctx?.sid ?? '',
+        uid: ctx?.uid ?? '',
+        channel: ctx?.channel ?? '',
+        did: ctx?.did ?? '',
+      },
+      config: {
+        enable: false,
+        showShare: false,
+        showDownload: false,
+        showReplay: true,
+        showExit: false,
+      },
+      metadata: node.metadata ?? {},
+      data: {},
+    };
+
+    const el = document.createElement('sunbird-quml-player') as any;
+    el.setAttribute('player-config', JSON.stringify(qumlConfig));
+    containerRef.current.innerHTML = '';
+    containerRef.current.appendChild(el);
+  }, [node.identifier, editorMode]);
+
+  return <div ref={containerRef} className={styles.playerWrapper} />;
+}

--- a/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
+++ b/projects/collection-editor-react/src/components/ContentPlayer/ContentPlayer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { INode, EditorMode } from '../../types/editor';
 import { useEditorStore } from '../../store/editor.store';
+import { fetchContentDetails } from '../../api/content';
 import styles from './ContentPlayer.module.scss';
 
 // ── MIME-type classification ──────────────────────────────────────────────────
@@ -48,13 +49,14 @@ function resolvePlayerType(mimeType: string): string {
 }
 
 // ── Player config builder ─────────────────────────────────────────────────────
+// fullMetadata: merged object — search-result fields overwritten by full content read
 function buildPlayerConfig(
   node: INode,
+  fullMetadata: Record<string, unknown>,
   editorConfig: ReturnType<typeof useEditorStore.getState>['editorConfig'],
 ) {
   const ctx = editorConfig?.context;
-  const metadata = (node.metadata ?? {}) as Record<string, unknown>;
-  const mimeType = node.mimeType ?? '';
+  const mimeType = (fullMetadata.mimeType as string) ?? node.mimeType ?? '';
 
   return {
     context: {
@@ -86,10 +88,12 @@ function buildPlayerConfig(
         { id: 'org.sunbird.player.endpage', ver: 1.1, type: 'plugin' },
       ],
       enableTelemetryValidation: false,
-      previewCdnUrl: undefined,
     },
-    metadata,
-    data: mimeType === 'application/vnd.ekstep.ecml-archive' ? (metadata.body ?? {}) : {},
+    // Full content data — includes artifactUrl, streamingUrl, body, etc.
+    metadata: fullMetadata,
+    data: mimeType === 'application/vnd.ekstep.ecml-archive'
+      ? (fullMetadata.body ?? {})
+      : {},
   };
 }
 
@@ -105,24 +109,28 @@ function loadScript(src: string): Promise<void> {
   });
 }
 
-function waitForCustomElement(tag: string, playerType: string, maxAttempts = 100): Promise<void> {
-  return loadScript(PLAYER_SCRIPTS[playerType] ?? '').then(
-    () => new Promise((resolve) => {
-      if (customElements.get(tag)) { resolve(); return; }
-      let attempts = 0;
-      const id = setInterval(() => {
-        attempts++;
-        if (customElements.get(tag) || attempts >= maxAttempts) { clearInterval(id); resolve(); }
-      }, 100);
-    }),
-  );
+async function waitForCustomElement(tag: string, playerType: string, maxAttempts = 100): Promise<void> {
+  await loadScript(PLAYER_SCRIPTS[playerType] ?? '');
+  if (customElements.get(tag)) return;
+  await new Promise<void>((resolve, reject) => {
+    let attempts = 0;
+    const id = setInterval(() => {
+      attempts++;
+      if (customElements.get(tag)) {
+        clearInterval(id);
+        resolve();
+      } else if (attempts >= maxAttempts) {
+        clearInterval(id);
+        reject(new Error(`Custom element <${tag}> did not register`));
+      }
+    }, 100);
+  });
 }
 
 // ── Info strip ────────────────────────────────────────────────────────────────
 const INFO_FIELDS: Array<{ key: string; label: string; icon: string }> = [
   { key: 'author',      label: 'Author',   icon: '👤' },
   { key: 'license',     label: 'License',  icon: '⚖️'  },
-  { key: 'copyright',   label: '©',        icon: ''   },
   { key: 'language',    label: 'Language', icon: '🌐'  },
   { key: 'gradeLevel',  label: 'Class',    icon: '🏫'  },
   { key: 'subject',     label: 'Subject',  icon: '📚'  },
@@ -153,7 +161,7 @@ function InfoStrip({ node }: { node: INode }) {
   );
 }
 
-// ── Cover overlay (shown while player initialises) ────────────────────────────
+// ── Cover overlay ─────────────────────────────────────────────────────────────
 function CoverOverlay({ node, hidden }: { node: INode; hidden: boolean }) {
   const thumb = node.appIcon ?? (node.metadata?.appIcon as string | undefined);
   return (
@@ -169,6 +177,16 @@ function CoverOverlay({ node, hidden }: { node: INode; hidden: boolean }) {
       ) : (
         <div className={styles.coverSkeleton} />
       )}
+    </div>
+  );
+}
+
+// ── Player error overlay ──────────────────────────────────────────────────────
+function PlayerError({ message }: { message: string }) {
+  return (
+    <div className={styles.playerError}>
+      <span className={styles.playerErrorIcon}>⚠</span>
+      <span className={styles.playerErrorMsg}>{message}</span>
     </div>
   );
 }
@@ -199,22 +217,14 @@ export const ContentPlayer: React.FC<ContentPlayerProps> = ({ node, editorMode, 
 
   return (
     <div className={styles.contentPlayerRoot}>
-      {/* Dark cinema stage */}
       <div className={styles.stage}>
-        {/* Header gradient bar */}
         <div className={styles.playerHeader}>
-          {thumb && (
-            <img src={thumb} alt="" className={styles.playerHeaderThumb} />
-          )}
+          {thumb && <img src={thumb} alt="" className={styles.playerHeaderThumb} />}
           <span className={styles.playerHeaderTitle}>{node.name}</span>
           <TypeBadge mimeType={node.mimeType ?? ''} />
         </div>
-
-        {/* Actual player */}
         <SunbirdContentPlayer node={node} />
       </div>
-
-      {/* Compact info strip below the stage */}
       <InfoStrip node={node} />
     </div>
   );
@@ -225,62 +235,129 @@ function SunbirdContentPlayer({ node }: { node: INode }) {
   const editorConfig = useEditorStore((s) => s.editorConfig);
   const [playerType, setPlayerType] = useState(() => resolvePlayerType(node.mimeType ?? ''));
   const [coverHidden, setCoverHidden] = useState(false);
+  const [playerError, setPlayerError] = useState<string | null>(null);
+  const [fullMetadata, setFullMetadata] = useState<Record<string, unknown>>(
+    (node.metadata ?? {}) as Record<string, unknown>,
+  );
+  // Gate: don't start the player until the full content fetch has resolved,
+  // so playerConfig.metadata always contains artifactUrl when initializePreview is called.
+  const [contentReady, setContentReady] = useState(false);
+
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const webComponentRef = useRef<HTMLDivElement>(null);
 
-  const playerConfig = buildPlayerConfig(node, { editorConfig } as any);
+  const previewUrl = editorConfig?.config?.previewCdnUrl ?? DEFAULT_PLAYER_URL;
 
+  // Fetch full content details — provides artifactUrl, streamingUrl, body, etc.
   useEffect(() => {
+    let cancelled = false;
+    setContentReady(false);
     setCoverHidden(false);
+    setPlayerError(null);
+    setFullMetadata((node.metadata ?? {}) as Record<string, unknown>);
     setPlayerType(resolvePlayerType(node.mimeType ?? ''));
-  }, [node.identifier, node.mimeType]);
 
-  // Default player — iframe
+    fetchContentDetails(node.identifier)
+      .then((content) => {
+        if (cancelled) return;
+        const merged = { ...(node.metadata ?? {}), ...content } as Record<string, unknown>;
+        setFullMetadata(merged);
+        const mime = (content.mimeType as string) ?? node.mimeType ?? '';
+        setPlayerType(resolvePlayerType(mime));
+        setContentReady(true);
+      })
+      .catch(() => {
+        // Proceed with whatever sparse metadata we have
+        if (!cancelled) setContentReady(true);
+      });
+
+    return () => { cancelled = true; };
+  }, [node.identifier]);
+
+  // Build playerConfig after fullMetadata is populated — this runs on every render
+  // so by the time contentReady=true the config already has artifactUrl
+  const playerConfig = buildPlayerConfig(node, fullMetadata, editorConfig);
+
+  // Default player — iframe. Only runs after contentReady so playerConfig has full metadata.
   useEffect(() => {
-    if (playerType !== 'default-player') return;
+    if (!contentReady || playerType !== 'default-player') return;
     const iframe = iframeRef.current;
     if (!iframe) return;
-    iframe.src = DEFAULT_PLAYER_URL;
-    iframe.onload = () => {
+
+    iframe.src = previewUrl;
+
+    const handleLoad = () => {
       try {
-        (iframe.contentWindow as any)?.initializePreview(playerConfig);
+        const win = iframe.contentWindow as Record<string, unknown> | null;
+        if (typeof win?.['initializePreview'] !== 'function') {
+          setPlayerError('Preview player unavailable. Check that /content/preview is reachable.');
+          return;
+        }
+        // playerConfig is captured here — contentReady gate ensures fullMetadata is set
+        (win['initializePreview'] as (cfg: unknown) => void)(playerConfig);
+        setTimeout(() => setCoverHidden(true), 300);
       } catch (err) {
-        console.error('initializePreview failed', err);
+        console.error('[ContentPlayer] initializePreview failed', err);
+        setPlayerError('Failed to initialize the content player.');
       }
-      setTimeout(() => setCoverHidden(true), 300);
+    };
+
+    const handleError = () => setPlayerError('Preview player could not be loaded.');
+
+    iframe.addEventListener('load', handleLoad);
+    iframe.addEventListener('error', handleError);
+    return () => {
+      iframe.removeEventListener('load', handleLoad);
+      iframe.removeEventListener('error', handleError);
+      iframe.src = '';
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [node.identifier, playerType]);
+  }, [node.identifier, playerType, previewUrl, contentReady]);
 
   // Web-component players (pdf / video / epub)
   useEffect(() => {
-    if (playerType === 'default-player') return;
+    if (!contentReady || playerType === 'default-player') return;
     const container = webComponentRef.current;
     if (!container) return;
     const tag = PLAYER_TAGS[playerType];
     if (!tag) return;
 
-    waitForCustomElement(tag, playerType).then(() => {
-      if (!webComponentRef.current) return;
-      if (!customElements.get(tag)) { setPlayerType('default-player'); return; }
+    // Snapshot playerConfig at effect-run time — contentReady gate ensures fullMetadata is set
+    const config = playerConfig;
 
-      const el = document.createElement(tag) as any;
-      el.setAttribute('player-config', JSON.stringify(playerConfig));
-      el.addEventListener('playerEvent', () => {});
-      el.addEventListener('telemetryEvent', () => {});
-      container.innerHTML = '';
-      container.appendChild(el);
-      setTimeout(() => {
-        try { el.playerConfig = playerConfig; } catch { /* attribute-only player */ }
-        setCoverHidden(true);
-      }, 200);
-    });
+    waitForCustomElement(tag, playerType)
+      .then(() => {
+        if (!webComponentRef.current) return;
+        if (!customElements.get(tag)) {
+          setPlayerType('default-player');
+          return;
+        }
+        const el = document.createElement(tag) as HTMLElement & Record<string, unknown>;
+        el.setAttribute('player-config', JSON.stringify(config));
+        el.addEventListener('playerEvent', () => {});
+        el.addEventListener('telemetryEvent', () => {});
+        container.innerHTML = '';
+        container.appendChild(el);
+        setTimeout(() => {
+          try { el['playerConfig'] = config; } catch { /* attribute-only */ }
+          setCoverHidden(true);
+        }, 200);
+      })
+      .catch(() => {
+        console.warn(`[ContentPlayer] ${playerType} script unavailable, falling back to iframe`);
+        setPlayerType('default-player');
+      });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [node.identifier, playerType]);
+  }, [node.identifier, playerType, contentReady]);
 
   return (
     <div className={styles.aspectRatio}>
-      <CoverOverlay node={node} hidden={coverHidden} />
+      {playerError ? (
+        <PlayerError message={playerError} />
+      ) : (
+        <CoverOverlay node={node} hidden={coverHidden} />
+      )}
+
       {playerType === 'default-player' ? (
         <iframe
           ref={iframeRef}
@@ -320,7 +397,7 @@ function QumlPlayer({ node, editorMode }: { node: INode; editorMode: EditorMode 
       data: {},
     };
 
-    const el = document.createElement('sunbird-quml-player') as any;
+    const el = document.createElement('sunbird-quml-player') as HTMLElement & Record<string, unknown>;
     el.setAttribute('player-config', JSON.stringify(qumlConfig));
     containerRef.current.innerHTML = '';
     containerRef.current.appendChild(el);

--- a/projects/collection-editor-react/src/components/ContentPlayer/index.ts
+++ b/projects/collection-editor-react/src/components/ContentPlayer/index.ts
@@ -1,0 +1,1 @@
+export { ContentPlayer } from './ContentPlayer';

--- a/projects/collection-editor-react/src/components/ContextualEditor/Breadcrumb.module.scss
+++ b/projects/collection-editor-react/src/components/ContextualEditor/Breadcrumb.module.scss
@@ -1,0 +1,17 @@
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 0 8px;
+  font-size: 12px;
+  color: var(--sbx-gray-500);
+}
+.crumb {
+  background: none; border: none; cursor: pointer;
+  color: var(--sbx-gray-500); font-size: 12px; padding: 2px 4px;
+  border-radius: var(--sbx-r-xs);
+  display: flex; align-items: center;
+  &:hover { color: var(--sbx-primary); background: var(--sbx-primary-light); }
+}
+.sep { color: var(--sbx-gray-300); flex-shrink: 0; }
+.current { color: var(--sbx-gray-700); font-weight: 500; }

--- a/projects/collection-editor-react/src/components/ContextualEditor/Breadcrumb.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/Breadcrumb.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ChevronRight, Home } from 'lucide-react';
+import { useTreeStore } from '../../store/tree.store';
+import styles from './Breadcrumb.module.scss';
+
+interface BreadcrumbProps {
+  crumbs: Array<{ id: string; name: string }>;
+}
+
+export const Breadcrumb: React.FC<BreadcrumbProps> = ({ crumbs }) => {
+  const selectNode = useTreeStore(s => s.selectNode);
+  if (!crumbs.length) return null;
+
+  return (
+    <nav className={styles.breadcrumb} aria-label="Node path">
+      <button className={styles.crumb} onClick={() => selectNode(crumbs[0].id)} aria-label="Home">
+        <Home size={13} />
+      </button>
+      {crumbs.map((crumb, i) => (
+        <React.Fragment key={crumb.id}>
+          <ChevronRight size={13} className={styles.sep} />
+          {i < crumbs.length - 1 ? (
+            <button className={styles.crumb} onClick={() => selectNode(crumb.id)}>
+              {crumb.name}
+            </button>
+          ) : (
+            <span className={styles.current}>{crumb.name}</span>
+          )}
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+};

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContentEditForm.module.scss
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContentEditForm.module.scss
@@ -1,0 +1,220 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-top: 1px solid var(--sbx-gray-200);
+  background: white;
+  flex-shrink: 0;
+}
+
+// Always-visible top bar with content-type badge + move btn + collapse toggle
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--sbx-gray-100);
+  gap: 8px;
+}
+
+.panelHeaderLeft {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.panelCollapseBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--sbx-gray-400);
+  border-radius: var(--sbx-r-sm);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  &:hover { background: var(--sbx-gray-100); color: var(--sbx-gray-700); }
+}
+
+// panel body fields share padding
+.titleRow,
+.field {
+  padding: 0 16px;
+}
+
+.container > .titleRow { padding-top: 16px; }
+.container > .field:last-of-type { padding-bottom: 16px; }
+.container > * + .titleRow,
+.container > * + .field { margin-top: 16px; }
+
+.moveBtn {
+  font-size: 12px;
+  padding: 4px 12px;
+  border: 1px solid var(--sbx-gray-300);
+  border-radius: var(--sbx-r-sm);
+  background: white;
+  cursor: pointer;
+  color: var(--sbx-gray-600);
+  &:hover { border-color: var(--sbx-primary); color: var(--sbx-primary); }
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--sbx-r-sm);
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid var(--sbx-gray-200);
+}
+
+.nameInput {
+  flex: 1;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--sbx-gray-900);
+  border: none;
+  border-bottom: 2px solid var(--sbx-gray-200);
+  padding: 4px 0;
+  background: transparent;
+  outline: none;
+  &:focus { border-bottom-color: var(--sbx-primary); }
+  &:disabled { color: var(--sbx-gray-700); cursor: default; }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fieldHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sbx-gray-700);
+}
+
+.fieldCount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--sbx-primary-light, #EFF6FF);
+  color: var(--sbx-primary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.collapseBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--sbx-gray-500);
+  border-radius: var(--sbx-r-sm);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  &:hover { background: var(--sbx-gray-100); color: var(--sbx-gray-700); }
+}
+
+.chevronUp {
+  transform: rotate(180deg);
+  transition: transform 0.2s;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: var(--sbx-r-xl);
+  background: var(--sbx-primary-light, #EFF6FF);
+  color: var(--sbx-primary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.chipRemove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  line-height: 1;
+  font-size: 14px;
+  opacity: 0.7;
+  &:hover { opacity: 1; }
+}
+
+.keywordInput {
+  display: flex;
+  gap: 8px;
+}
+
+.input {
+  flex: 1;
+  height: 36px;
+  padding: 0 10px;
+  border: 1.5px solid var(--sbx-gray-300);
+  border-radius: var(--sbx-r-sm);
+  font-size: 13px;
+  outline: none;
+  &:focus { border-color: var(--sbx-primary); }
+}
+
+.addBtn {
+  height: 36px;
+  padding: 0 16px;
+  border: 1.5px solid var(--sbx-gray-300);
+  border-radius: var(--sbx-r-sm);
+  background: white;
+  font-size: 13px;
+  cursor: pointer;
+  &:hover { border-color: var(--sbx-primary); color: var(--sbx-primary); }
+}
+
+.radioGroup {
+  display: flex;
+  gap: 20px;
+}
+
+.radioLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--sbx-gray-700);
+  cursor: pointer;
+  input { cursor: pointer; accent-color: var(--sbx-primary); }
+}

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContentEditForm.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContentEditForm.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import type { INode, EditorMode } from '../../types/editor';
 import { useTreeStore } from '../../store/tree.store';
+import { useEditorStore } from '../../store/editor.store';
 import { getCtStyle } from '../../hooks/useContentType';
 import styles from './ContentEditForm.module.scss';
 
@@ -19,29 +20,46 @@ export const ContentEditForm: React.FC<ContentEditFormProps> = ({
   const isEditable = editorMode === 'edit';
   const ctStyle = getCtStyle(node);
 
+  // The leaf-in-collection metadata form is defined by forms.relationalMetadata.
+  // Use it to drive field labels / visibility, falling back to defaults.
+  const relationalForm = useEditorStore((s) => s.relationalFormConfig);
+  const fieldOf = (code: string) => relationalForm?.find((f) => f.code === code);
+  const showField = (code: string) => !relationalForm || !!fieldOf(code);
+  const labelOf = (code: string, fallback: string) => fieldOf(code)?.label || fallback;
+
   // Panel-level collapse (entire metadata section)
   const [panelOpen, setPanelOpen] = useState(true);
-  // Keywords section collapse (within the panel)
-  const [kwOpen, setKwOpen] = useState(false);
 
-  const [name, setName] = useState(node.name ?? '');
+  // relationalMetadata holds the collection-specific overrides for this resource.
+  // The hierarchy/update API stores name/keywords/optional there (on the parent unit),
+  // NOT in nodesModified for the leaf content itself.
+  const relMeta = (node.metadata?.relationalMetadata ?? {}) as Record<string, unknown>;
+
+  const [name, setName] = useState(
+    (relMeta.name as string) ?? node.name ?? '',
+  );
   const [keywordsInput, setKeywordsInput] = useState('');
   const [keywords, setKeywords] = useState<string[]>(
-    Array.isArray(node.metadata?.keywords) ? node.metadata.keywords as string[] : [],
+    Array.isArray(relMeta.keywords) ? relMeta.keywords as string[]
+      : Array.isArray(node.metadata?.keywords) ? node.metadata.keywords as string[]
+      : [],
   );
-  const [trackable, setTrackable] = useState<boolean>(
-    !!(node.metadata?.trackable === 'Yes' || node.metadata?.trackable === true
-      || (node.metadata?.trackable as Record<string, unknown>)?.enabled === 'Yes'),
+  // `optional: true`  = content is optional in this collection (tracking not required)
+  // `optional: false` = content is required  (must be completed / tracked)
+  const [optional, setOptional] = useState<boolean>(
+    !!(relMeta.optional),
   );
 
   // Reset when node changes
   useEffect(() => {
-    setName(node.name ?? '');
-    setKeywords(Array.isArray(node.metadata?.keywords) ? node.metadata.keywords as string[] : []);
-    setTrackable(
-      !!(node.metadata?.trackable === 'Yes' || node.metadata?.trackable === true
-        || (node.metadata?.trackable as Record<string, unknown>)?.enabled === 'Yes'),
+    const rm = (node.metadata?.relationalMetadata ?? {}) as Record<string, unknown>;
+    setName((rm.name as string) ?? node.name ?? '');
+    setKeywords(
+      Array.isArray(rm.keywords) ? rm.keywords as string[]
+        : Array.isArray(node.metadata?.keywords) ? node.metadata.keywords as string[]
+        : [],
     );
+    setOptional(!!(rm.optional));
   }, [node.id]);
 
   const handleNameBlur = () => {
@@ -69,9 +87,9 @@ export const ContentEditForm: React.FC<ContentEditFormProps> = ({
     markDirty();
   };
 
-  const handleTrackChange = (val: boolean) => {
-    setTrackable(val);
-    updateNode(node.id, { trackable: { enabled: val ? 'Yes' : 'No', autoBatch: 'No' } });
+  const handleOptionalChange = (val: boolean) => {
+    setOptional(val);
+    updateNode(node.id, { optional: val });
     markDirty();
   };
 
@@ -118,66 +136,56 @@ export const ContentEditForm: React.FC<ContentEditFormProps> = ({
             />
           </div>
 
-          {/* Keywords — collapsible within the panel */}
+          {/* Keywords — the panel-level collapse already covers this section */}
+          {showField('keywords') && (
           <div className={styles.field}>
             <div className={styles.fieldHeader}>
               <label className={styles.label}>
-                Keywords
+                {labelOf('keywords', 'Keywords')}
                 {keywords.length > 0 && (
                   <span className={styles.fieldCount}>{keywords.length}</span>
                 )}
               </label>
-              <button
-                type="button"
-                className={styles.collapseBtn}
-                onClick={() => setKwOpen(v => !v)}
-                aria-expanded={kwOpen}
-                aria-label={kwOpen ? 'Collapse keywords' : 'Expand keywords'}
-              >
-                <ChevronDown size={14} className={kwOpen ? styles.chevronUp : ''} />
-              </button>
             </div>
-            {kwOpen && (
-              <>
-                {keywords.length > 0 && (
-                  <div className={styles.chips}>
-                    {keywords.map(kw => (
-                      <span key={kw} className={styles.chip}>
-                        {kw}
-                        {isEditable && (
-                          <button type="button" className={styles.chipRemove} onClick={() => removeKeyword(kw)}>×</button>
-                        )}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                {isEditable && (
-                  <div className={styles.keywordInput}>
-                    <input
-                      type="text"
-                      className={styles.input}
-                      value={keywordsInput}
-                      placeholder="Add keyword and press Enter"
-                      onChange={e => setKeywordsInput(e.target.value)}
-                      onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addKeyword(); } }}
-                    />
-                    <button type="button" className={styles.addBtn} onClick={addKeyword}>Add</button>
-                  </div>
-                )}
-              </>
+            {keywords.length > 0 && (
+              <div className={styles.chips}>
+                {keywords.map(kw => (
+                  <span key={kw} className={styles.chip}>
+                    {kw}
+                    {isEditable && (
+                      <button type="button" className={styles.chipRemove} onClick={() => removeKeyword(kw)}>×</button>
+                    )}
+                  </span>
+                ))}
+              </div>
+            )}
+            {isEditable && (
+              <div className={styles.keywordInput}>
+                <input
+                  type="text"
+                  className={styles.input}
+                  value={keywordsInput}
+                  placeholder="Add keyword and press Enter"
+                  onChange={e => setKeywordsInput(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addKeyword(); } }}
+                />
+                <button type="button" className={styles.addBtn} onClick={addKeyword}>Add</button>
+              </div>
             )}
           </div>
+          )}
 
-          {/* Track in Collections */}
+          {/* Optional in collection (optional: true = not required, optional: false = required) */}
+          {showField('optional') && (
           <div className={styles.field}>
-            <label className={styles.label}>Track in Collections</label>
+            <label className={styles.label}>{labelOf('optional', 'Optional in Collection')}</label>
             <div className={styles.radioGroup}>
               <label className={styles.radioLabel}>
                 <input
                   type="radio"
-                  name={`trackable-${node.id}`}
-                  checked={trackable === true}
-                  onChange={() => handleTrackChange(true)}
+                  name={`optional-${node.id}`}
+                  checked={optional === true}
+                  onChange={() => handleOptionalChange(true)}
                   disabled={!isEditable}
                 />
                 Yes
@@ -185,15 +193,16 @@ export const ContentEditForm: React.FC<ContentEditFormProps> = ({
               <label className={styles.radioLabel}>
                 <input
                   type="radio"
-                  name={`trackable-${node.id}`}
-                  checked={trackable === false}
-                  onChange={() => handleTrackChange(false)}
+                  name={`optional-${node.id}`}
+                  checked={optional === false}
+                  onChange={() => handleOptionalChange(false)}
                   disabled={!isEditable}
                 />
                 No
               </label>
             </div>
           </div>
+          )}
         </>
       )}
 

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContentEditForm.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContentEditForm.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useEffect } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import type { INode, EditorMode } from '../../types/editor';
+import { useTreeStore } from '../../store/tree.store';
+import { getCtStyle } from '../../hooks/useContentType';
+import styles from './ContentEditForm.module.scss';
+
+interface ContentEditFormProps {
+  node: INode;
+  editorMode: EditorMode;
+  onMoveClick: () => void;
+  reorderDialog?: React.ReactNode;
+}
+
+export const ContentEditForm: React.FC<ContentEditFormProps> = ({
+  node, editorMode, onMoveClick, reorderDialog,
+}) => {
+  const { updateNode, markDirty } = useTreeStore();
+  const isEditable = editorMode === 'edit';
+  const ctStyle = getCtStyle(node);
+
+  // Panel-level collapse (entire metadata section)
+  const [panelOpen, setPanelOpen] = useState(true);
+  // Keywords section collapse (within the panel)
+  const [kwOpen, setKwOpen] = useState(false);
+
+  const [name, setName] = useState(node.name ?? '');
+  const [keywordsInput, setKeywordsInput] = useState('');
+  const [keywords, setKeywords] = useState<string[]>(
+    Array.isArray(node.metadata?.keywords) ? node.metadata.keywords as string[] : [],
+  );
+  const [trackable, setTrackable] = useState<boolean>(
+    !!(node.metadata?.trackable === 'Yes' || node.metadata?.trackable === true
+      || (node.metadata?.trackable as Record<string, unknown>)?.enabled === 'Yes'),
+  );
+
+  // Reset when node changes
+  useEffect(() => {
+    setName(node.name ?? '');
+    setKeywords(Array.isArray(node.metadata?.keywords) ? node.metadata.keywords as string[] : []);
+    setTrackable(
+      !!(node.metadata?.trackable === 'Yes' || node.metadata?.trackable === true
+        || (node.metadata?.trackable as Record<string, unknown>)?.enabled === 'Yes'),
+    );
+  }, [node.id]);
+
+  const handleNameBlur = () => {
+    if (name.trim() && name !== node.name) {
+      updateNode(node.id, { name: name.trim() });
+      markDirty();
+    }
+  };
+
+  const addKeyword = () => {
+    const kw = keywordsInput.trim();
+    if (kw && !keywords.includes(kw)) {
+      const next = [...keywords, kw];
+      setKeywords(next);
+      updateNode(node.id, { keywords: next });
+      markDirty();
+    }
+    setKeywordsInput('');
+  };
+
+  const removeKeyword = (kw: string) => {
+    const next = keywords.filter(k => k !== kw);
+    setKeywords(next);
+    updateNode(node.id, { keywords: next });
+    markDirty();
+  };
+
+  const handleTrackChange = (val: boolean) => {
+    setTrackable(val);
+    updateNode(node.id, { trackable: { enabled: val ? 'Yes' : 'No', autoBatch: 'No' } });
+    markDirty();
+  };
+
+  return (
+    <div className={styles.container}>
+      {/* Panel header — always visible, contains collapse toggle */}
+      <div className={styles.panelHeader}>
+        <div className={styles.panelHeaderLeft}>
+          <span className={`sbx-ct-badge--${ctStyle.key}`}>{ctStyle.label}</span>
+          {isEditable && (
+            <button type="button" className={styles.moveBtn} onClick={onMoveClick}>
+              Move to another unit
+            </button>
+          )}
+        </div>
+        <button
+          type="button"
+          className={styles.panelCollapseBtn}
+          onClick={() => setPanelOpen(v => !v)}
+          aria-expanded={panelOpen}
+          aria-label={panelOpen ? 'Collapse metadata panel' : 'Expand metadata panel'}
+          title={panelOpen ? 'Collapse' : 'Expand'}
+        >
+          {panelOpen ? <ChevronDown size={15} /> : <ChevronUp size={15} />}
+        </button>
+      </div>
+
+      {/* Panel body — collapses entirely */}
+      {panelOpen && (
+        <>
+          {/* App icon + name */}
+          <div className={styles.titleRow}>
+            {node.appIcon && (
+              <img src={node.appIcon} alt="icon" className={styles.icon} />
+            )}
+            <input
+              type="text"
+              className={styles.nameInput}
+              value={name}
+              disabled={!isEditable}
+              onChange={e => setName(e.target.value)}
+              onBlur={handleNameBlur}
+              placeholder="Content name"
+            />
+          </div>
+
+          {/* Keywords — collapsible within the panel */}
+          <div className={styles.field}>
+            <div className={styles.fieldHeader}>
+              <label className={styles.label}>
+                Keywords
+                {keywords.length > 0 && (
+                  <span className={styles.fieldCount}>{keywords.length}</span>
+                )}
+              </label>
+              <button
+                type="button"
+                className={styles.collapseBtn}
+                onClick={() => setKwOpen(v => !v)}
+                aria-expanded={kwOpen}
+                aria-label={kwOpen ? 'Collapse keywords' : 'Expand keywords'}
+              >
+                <ChevronDown size={14} className={kwOpen ? styles.chevronUp : ''} />
+              </button>
+            </div>
+            {kwOpen && (
+              <>
+                {keywords.length > 0 && (
+                  <div className={styles.chips}>
+                    {keywords.map(kw => (
+                      <span key={kw} className={styles.chip}>
+                        {kw}
+                        {isEditable && (
+                          <button type="button" className={styles.chipRemove} onClick={() => removeKeyword(kw)}>×</button>
+                        )}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {isEditable && (
+                  <div className={styles.keywordInput}>
+                    <input
+                      type="text"
+                      className={styles.input}
+                      value={keywordsInput}
+                      placeholder="Add keyword and press Enter"
+                      onChange={e => setKeywordsInput(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addKeyword(); } }}
+                    />
+                    <button type="button" className={styles.addBtn} onClick={addKeyword}>Add</button>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Track in Collections */}
+          <div className={styles.field}>
+            <label className={styles.label}>Track in Collections</label>
+            <div className={styles.radioGroup}>
+              <label className={styles.radioLabel}>
+                <input
+                  type="radio"
+                  name={`trackable-${node.id}`}
+                  checked={trackable === true}
+                  onChange={() => handleTrackChange(true)}
+                  disabled={!isEditable}
+                />
+                Yes
+              </label>
+              <label className={styles.radioLabel}>
+                <input
+                  type="radio"
+                  name={`trackable-${node.id}`}
+                  checked={trackable === false}
+                  onChange={() => handleTrackChange(false)}
+                  disabled={!isEditable}
+                />
+                No
+              </label>
+            </div>
+          </div>
+        </>
+      )}
+
+      {reorderDialog}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.module.scss
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.module.scss
@@ -65,8 +65,8 @@
   display: flex;
   gap: 8px;
   align-items: flex-start;
-  background: #fffbe6;
-  border: 1px solid #ffe58f;
+  background: var(--sbx-warn-bg);
+  border: 1px solid var(--sbx-warn-border);
   border-radius: var(--sbx-r-sm, 4px);
   padding: 10px 14px;
   margin-bottom: 12px;
@@ -75,10 +75,10 @@
 }
 .reviewCommentLabel {
   font-weight: 600;
-  color: #ad6800;
+  color: var(--sbx-warn-text);
   white-space: nowrap;
 }
-.reviewCommentText { color: #595959; }
+.reviewCommentText { color: var(--sbx-warn-body); }
 
 // Dialcode section
 .dialcodeSection {

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.module.scss
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.module.scss
@@ -1,0 +1,119 @@
+// Leaf content: player grows to fill space, edit form sticks to bottom
+.leafContentLayout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  // ContentPlayer gets flex:1, ContentEditForm is flex-shrink:0
+}
+
+.container {
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 100%;
+  position: relative;
+}
+.emptyState {
+  display: flex; align-items: center; justify-content: center;
+  height: 100%; color: var(--sbx-gray-400); font-size: 14px; font-style: italic;
+}
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0 16px;
+}
+.titleIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--sbx-r-sm);
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid var(--sbx-gray-200);
+}
+.nodeTitle {
+  font-size: 22px; font-weight: 700; color: var(--sbx-gray-900);
+  margin: 0;
+  outline: none;
+  border-radius: var(--sbx-r-sm);
+  padding: 2px 4px;
+  min-height: 1.3em;
+  &:focus { background: var(--sbx-gray-50); box-shadow: 0 0 0 2px var(--sbx-primary); }
+  &:empty::before { content: attr(data-placeholder); color: var(--sbx-gray-400); }
+  &[contenteditable="false"] { cursor: default; }
+}
+.formArea { margin-bottom: 24px; }
+.contentListArea { border-top: 1px solid var(--sbx-gray-200); padding-top: 20px; }
+.dropZone { position: absolute; inset: 0; z-index: 5; border-radius: 0; }
+
+// Review comment banner
+.reviewComment {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  background: #fffbe6;
+  border: 1px solid #ffe58f;
+  border-radius: var(--sbx-r-sm, 4px);
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.reviewCommentLabel {
+  font-weight: 600;
+  color: #ad6800;
+  white-space: nowrap;
+}
+.reviewCommentText { color: #595959; }
+
+// Dialcode section
+.dialcodeSection {
+  border-top: 1px solid var(--sbx-gray-200, #e8e8e8);
+  padding-top: 16px;
+  margin-top: 8px;
+  margin-bottom: 16px;
+}
+.sectionTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sbx-gray-600, #555);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  margin-bottom: 10px;
+}
+
+// Content toolbar (leaf nodes)
+.contentToolbar {
+  display: flex;
+  gap: 8px;
+  padding: 8px 24px;
+  border-bottom: 1px solid var(--sbx-gray-200, #e8e8e8);
+  background: var(--sbx-gray-50, #fafafa);
+}
+.moveBtn {
+  padding: 4px 12px;
+  font-size: 12px;
+  border: 1px solid var(--sbx-gray-300, #d9d9d9);
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  &:hover { border-color: var(--sbx-primary, #1890ff); color: var(--sbx-primary, #1890ff); }
+}
+
+// Assign page row
+.assignPageRow {
+  border-top: 1px solid var(--sbx-gray-200, #e8e8e8);
+  padding-top: 12px;
+  margin-top: 8px;
+}
+.assignPageBtn {
+  font-size: 13px;
+  padding: 6px 14px;
+  border: 1px solid var(--sbx-gray-300, #d9d9d9);
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  &:hover { border-color: var(--sbx-primary, #1890ff); color: var(--sbx-primary, #1890ff); }
+}

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.module.scss
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.module.scss
@@ -1,10 +1,22 @@
-// Leaf content: player grows to fill space, edit form sticks to bottom
+// Leaf content: player on top, metadata/edit panel scrolls below.
 .leafContentLayout {
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  // ContentPlayer gets flex:1, ContentEditForm is flex-shrink:0
+
+  // ContentPlayer fills remaining vertical space
+  > *:first-child {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  // ContentEditForm is natural height, scrollable
+  > *:last-child {
+    flex: 0 0 auto;
+    overflow-y: auto;
+    background: #fff;
+  }
 }
 
 .container {

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -68,8 +68,8 @@ export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, 
 
   const handleFormStatusChange = useCallback((isValid: boolean, invalidTabs: TabId[]) => {
     setErrorTabs(invalidTabs);
-    onToolbarEvent({ action: 'onFormStatusChange', data: { isValid } });
-  }, [onToolbarEvent]);
+    onToolbarEvent({ action: 'onFormStatusChange', data: { isValid, nodeId: selectedNodeId } });
+  }, [onToolbarEvent, selectedNodeId]);
 
   if (!selectedNode) {
     return (

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -14,7 +14,9 @@ import { ContentEditForm } from './ContentEditForm';
 import { TitleAppIcon } from './TitleAppIcon';
 import styles from './ContextualEditor.module.scss';
 
-const QUML_TYPES = ['application/vnd.sunbird.questionset'];
+const QUESTIONSET_MIME = 'application/vnd.sunbird.questionset';
+const QUESTION_MIME = 'application/vnd.sunbird.question';
+const QUML_TYPES = [QUESTIONSET_MIME, QUESTION_MIME];
 
 interface ContextualEditorProps {
   editorMode: EditorMode;
@@ -46,6 +48,7 @@ export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, 
   const isCurrentNodeFolder = !!selectedNode?.isFolder;
 
   const isQuml = selectedNode && QUML_TYPES.includes(selectedNode.mimeType ?? '');
+  const isSingleQuestion = selectedNode?.mimeType === QUESTION_MIME;
   const isLeafContent = selectedNode && !selectedNode.isFolder && !isQuml && !isCurrentNodeRoot;
 
   // Review comment from previous rejection cycle
@@ -80,7 +83,14 @@ export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, 
   }
 
   if (isQuml) {
-    return <ContentPlayer node={selectedNode} editorMode={editorMode} type="quml" />;
+    return (
+      <ContentPlayer
+        node={selectedNode}
+        editorMode={editorMode}
+        type="quml"
+        singleQuestion={isSingleQuestion}
+      />
+    );
   }
 
   if (isLeafContent) {

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -31,12 +31,18 @@ export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, 
   const titleTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   const { selectedNodeId, breadcrumb, activeNodeMeta, updateNode, treeData } = useTreeStore();
-  const { isCurrentNodeFolder, isCurrentNodeRoot } = useEditorStore();
   const contentId = useEditorStore(
     s => s.editorConfig?.context?.contentId ?? s.editorConfig?.context?.identifier ?? '',
   );
 
   const selectedNode = selectedNodeId ? findNodeById(treeData, selectedNodeId) : null;
+
+  // Derive node flags synchronously from the resolved node. The editor-store
+  // flags (isCurrentNodeRoot/isCurrentNodeFolder) are set asynchronously in
+  // selectNode and lag a render behind, which made the form mount with the
+  // wrong field set on root→unit→root and lose its pre-selected dropdowns.
+  const isCurrentNodeRoot = !!selectedNode && !selectedNode.parent;
+  const isCurrentNodeFolder = !!selectedNode?.isFolder;
 
   const isQuml = selectedNode && QUML_TYPES.includes(selectedNode.mimeType ?? '');
   const isLeafContent = selectedNode && !selectedNode.isFolder && !isQuml && !isCurrentNodeRoot;
@@ -143,7 +149,7 @@ export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, 
       {/* Form */}
       <div className={styles.formArea}>
         <SparkMetaForm
-          key={selectedNodeId ?? 'none'}
+          key={`${selectedNodeId ?? 'none'}:${isCurrentNodeRoot ? 'root' : 'node'}`}
           nodeMetadata={activeNodeMeta}
           activeTab={activeTab}
           isRoot={isCurrentNodeRoot}

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -1,0 +1,192 @@
+import React, { useState, useCallback, useRef } from 'react';
+import type { EditorMode, ToolbarAction } from '../../types/editor';
+import { useTreeStore } from '../../store/tree.store';
+import { useEditorStore } from '../../store/editor.store';
+import { Breadcrumb } from './Breadcrumb';
+import { TabBar } from './TabBar';
+import { SparkMetaForm } from '../SparkMetaForm';
+import { UnitContentList } from '../UnitContentList';
+import { DropZone } from '../shared/DropZone';
+import { ContentPlayer } from '../ContentPlayer';
+import { ResourceReorderDialog } from '../ResourceReorder/ResourceReorderDialog';
+import { AssignPageNumber } from '../AssignPageNumber/AssignPageNumber';
+import { ContentEditForm } from './ContentEditForm';
+import styles from './ContextualEditor.module.scss';
+
+const QUML_TYPES = ['application/vnd.sunbird.questionset'];
+
+interface ContextualEditorProps {
+  editorMode: EditorMode;
+  onToolbarEvent: (event: { action: ToolbarAction; data?: unknown }) => void;
+}
+
+type TabId = 'details' | 'audience' | 'licensing';
+
+export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, onToolbarEvent }) => {
+  const [activeTab, setActiveTab] = useState<TabId>('details');
+  const [errorTabs, setErrorTabs] = useState<TabId[]>([]);
+  const [reorderResourceId, setReorderResourceId] = useState<string | null>(null);
+  const [showAssignPage, setShowAssignPage] = useState(false);
+  const titleRef = useRef<HTMLDivElement>(null);
+  const titleTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const { selectedNodeId, breadcrumb, activeNodeMeta, updateNode, treeData } = useTreeStore();
+  const { isCurrentNodeFolder, isCurrentNodeRoot } = useEditorStore();
+  const contentId = useEditorStore(
+    s => s.editorConfig?.context?.contentId ?? s.editorConfig?.context?.identifier ?? '',
+  );
+
+  const selectedNode = selectedNodeId ? findNodeById(treeData, selectedNodeId) : null;
+
+  const isQuml = selectedNode && QUML_TYPES.includes(selectedNode.mimeType ?? '');
+  const isLeafContent = selectedNode && !selectedNode.isFolder && !isQuml && !isCurrentNodeRoot;
+
+  // Review comment from previous rejection cycle
+  const reviewComment = (selectedNode?.metadata?.rejectComment as string | undefined)
+    ?? (isCurrentNodeRoot ? (treeData[0]?.metadata?.rejectComment as string | undefined) : undefined);
+
+  const handleTitleChange = useCallback(() => {
+    const el = titleRef.current;
+    if (!el || !selectedNodeId) return;
+    const newTitle = el.innerText.trim();
+    clearTimeout(titleTimerRef.current);
+    titleTimerRef.current = setTimeout(() => {
+      updateNode(selectedNodeId, { name: newTitle });
+    }, 600);
+  }, [selectedNodeId, updateNode]);
+
+  const handleFormValueChange = useCallback((data: unknown) => {
+    onToolbarEvent({ action: 'onFormValueChange', data });
+  }, [onToolbarEvent]);
+
+  const handleFormStatusChange = useCallback((isValid: boolean, invalidTabs: TabId[]) => {
+    setErrorTabs(invalidTabs);
+    onToolbarEvent({ action: 'onFormStatusChange', data: { isValid } });
+  }, [onToolbarEvent]);
+
+  if (!selectedNode) {
+    return (
+      <div className={styles.emptyState}>
+        <p>Select a unit from the outline to edit its details</p>
+      </div>
+    );
+  }
+
+  if (isQuml) {
+    return <ContentPlayer node={selectedNode} editorMode={editorMode} type="quml" />;
+  }
+
+  if (isLeafContent) {
+    return (
+      <div className={styles.leafContentLayout}>
+        <ContentPlayer node={selectedNode} editorMode={editorMode} type="content" />
+        <ContentEditForm
+          node={selectedNode}
+          editorMode={editorMode}
+          onMoveClick={() => setReorderResourceId(selectedNode.identifier)}
+          reorderDialog={reorderResourceId ? (
+            <ResourceReorderDialog
+              resourceId={reorderResourceId}
+              resourceName={selectedNode.name}
+              currentUnitId={selectedNode.parent ?? ''}
+              onClose={() => setReorderResourceId(null)}
+            />
+          ) : null}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <Breadcrumb crumbs={breadcrumb} />
+
+      {/* Review comment bar — shown in review mode if a rejection comment exists */}
+      {editorMode === 'review' && reviewComment && (
+        <div className={styles.reviewComment} role="alert">
+          <span className={styles.reviewCommentLabel}>Reviewer comment:</span>
+          <span className={styles.reviewCommentText}>{reviewComment}</span>
+        </div>
+      )}
+
+      {/* Title row: app icon (root only) + inline editable title */}
+      <div className={styles.titleRow}>
+        {isCurrentNodeRoot && !!(selectedNode.appIcon ?? selectedNode.metadata?.appIcon) && (
+          <img
+            src={String(selectedNode.appIcon ?? selectedNode.metadata?.appIcon)}
+            alt="Course icon"
+            className={styles.titleIcon}
+          />
+        )}
+        <div
+          ref={titleRef}
+          className={styles.nodeTitle}
+          contentEditable={editorMode === 'edit'}
+          suppressContentEditableWarning
+          onInput={handleTitleChange}
+          onBlur={handleTitleChange}
+          data-placeholder="Untitled"
+          aria-label="Node title"
+        >
+          {selectedNode.name}
+        </div>
+      </div>
+
+      {/* Tabs — root shows all three; units show only Details */}
+      <TabBar
+        activeTab={activeTab}
+        onChange={tab => setActiveTab(tab as TabId)}
+        errorTabs={errorTabs}
+        visibleTabs={isCurrentNodeRoot ? undefined : ['details']}
+      />
+
+      {/* Form */}
+      <div className={styles.formArea}>
+        <SparkMetaForm
+          key={selectedNodeId ?? 'none'}
+          nodeMetadata={activeNodeMeta}
+          activeTab={activeTab}
+          isRoot={isCurrentNodeRoot}
+          isFolder={isCurrentNodeFolder}
+          editorMode={editorMode}
+          onFormValueChange={handleFormValueChange}
+          onFormStatusChange={handleFormStatusChange}
+        />
+      </div>
+
+      {/* Content list — for folder nodes (both root and non-root units) */}
+      {(isCurrentNodeFolder || isCurrentNodeRoot) && activeTab === 'details' && (
+        <div className={styles.contentListArea}>
+          <UnitContentList editorMode={editorMode} />
+        </div>
+      )}
+
+      {/* Drop zone overlay */}
+      <DropZone
+        isActive={false}
+        label="Drop to add content to this unit"
+        nodeId={selectedNodeId ?? undefined}
+        className={styles.dropZone}
+      />
+
+      {/* Modals */}
+      {showAssignPage && (
+        <AssignPageNumber contentId={contentId} onClose={() => setShowAssignPage(false)} />
+      )}
+    </div>
+  );
+};
+
+function findNodeById(
+  nodes: import('../../types/editor').INode[],
+  id: string,
+): import('../../types/editor').INode | undefined {
+  for (const n of nodes) {
+    if (n.id === id) return n;
+    if (n.children) {
+      const f = findNodeById(n.children, id);
+      if (f) return f;
+    }
+  }
+  return undefined;
+}

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -11,6 +11,7 @@ import { ContentPlayer } from '../ContentPlayer';
 import { ResourceReorderDialog } from '../ResourceReorder/ResourceReorderDialog';
 import { AssignPageNumber } from '../AssignPageNumber/AssignPageNumber';
 import { ContentEditForm } from './ContentEditForm';
+import { TitleAppIcon } from './TitleAppIcon';
 import styles from './ContextualEditor.module.scss';
 
 const QUML_TYPES = ['application/vnd.sunbird.questionset'];
@@ -117,11 +118,11 @@ export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, 
 
       {/* Title row: app icon (root only) + inline editable title */}
       <div className={styles.titleRow}>
-        {isCurrentNodeRoot && !!(selectedNode.appIcon ?? selectedNode.metadata?.appIcon) && (
-          <img
-            src={String(selectedNode.appIcon ?? selectedNode.metadata?.appIcon)}
-            alt="Course icon"
-            className={styles.titleIcon}
+        {isCurrentNodeRoot && selectedNodeId && (
+          <TitleAppIcon
+            nodeId={selectedNodeId}
+            value={String(selectedNode.appIcon ?? selectedNode.metadata?.appIcon ?? '')}
+            editable={editorMode === 'edit'}
           />
         )}
         <div

--- a/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -108,8 +108,8 @@ export const ContextualEditor: React.FC<ContextualEditorProps> = ({ editorMode, 
     <div className={styles.container}>
       <Breadcrumb crumbs={breadcrumb} />
 
-      {/* Review comment bar — shown in review mode if a rejection comment exists */}
-      {editorMode === 'review' && reviewComment && (
+      {/* Review comment bar — shown whenever a rejection comment exists (edit or review mode) */}
+      {reviewComment && (
         <div className={styles.reviewComment} role="alert">
           <span className={styles.reviewCommentLabel}>Reviewer comment:</span>
           <span className={styles.reviewCommentText}>{reviewComment}</span>

--- a/projects/collection-editor-react/src/components/ContextualEditor/TabBar.module.scss
+++ b/projects/collection-editor-react/src/components/ContextualEditor/TabBar.module.scss
@@ -1,0 +1,31 @@
+.tabBar {
+  display: flex;
+  border-bottom: 1px solid var(--sbx-gray-200);
+  margin-bottom: 16px;
+  gap: 0;
+}
+.tab {
+  display: flex; align-items: center; gap: 6px;
+  padding: 10px 16px;
+  border: none; background: none; cursor: pointer;
+  font-size: 13px; font-weight: 500;
+  color: var(--sbx-gray-500);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  white-space: nowrap;
+  transition: all 0.15s;
+  position: relative;
+  &:hover { color: var(--sbx-primary); }
+}
+.active {
+  color: var(--sbx-primary);
+  border-bottom-color: var(--sbx-primary);
+  font-weight: 600;
+}
+.error { color: var(--sbx-error); }
+.errorDot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--sbx-error);
+  display: inline-block;
+}

--- a/projects/collection-editor-react/src/components/ContextualEditor/TabBar.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/TabBar.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styles from './TabBar.module.scss';
+
+const TABS = [
+  { id: 'details', label: 'Details' },
+  { id: 'audience', label: 'Audience & Curriculum' },
+  { id: 'licensing', label: 'Licensing' },
+] as const;
+
+type TabId = typeof TABS[number]['id'];
+
+interface TabBarProps {
+  activeTab: TabId;
+  onChange: (tab: TabId) => void;
+  errorTabs?: string[];
+  visibleTabs?: TabId[];
+}
+
+export const TabBar: React.FC<TabBarProps> = ({ activeTab, onChange, errorTabs = [], visibleTabs }) => {
+  const tabs = visibleTabs ? TABS.filter(t => visibleTabs.includes(t.id)) : TABS;
+  return (
+    <div className={styles.tabBar} role="tablist" aria-label="Metadata sections">
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          aria-controls={`panel-${tab.id}`}
+          className={[styles.tab, activeTab === tab.id ? styles.active : '', errorTabs.includes(tab.id) ? styles.error : ''].join(' ')}
+          onClick={() => onChange(tab.id)}
+        >
+          {tab.label}
+          {errorTabs.includes(tab.id) && <span className={styles.errorDot} aria-label="Has errors" />}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/ContextualEditor/TitleAppIcon.module.scss
+++ b/projects/collection-editor-react/src/components/ContextualEditor/TitleAppIcon.module.scss
@@ -1,0 +1,53 @@
+.iconBtn {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border-radius: var(--sbx-r-sm);
+  border: 1.5px dashed var(--sbx-gray-300);
+  overflow: visible;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--sbx-gray-50);
+
+  &.editable {
+    cursor: pointer;
+    &:hover { border-color: var(--sbx-primary); background: var(--sbx-primary-light, #eef3fd); }
+    &:focus-visible { outline: 2px solid var(--sbx-primary); outline-offset: 2px; }
+  }
+}
+
+.iconImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: calc(var(--sbx-r-sm) - 1px);
+  display: block;
+}
+
+.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--sbx-gray-400);
+}
+
+.removeBtn {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--sbx-error, #dc2626);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+
+  .iconBtn:hover & { display: flex; }
+}

--- a/projects/collection-editor-react/src/components/ContextualEditor/TitleAppIcon.tsx
+++ b/projects/collection-editor-react/src/components/ContextualEditor/TitleAppIcon.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { ImageIcon, Trash2 } from 'lucide-react';
+import { AppIconPickerModal } from '../SparkMetaForm/fields/AppIconPickerModal';
+import { useTreeStore } from '../../store/tree.store';
+import styles from './TitleAppIcon.module.scss';
+
+interface TitleAppIconProps {
+  nodeId: string;
+  value?: string;
+  editable: boolean;
+}
+
+export const TitleAppIcon: React.FC<TitleAppIconProps> = ({ nodeId, value, editable }) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { updateNode, markDirty } = useTreeStore();
+
+  const handleSelect = (url: string) => {
+    updateNode(nodeId, { appIcon: url });
+    markDirty();
+    setPickerOpen(false);
+  };
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    updateNode(nodeId, { appIcon: '' });
+    markDirty();
+  };
+
+  return (
+    <>
+      <div
+        className={[styles.iconBtn, editable ? styles.editable : ''].filter(Boolean).join(' ')}
+        role={editable ? 'button' : undefined}
+        tabIndex={editable ? 0 : -1}
+        aria-label={editable ? 'Select app icon' : 'App icon'}
+        onClick={() => editable && setPickerOpen(true)}
+        onKeyDown={e => { if (editable && (e.key === 'Enter' || e.key === ' ')) setPickerOpen(true); }}
+      >
+        {value ? (
+          <img src={value} alt="App icon" className={styles.iconImg} />
+        ) : (
+          <div className={styles.placeholder}>
+            <ImageIcon size={18} />
+          </div>
+        )}
+        {value && editable && (
+          <button
+            type="button"
+            className={styles.removeBtn}
+            onClick={handleRemove}
+            aria-label="Remove icon"
+          >
+            <Trash2 size={11} />
+          </button>
+        )}
+      </div>
+
+      {pickerOpen && (
+        <AppIconPickerModal
+          nodeId={nodeId}
+          currentValue={value}
+          onSelect={handleSelect}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </>
+  );
+};

--- a/projects/collection-editor-react/src/components/ContextualEditor/index.ts
+++ b/projects/collection-editor-react/src/components/ContextualEditor/index.ts
@@ -1,0 +1,1 @@
+export { ContextualEditor } from './ContextualEditor';

--- a/projects/collection-editor-react/src/components/Dialcode/DialcodePanel.module.scss
+++ b/projects/collection-editor-react/src/components/Dialcode/DialcodePanel.module.scss
@@ -1,0 +1,129 @@
+.panel {
+  padding: 20px;
+  background: white;
+  border-radius: var(--sbx-r-md);
+  border: 1px solid var(--sbx-gray-200);
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--sbx-gray-800);
+  margin: 0 0 16px;
+}
+
+.qrSection {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+  padding: 16px;
+  background: var(--sbx-gray-50);
+  border-radius: var(--sbx-r-md);
+  border: 1px solid var(--sbx-gray-200);
+  margin-bottom: 20px;
+}
+
+.qrImageWrap {
+  flex-shrink: 0;
+  border: 1px solid var(--sbx-gray-300);
+  border-radius: var(--sbx-r-sm);
+  overflow: hidden;
+  background: white;
+  padding: 4px;
+}
+
+.qrImage {
+  display: block;
+  width: 150px;
+  height: 150px;
+}
+
+.qrMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+}
+
+.dialcodeLabel {
+  font-size: 12px;
+  color: var(--sbx-gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.dialcodeValue {
+  font-family: 'Courier New', monospace;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--sbx-gray-900);
+  letter-spacing: 0.1em;
+  background: var(--sbx-gray-100);
+  padding: 4px 10px;
+  border-radius: var(--sbx-r-sm);
+  border: 1px solid var(--sbx-gray-300);
+}
+
+.removeBtn {
+  margin-top: 4px;
+  align-self: flex-start;
+}
+
+.emptyState {
+  font-size: 13px;
+  color: var(--sbx-gray-500);
+  margin: 0 0 20px;
+}
+
+.linkSection {
+  border-top: 1px solid var(--sbx-gray-200);
+  padding-top: 16px;
+}
+
+.sectionLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sbx-gray-700);
+  margin: 0 0 10px;
+}
+
+.inputRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  height: 36px;
+  padding: 0 12px;
+  border: 1.5px solid var(--sbx-gray-300);
+  border-radius: var(--sbx-r-sm);
+  font-size: 14px;
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.05em;
+  color: var(--sbx-gray-900);
+  transition: border-color 0.15s;
+
+  &:focus {
+    outline: none;
+    border-color: var(--sbx-primary);
+  }
+
+  &:disabled {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-400);
+  }
+}
+
+.error {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--sbx-error);
+}
+
+.successMsg {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--sbx-success);
+}

--- a/projects/collection-editor-react/src/components/Dialcode/DialcodePanel.tsx
+++ b/projects/collection-editor-react/src/components/Dialcode/DialcodePanel.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useCallback } from 'react';
+import { Button } from '../shared/Button';
+import { checkDialCode, linkDialCode, unlinkDialcode } from '../../api/dialcode';
+import styles from './DialcodePanel.module.scss';
+
+interface DialcodePanelProps {
+  contentId: string;
+  existingDialcode?: string;
+  editorMode: 'edit' | 'review' | 'read' | 'sourcingreview';
+  onDialcodeChange?: (dialcode: string | null) => void;
+}
+
+type Status = 'idle' | 'loading' | 'error' | 'success';
+
+export const DialcodePanel: React.FC<DialcodePanelProps> = ({
+  contentId,
+  existingDialcode,
+  editorMode,
+  onDialcodeChange,
+}) => {
+  const [dialcode, setDialcode] = useState<string | null>(existingDialcode ?? null);
+  const [inputValue, setInputValue] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const isReadOnly = editorMode === 'review' || editorMode === 'read' || editorMode === 'sourcingreview';
+
+  const handleLink = useCallback(async () => {
+    const code = inputValue.trim().toUpperCase();
+    if (!code) return;
+
+    setStatus('loading');
+    setErrorMsg('');
+
+    try {
+      const result = await checkDialCode(code);
+      const dialcodeData = (result as Record<string, unknown>)?.result as Record<string, unknown> | undefined;
+      const dialcodes = dialcodeData?.['dialcodes'] as unknown[] | undefined;
+      if (!dialcodes || dialcodes.length === 0) {
+        setErrorMsg('Dialcode not found. Please enter a valid code.');
+        setStatus('error');
+        return;
+      }
+
+      await linkDialCode(contentId, code);
+      setDialcode(code);
+      setInputValue('');
+      setStatus('success');
+      onDialcodeChange?.(code);
+    } catch {
+      setErrorMsg('Failed to link dialcode. Please try again.');
+      setStatus('error');
+    }
+  }, [contentId, inputValue, onDialcodeChange]);
+
+  const handleUnlink = useCallback(async () => {
+    if (!dialcode) return;
+
+    setStatus('loading');
+    setErrorMsg('');
+
+    try {
+      await unlinkDialcode(contentId);
+      setDialcode(null);
+      setStatus('idle');
+      onDialcodeChange?.(null);
+    } catch {
+      setErrorMsg('Failed to remove dialcode. Please try again.');
+      setStatus('error');
+    }
+  }, [contentId, dialcode, onDialcodeChange]);
+
+  return (
+    <div className={styles.panel}>
+      <h3 className={styles.title}>QR Code (Dialcode)</h3>
+
+      {dialcode ? (
+        <div className={styles.qrSection}>
+          <div className={styles.qrImageWrap}>
+            <img
+              src={`https://chart.googleapis.com/chart?cht=qr&chs=150x150&chl=${dialcode}`}
+              alt={`QR code for ${dialcode}`}
+              className={styles.qrImage}
+            />
+          </div>
+          <div className={styles.qrMeta}>
+            <span className={styles.dialcodeLabel}>Linked code:</span>
+            <code className={styles.dialcodeValue}>{dialcode}</code>
+            {!isReadOnly && (
+              <Button
+                variant="danger"
+                size="sm"
+                isLoading={status === 'loading'}
+                onClick={handleUnlink}
+                className={styles.removeBtn}
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <p className={styles.emptyState}>No QR code linked to this content.</p>
+      )}
+
+      {!isReadOnly && (
+        <div className={styles.linkSection}>
+          <p className={styles.sectionLabel}>Link manually</p>
+          <div className={styles.inputRow}>
+            <input
+              type="text"
+              className={styles.input}
+              placeholder="Enter dialcode (e.g. A1B2C3)"
+              value={inputValue}
+              onChange={(e) => {
+                setInputValue(e.target.value.toUpperCase());
+                if (status === 'error') setStatus('idle');
+              }}
+              onKeyDown={(e) => e.key === 'Enter' && handleLink()}
+              disabled={status === 'loading'}
+              aria-label="Dialcode input"
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              isLoading={status === 'loading'}
+              disabled={!inputValue.trim()}
+              onClick={handleLink}
+            >
+              Link
+            </Button>
+          </div>
+          {errorMsg && <p className={styles.error} role="alert">{errorMsg}</p>}
+          {status === 'success' && (
+            <p className={styles.successMsg} role="status">Dialcode linked successfully.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/Dialcode/DialcodePanel.tsx
+++ b/projects/collection-editor-react/src/components/Dialcode/DialcodePanel.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useCallback } from 'react';
 import { Button } from '../shared/Button';
 import { checkDialCode, linkDialCode, unlinkDialcode } from '../../api/dialcode';
+import { useTreeStore } from '../../store/tree.store';
 import styles from './DialcodePanel.module.scss';
+
+const DIALCODE_FORMAT = /^[A-Z0-9]{2,}$/;
 
 interface DialcodePanelProps {
   contentId: string;
@@ -23,11 +26,34 @@ export const DialcodePanel: React.FC<DialcodePanelProps> = ({
   const [status, setStatus] = useState<Status>('idle');
   const [errorMsg, setErrorMsg] = useState('');
 
+  const treeData = useTreeStore((s) => s.treeData);
   const isReadOnly = editorMode === 'review' || editorMode === 'read' || editorMode === 'sourcingreview';
 
   const handleLink = useCallback(async () => {
     const code = inputValue.trim().toUpperCase();
     if (!code) return;
+
+    // Format check: must be alphanumeric uppercase, at least 2 chars
+    if (!DIALCODE_FORMAT.test(code)) {
+      setErrorMsg('Invalid DIAL code format. Use uppercase letters and digits only (e.g. A1B2C3).');
+      setStatus('error');
+      return;
+    }
+
+    // Cross-tree duplicate check — same QR on multiple nodes causes ambiguous scans
+    const isDuplicate = (function checkTree(nodes: typeof treeData): boolean {
+      for (const node of nodes) {
+        const nodeCodes = node.metadata?.['dialcodes'] as string[] | undefined;
+        if (nodeCodes?.includes(code)) return true;
+        if (node.children && checkTree(node.children)) return true;
+      }
+      return false;
+    })(treeData);
+    if (isDuplicate) {
+      setErrorMsg(`DIAL code "${code}" is already linked to another node in this collection.`);
+      setStatus('error');
+      return;
+    }
 
     setStatus('loading');
     setErrorMsg('');
@@ -51,7 +77,7 @@ export const DialcodePanel: React.FC<DialcodePanelProps> = ({
       setErrorMsg('Failed to link dialcode. Please try again.');
       setStatus('error');
     }
-  }, [contentId, inputValue, onDialcodeChange]);
+  }, [contentId, inputValue, onDialcodeChange, treeData]);
 
   const handleUnlink = useCallback(async () => {
     if (!dialcode) return;
@@ -78,7 +104,7 @@ export const DialcodePanel: React.FC<DialcodePanelProps> = ({
         <div className={styles.qrSection}>
           <div className={styles.qrImageWrap}>
             <img
-              src={`https://chart.googleapis.com/chart?cht=qr&chs=150x150&chl=${dialcode}`}
+              src={`https://chart.googleapis.com/chart?cht=qr&chs=150x150&chl=${encodeURIComponent(dialcode ?? '')}`}
               alt={`QR code for ${dialcode}`}
               className={styles.qrImage}
             />

--- a/projects/collection-editor-react/src/components/Dialcode/index.ts
+++ b/projects/collection-editor-react/src/components/Dialcode/index.ts
@@ -1,0 +1,1 @@
+export { DialcodePanel } from './DialcodePanel';

--- a/projects/collection-editor-react/src/components/LibraryDock/FilterChips.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/FilterChips.module.scss
@@ -1,0 +1,17 @@
+.chips {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.chip {
+  flex-shrink: 0;
+  font-size: 12px;
+  padding: 3px 10px;
+}

--- a/projects/collection-editor-react/src/components/LibraryDock/FilterChips.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/FilterChips.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styles from './FilterChips.module.scss';
+
+interface FilterChip { label: string; value: string; }
+interface FilterChipsProps {
+  filters: readonly FilterChip[];
+  active: string;
+  onChange: (value: string) => void;
+}
+
+export const FilterChips: React.FC<FilterChipsProps> = ({ filters, active, onChange }) => (
+  <div className={styles.chips} role="group" aria-label="Content type filters">
+    {filters.map(f => (
+      <button
+        key={f.value}
+        type="button"
+        role="radio"
+        aria-checked={active === f.value}
+        className={[`sbx-chip`, active === f.value ? 'filled' : 'outline', styles.chip].join(' ')}
+        onClick={() => onChange(f.value)}
+      >
+        {f.label}
+      </button>
+    ))}
+  </div>
+);

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.module.scss
@@ -80,11 +80,11 @@
 }
 
 .added {
-  border-color: #16A34A;
-  background: #F0FDF4;
+  border-color: var(--sbx-success);
+  background: var(--sbx-status-ok-bg);
 
   &:hover {
-    border-color: #16A34A;
+    border-color: var(--sbx-success);
     box-shadow: var(--sbx-shadow-1);
   }
 }
@@ -97,6 +97,6 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: #16A34A;
+  background: var(--sbx-success);
   color: white;
 }

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.module.scss
@@ -1,0 +1,102 @@
+.card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 10px 10px 12px;
+  border-radius: var(--sbx-r-md);
+  border: 1px solid var(--sbx-gray-200);
+  background: white;
+  cursor: grab;
+  transition: all 0.15s;
+  user-select: none;
+
+  &:hover {
+    border-color: var(--sbx-primary);
+    box-shadow: var(--sbx-shadow-1);
+
+    .addBtn {
+      opacity: 1;
+    }
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.dragging {
+  opacity: 0.4;
+  box-shadow: none;
+}
+
+.ctIcon {
+  flex-shrink: 0;
+}
+
+.info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--sbx-gray-800);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  font-size: 11px;
+  color: var(--sbx-gray-500);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.addBtn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: var(--sbx-primary-light);
+  color: var(--sbx-primary);
+  border-radius: var(--sbx-r-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+
+  &:hover {
+    background: var(--sbx-primary);
+    color: white;
+  }
+}
+
+.added {
+  border-color: #16A34A;
+  background: #F0FDF4;
+
+  &:hover {
+    border-color: #16A34A;
+    box-shadow: var(--sbx-shadow-1);
+  }
+}
+
+.addedBadge {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #16A34A;
+  color: white;
+}

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.module.scss
@@ -79,6 +79,16 @@
   }
 }
 
+.addBtnMuted {
+  opacity: 0.4;
+  cursor: default;
+
+  &:hover {
+    background: var(--sbx-primary-light);
+    color: var(--sbx-primary);
+  }
+}
+
 .added {
   border-color: var(--sbx-success);
   background: var(--sbx-status-ok-bg);

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
@@ -80,15 +80,18 @@ export const LibraryCard: React.FC<LibraryCardProps> = ({
         </span>
       )}
 
-      {/* Add button — hidden when already added; disabled for non-Draft content */}
+      {/* Add button — hidden when already added; disabled for non-Draft content.
+          When isDraft but no unit is selected, keep the button clickable so the
+          parent can fire a helpful "select a unit first" toast. */}
       {!isAdded && (
         <button
           type="button"
-          className={styles.addBtn}
-          onClick={(e) => { e.stopPropagation(); if (canAdd) onAdd(item); }}
-          disabled={!canAdd}
+          className={[styles.addBtn, !canAdd && isDraft ? styles.addBtnMuted : ''].join(' ')}
+          onClick={(e) => { e.stopPropagation(); onAdd(item); }}
+          disabled={!isDraft}
+          aria-disabled={!canAdd}
           aria-label={`Add ${item.name} to unit`}
-          title={isDraft ? 'Add to unit' : 'Only Draft content can be edited'}
+          title={isDraft ? (isUnitSelected ? 'Add to unit' : 'Select a unit to add') : 'Only Draft content can be added'}
         >
           <Plus size={14} />
         </button>

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
@@ -3,6 +3,7 @@ import { useDraggable } from '@dnd-kit/core';
 import { Plus, Video, FileText, Layers, Package, Music, HelpCircle, File, Check } from 'lucide-react';
 import type { IContent } from '../../types/content';
 import { getCtStyle } from '../../hooks/useContentType';
+import { useIsDraftStatus } from '../../hooks/useContentStatus';
 import styles from './LibraryCard.module.scss';
 
 const CT_ICONS: Record<string, React.ElementType> = {
@@ -27,10 +28,13 @@ export const LibraryCard: React.FC<LibraryCardProps> = ({
 }) => {
   const ctStyle = getCtStyle(item);
   const CtIcon = CT_ICONS[ctStyle.key] ?? File;
+  const isDraft = useIsDraftStatus();
+  // Content can only be added while the collection is in Draft.
+  const canAdd = isDraft && !isAdded;
 
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: item.identifier,
-    disabled: !isDraggable,
+    disabled: !isDraggable || !isDraft,
     data: { type: 'library-item', item },
   });
 
@@ -75,14 +79,15 @@ export const LibraryCard: React.FC<LibraryCardProps> = ({
         </span>
       )}
 
-      {/* Add button — hidden when already added */}
+      {/* Add button — hidden when already added; disabled for non-Draft content */}
       {!isAdded && (
         <button
           type="button"
           className={styles.addBtn}
-          onClick={(e) => { e.stopPropagation(); onAdd(item); }}
+          onClick={(e) => { e.stopPropagation(); if (canAdd) onAdd(item); }}
+          disabled={!canAdd}
           aria-label={`Add ${item.name} to unit`}
-          title="Add to unit"
+          title={isDraft ? 'Add to unit' : 'Only Draft content can be edited'}
         >
           <Plus size={14} />
         </button>

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
@@ -3,7 +3,7 @@ import { useDraggable } from '@dnd-kit/core';
 import { Plus, Video, FileText, Layers, Package, Music, HelpCircle, File, Check } from 'lucide-react';
 import type { IContent } from '../../types/content';
 import { getCtStyle } from '../../hooks/useContentType';
-import { useIsDraftStatus } from '../../hooks/useContentStatus';
+import { useIsDraftStatus, useSelectedNodeIsUnit } from '../../hooks/useContentStatus';
 import styles from './LibraryCard.module.scss';
 
 const CT_ICONS: Record<string, React.ElementType> = {
@@ -29,12 +29,13 @@ export const LibraryCard: React.FC<LibraryCardProps> = ({
   const ctStyle = getCtStyle(item);
   const CtIcon = CT_ICONS[ctStyle.key] ?? File;
   const isDraft = useIsDraftStatus();
-  // Content can only be added while the collection is in Draft.
-  const canAdd = isDraft && !isAdded;
+  const isUnitSelected = useSelectedNodeIsUnit();
+  // Content can only be added while the collection is in Draft and a unit is selected.
+  const canAdd = isDraft && !isAdded && isUnitSelected;
 
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: item.identifier,
-    disabled: !isDraggable || !isDraft,
+    disabled: !isDraggable || !isDraft || !isUnitSelected,
     data: { type: 'library-item', item },
   });
 

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryCard.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import { Plus, Video, FileText, Layers, Package, Music, HelpCircle, File, Check } from 'lucide-react';
+import type { IContent } from '../../types/content';
+import { getCtStyle } from '../../hooks/useContentType';
+import styles from './LibraryCard.module.scss';
+
+const CT_ICONS: Record<string, React.ElementType> = {
+  video: Video, pdf: FileText, h5p: Layers, scorm: Package,
+  audio: Music, quiz: HelpCircle, default: File,
+};
+
+interface LibraryCardProps {
+  item: IContent;
+  onAdd: (item: IContent) => void;
+  onPreview?: (item: IContent) => void;
+  isDraggable?: boolean;
+  isAdded?: boolean;
+}
+
+export const LibraryCard: React.FC<LibraryCardProps> = ({
+  item,
+  onAdd,
+  onPreview,
+  isDraggable,
+  isAdded,
+}) => {
+  const ctStyle = getCtStyle(item);
+  const CtIcon = CT_ICONS[ctStyle.key] ?? File;
+
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: item.identifier,
+    disabled: !isDraggable,
+    data: { type: 'library-item', item },
+  });
+
+  const handleCardClick = () => {
+    if (onPreview) {
+      onPreview(item);
+    }
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={[
+        styles.card,
+        isDragging ? styles.dragging : '',
+        isAdded ? styles.added : '',
+      ].join(' ')}
+      aria-label={item.name}
+      {...(isDraggable ? { ...attributes, ...listeners } : {})}
+      role="listitem"
+      onClick={handleCardClick}
+    >
+      {/* CT icon */}
+      <span className={[`sbx-ct-sq--${ctStyle.key}`, styles.ctIcon].join(' ')} aria-hidden="true">
+        <CtIcon size={14} />
+      </span>
+
+      {/* Info */}
+      <div className={styles.info}>
+        <span className={styles.name} title={item.name}>{item.name}</span>
+        <span className={styles.meta}>
+          {item.organisation?.[0] ?? item.channel ?? ''}
+          {item.organisation?.[0] && item.primaryCategory ? ' · ' : ''}
+          {item.primaryCategory ?? ''}
+        </span>
+      </div>
+
+      {/* Already-added badge */}
+      {isAdded && (
+        <span className={styles.addedBadge} aria-label="Already added" title="Already added to this collection">
+          <Check size={12} />
+        </span>
+      )}
+
+      {/* Add button — hidden when already added */}
+      {!isAdded && (
+        <button
+          type="button"
+          className={styles.addBtn}
+          onClick={(e) => { e.stopPropagation(); onAdd(item); }}
+          aria-label={`Add ${item.name} to unit`}
+          title="Add to unit"
+        >
+          <Plus size={14} />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryContentCard.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryContentCard.module.scss
@@ -12,7 +12,7 @@
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
-  background: #f1f5f9;
+  background: var(--sbx-gray-100);
   flex-shrink: 0;
   overflow: hidden;
 }
@@ -30,7 +30,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #e2e8f0 0%, #f1f5f9 100%);
+  background: linear-gradient(135deg, var(--sbx-gray-200) 0%, var(--sbx-gray-100) 100%);
 }
 
 .heroPlaceholderIcon {

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryContentCard.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryContentCard.module.scss
@@ -1,0 +1,123 @@
+// ── Library content preview card ──────────────────────────────────────────────
+
+.card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #fff;
+}
+
+// Thumbnail hero
+.hero {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: #f1f5f9;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.heroImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.heroPlaceholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #e2e8f0 0%, #f1f5f9 100%);
+}
+
+.heroPlaceholderIcon {
+  font-size: 48px;
+  opacity: 0.4;
+}
+
+.typeBadge {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+// Details area
+.body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.name {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--sbx-gray-900, #0f172a);
+  line-height: 1.4;
+}
+
+.description {
+  margin: 0;
+  font-size: 13px;
+  color: var(--sbx-gray-500, #64748b);
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.metaChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--sbx-gray-50, #f8fafc);
+  border: 1px solid var(--sbx-gray-200, #e2e8f0);
+  font-size: 12px;
+  color: var(--sbx-gray-700, #334155);
+  max-width: 100%;
+}
+
+.metaLabel {
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--sbx-gray-400, #94a3b8);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+}
+
+.metaValue {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
+}
+
+.org {
+  margin: 0;
+  font-size: 12px;
+  color: var(--sbx-gray-400, #94a3b8);
+  font-style: italic;
+}

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.module.scss
@@ -1,0 +1,276 @@
+.dock {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--sbx-gray-100);
+  flex-shrink: 0;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--sbx-gray-700);
+}
+
+.headerTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sbx-gray-800);
+}
+
+.count {
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--sbx-gray-100);
+  color: var(--sbx-gray-600);
+  padding: 2px 8px;
+  border-radius: var(--sbx-r-xl);
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px 6px;
+  flex-shrink: 0;
+}
+
+.searchWrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--sbx-gray-400);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 7px 10px 7px 32px;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-xl);
+  font-size: 13px;
+  font-family: var(--sbx-font);
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+
+  &:focus {
+    border-color: var(--sbx-primary);
+  }
+
+  &::placeholder {
+    color: var(--sbx-gray-400);
+  }
+}
+
+.filterToggleBtn {
+  flex-shrink: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-md);
+  background: white;
+  color: var(--sbx-gray-600);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+
+  &:hover {
+    border-color: var(--sbx-primary);
+    color: var(--sbx-primary);
+  }
+
+  &.filterToggleBtnActive {
+    border-color: var(--sbx-primary);
+    background: var(--sbx-primary-light);
+    color: var(--sbx-primary);
+  }
+}
+
+.filterBadge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--sbx-primary);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  box-sizing: border-box;
+}
+
+.filters {
+  padding: 4px 12px 8px;
+  flex-shrink: 0;
+  overflow-x: auto;
+  // hide scrollbar but keep scrollability
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
+}
+
+// mainArea fills remaining vertical space and lets cardList scroll inside it
+.mainArea {
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.cardList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--sbx-gray-300);
+    border-radius: 2px;
+  }
+}
+
+.skeleton {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: var(--sbx-r-md);
+  background: var(--sbx-gray-50);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.skeletonIcon {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: var(--sbx-gray-200);
+  flex-shrink: 0;
+}
+
+.skeletonText {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skeletonLine {
+  height: 12px;
+  background: var(--sbx-gray-200);
+  border-radius: 4px;
+  width: 80%;
+}
+
+.skeletonLineSm {
+  height: 10px;
+  background: var(--sbx-gray-100);
+  border-radius: 4px;
+  width: 50%;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.loadMoreBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 8px 0;
+  margin-top: 4px;
+  background: none;
+  border: 1px solid var(--sbx-primary, #1890ff);
+  border-radius: var(--sbx-r-sm, 4px);
+  color: var(--sbx-primary, #1890ff);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--sbx-font);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sbx-primary-light, #e6f4ff);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 8px;
+  color: var(--sbx-gray-400);
+  padding: 24px;
+  text-align: center;
+
+  p {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  span {
+    font-size: 12px;
+  }
+}
+
+.collapseBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--sbx-gray-400);
+  border-radius: var(--sbx-r-sm);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-700);
+  }
+}

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.module.scss
@@ -144,6 +144,17 @@
   flex-direction: column;
 }
 
+// Filter / preview side panels overlay the card list, filling .mainArea.
+// Must have resolved dimensions so the ContentPlayer (flex:1) inside gets height.
+.sidePanelOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  background: white;
+}
+
 .cardList {
   flex: 1;
   overflow-y: auto;

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
@@ -104,24 +104,24 @@ export const LibraryDock: React.FC<LibraryDockProps> = ({ editorMode, collapsed 
 
   return (
     <div className={styles.dock}>
-      {/* Header */}
+      {/* Header — collapse control sits to the left of the Library icon */}
       <div className={styles.header}>
         <div className={styles.headerLeft}>
+          <button
+            type="button"
+            className={styles.collapseBtn}
+            onClick={onToggleCollapse}
+            aria-label="Collapse library panel"
+            title="Collapse library"
+          >
+            <PanelRightClose size={15} />
+          </button>
           <Library size={16} />
           <span className={styles.headerTitle}>Library</span>
           {totalCount > 0 && (
             <span className={styles.count}>{totalCount}</span>
           )}
         </div>
-        <button
-          type="button"
-          className={styles.collapseBtn}
-          onClick={onToggleCollapse}
-          aria-label="Collapse library panel"
-          title="Collapse library"
-        >
-          <PanelRightClose size={15} />
-        </button>
       </div>
 
       {/* Search + Filter button row */}

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
@@ -1,0 +1,247 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Search, Library, SlidersHorizontal, ArrowUpAZ, Clock, PanelRightClose } from 'lucide-react';
+import type { EditorMode } from '../../types/editor';
+import type { IContent } from '../../types/content';
+import { CT_FILTERS } from '../../types/content';
+import { useLibrary } from '../../hooks/useLibrary';
+import { useTreeStore } from '../../store/tree.store';
+import { LibraryCard } from './LibraryCard';
+import { FilterChips } from './FilterChips';
+import { LibraryFilterPanel } from './LibraryFilterPanel';
+import type { LibraryFilters } from './LibraryFilterPanel';
+import { LibraryPreviewPanel } from './LibraryPreviewPanel';
+import toast from 'react-hot-toast';
+import styles from './LibraryDock.module.scss';
+
+interface LibraryDockProps {
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  editorMode: EditorMode;
+}
+
+// Collect all resource identifiers from the tree (non-folder nodes)
+function collectResourceIds(nodes: ReturnType<typeof useTreeStore.getState>['treeData']): Set<string> {
+  const ids = new Set<string>();
+  const queue = [...nodes];
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    if (!node.isFolder) {
+      ids.add(node.identifier);
+    }
+    if (node.children) queue.push(...node.children);
+  }
+  return ids;
+}
+
+export const LibraryDock: React.FC<LibraryDockProps> = ({ editorMode, collapsed = false, onToggleCollapse }) => {
+  const {
+    content,
+    isLoading,
+    totalCount,
+    activeFilter,
+    searchQuery,
+    sortAZ,
+    hasMore,
+    search,
+    setFilter,
+    applyAdvancedFilters,
+    toggleSort,
+    loadMore,
+  } = useLibrary();
+
+  const { addResource, selectedNodeId, treeData } = useTreeStore();
+  const isEditable = editorMode === 'edit';
+
+  // Panel state
+  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
+  const [activeFilters, setActiveFilters] = useState<LibraryFilters>({});
+  const [previewContent, setPreviewContent] = useState<IContent | null>(null);
+
+  // Build a set of already-added resource identifiers for O(1) lookup
+  const addedIds = useMemo(() => collectResourceIds(treeData), [treeData]);
+
+  const handleAdd = useCallback(
+    (item: IContent) => {
+      if (!selectedNodeId) {
+        toast.error('Select a unit first');
+        return;
+      }
+      addResource(item, selectedNodeId);
+      toast.success(`Added "${item.name}"`);
+    },
+    [selectedNodeId, addResource],
+  );
+
+  const handleApplyFilters = useCallback(
+    (filters: LibraryFilters) => {
+      setActiveFilters(filters);
+      applyAdvancedFilters(filters);
+    },
+    [applyAdvancedFilters],
+  );
+
+  const handleCardPreview = useCallback((item: IContent) => {
+    setPreviewContent(item);
+  }, []);
+
+  const handlePreviewAdd = useCallback(
+    (item: IContent) => {
+      handleAdd(item);
+      setPreviewContent(null);
+    },
+    [handleAdd],
+  );
+
+  // Count active advanced filters for badge
+  const activeFilterCount = useMemo(
+    () =>
+      Object.values(activeFilters).reduce(
+        (sum, arr) => sum + (arr?.length ?? 0),
+        0,
+      ),
+    [activeFilters],
+  );
+
+  return (
+    <div className={styles.dock}>
+      {/* Header */}
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <Library size={16} />
+          <span className={styles.headerTitle}>Library</span>
+          {totalCount > 0 && (
+            <span className={styles.count}>{totalCount}</span>
+          )}
+        </div>
+        <button
+          type="button"
+          className={styles.collapseBtn}
+          onClick={onToggleCollapse}
+          aria-label="Collapse library panel"
+          title="Collapse library"
+        >
+          <PanelRightClose size={15} />
+        </button>
+      </div>
+
+      {/* Search + Filter button row */}
+      <div className={styles.searchRow}>
+        <div className={styles.searchWrap}>
+          <Search size={14} className={styles.searchIcon} />
+          <input
+            type="search"
+            className={styles.searchInput}
+            placeholder="Search content…"
+            value={searchQuery}
+            onChange={(e) => search(e.target.value)}
+            aria-label="Search library"
+          />
+        </div>
+        <button
+          type="button"
+          className={[styles.filterToggleBtn, sortAZ ? styles.filterToggleBtnActive : ''].join(' ')}
+          onClick={toggleSort}
+          aria-label={sortAZ ? 'Sort: A–Z (click for Recent)' : 'Sort: Recent (click for A–Z)'}
+          title={sortAZ ? 'A–Z' : 'Recent'}
+        >
+          {sortAZ ? <ArrowUpAZ size={15} /> : <Clock size={15} />}
+        </button>
+        <button
+          type="button"
+          className={[
+            styles.filterToggleBtn,
+            filterPanelOpen ? styles.filterToggleBtnActive : '',
+          ].join(' ')}
+          onClick={() => setFilterPanelOpen((v) => !v)}
+          aria-label="Toggle advanced filters"
+          aria-pressed={filterPanelOpen}
+          title="Advanced filters"
+        >
+          <SlidersHorizontal size={15} />
+          {activeFilterCount > 0 && (
+            <span className={styles.filterBadge}>{activeFilterCount}</span>
+          )}
+        </button>
+      </div>
+
+      {/* Content type filter chips */}
+      <div className={styles.filters}>
+        <FilterChips filters={CT_FILTERS} active={activeFilter} onChange={setFilter} />
+      </div>
+
+      {/* Main area: card list + optional side panels */}
+      <div className={styles.mainArea}>
+        {/* Card list */}
+        <div className={styles.cardList} role="list" aria-label="Library content">
+          {isLoading && content.length === 0 ? (
+            // Loading skeleton
+            Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className={styles.skeleton} aria-hidden="true">
+                <div className={styles.skeletonIcon} />
+                <div className={styles.skeletonText}>
+                  <div className={styles.skeletonLine} />
+                  <div className={styles.skeletonLineSm} />
+                </div>
+              </div>
+            ))
+          ) : content.length > 0 ? (
+            <>
+              {content.map((item) => (
+                <LibraryCard
+                  key={item.identifier}
+                  item={item}
+                  onAdd={handleAdd}
+                  onPreview={handleCardPreview}
+                  isDraggable={isEditable}
+                  isAdded={addedIds.has(item.identifier)}
+                />
+              ))}
+
+              {/* Load More */}
+              {hasMore && (
+                <button
+                  type="button"
+                  className={styles.loadMoreBtn}
+                  onClick={loadMore}
+                  disabled={isLoading}
+                  aria-label="Load more content"
+                >
+                  {isLoading ? 'Loading…' : 'Load More'}
+                </button>
+              )}
+            </>
+          ) : (
+            <div className={styles.emptyState}>
+              <Search size={24} />
+              <p>No content found</p>
+              <span>Try a different search or filter</span>
+            </div>
+          )}
+        </div>
+
+        {/* Advanced filter panel */}
+        {filterPanelOpen && (
+          <div className={styles.sidePanelOverlay}>
+            <LibraryFilterPanel
+              isOpen={filterPanelOpen}
+              filters={activeFilters}
+              onApply={handleApplyFilters}
+              onClose={() => setFilterPanelOpen(false)}
+            />
+          </div>
+        )}
+
+        {/* Preview panel */}
+        {previewContent && (
+          <div className={styles.sidePanelOverlay}>
+            <LibraryPreviewPanel
+              content={previewContent}
+              onAdd={handlePreviewAdd}
+              onClose={() => setPreviewContent(null)}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
@@ -66,10 +66,22 @@ export const LibraryDock: React.FC<LibraryDockProps> = ({ editorMode, collapsed 
         toast.error('Select a unit first');
         return;
       }
-      addResource(item, selectedNodeId);
+      const rootId = treeData[0]?.id;
+      if (selectedNodeId === rootId) {
+        toast('Select a unit from the outline to add content — resources cannot be added directly to the course.', {
+          icon: 'ℹ️',
+          duration: 4000,
+        });
+        return;
+      }
+      const added = addResource(item, selectedNodeId);
+      if (added === false) {
+        toast.error(`"${item.name}" is already in this collection`);
+        return;
+      }
       toast.success(`Added "${item.name}"`);
     },
-    [selectedNodeId, addResource],
+    [selectedNodeId, addResource, treeData],
   );
 
   const handleApplyFilters = useCallback(

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryDock.tsx
@@ -231,15 +231,13 @@ export const LibraryDock: React.FC<LibraryDockProps> = ({ editorMode, collapsed 
           </div>
         )}
 
-        {/* Preview panel */}
+        {/* Preview — opens directly as a centered modal (self-portaled) */}
         {previewContent && (
-          <div className={styles.sidePanelOverlay}>
-            <LibraryPreviewPanel
-              content={previewContent}
-              onAdd={handlePreviewAdd}
-              onClose={() => setPreviewContent(null)}
-            />
-          </div>
+          <LibraryPreviewPanel
+            content={previewContent}
+            onAdd={handlePreviewAdd}
+            onClose={() => setPreviewContent(null)}
+          />
         )}
       </div>
     </div>

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.module.scss
@@ -1,0 +1,154 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: white;
+  border-left: 1px solid var(--sbx-gray-200);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--sbx-gray-100);
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sbx-gray-800);
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--sbx-gray-500);
+  border-radius: var(--sbx-r-sm);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-800);
+  }
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--sbx-gray-300);
+    border-radius: 2px;
+  }
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--sbx-gray-500);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--sbx-font);
+  font-weight: 500;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-xl);
+  background: white;
+  color: var(--sbx-gray-700);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  line-height: 1.4;
+
+  &:hover {
+    border-color: var(--sbx-primary);
+    color: var(--sbx-primary);
+  }
+
+  &.active {
+    border-color: var(--sbx-primary);
+    background: var(--sbx-primary-light);
+    color: var(--sbx-primary);
+  }
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--sbx-gray-100);
+  flex-shrink: 0;
+}
+
+.resetBtn {
+  padding: 6px 16px;
+  font-size: 13px;
+  font-family: var(--sbx-font);
+  font-weight: 500;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-md);
+  background: white;
+  color: var(--sbx-gray-600);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+
+  &:hover {
+    border-color: var(--sbx-gray-400);
+    background: var(--sbx-gray-50);
+  }
+}
+
+.applyBtn {
+  padding: 6px 16px;
+  font-size: 13px;
+  font-family: var(--sbx-font);
+  font-weight: 600;
+  border: none;
+  border-radius: var(--sbx-r-md);
+  background: var(--sbx-primary);
+  color: white;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:active {
+    opacity: 0.8;
+  }
+}

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.tsx
@@ -10,9 +10,20 @@ export interface LibraryFilters {
   medium?: string[];
   gradeLevel?: string[];
   subject?: string[];
+  topic?: string[];
   primaryCategory?: string[];
   contentType?: string[];
 }
+
+// Framework-category filter sections, used when the API search form is absent.
+const DEFAULT_FILTER_SECTIONS: Array<{ key: keyof LibraryFilters; label: string }> = [
+  { key: 'board', label: 'Board' },
+  { key: 'medium', label: 'Medium' },
+  { key: 'gradeLevel', label: 'Class' },
+  { key: 'subject', label: 'Subject' },
+];
+
+const FRAMEWORK_FILTER_KEYS = new Set(['board', 'medium', 'gradeLevel', 'subject', 'topic']);
 
 interface LibraryFilterPanelProps {
   isOpen: boolean;
@@ -57,11 +68,21 @@ export const LibraryFilterPanel: React.FC<LibraryFilterPanelProps> = ({
   onClose,
 }) => {
   const config = useEditorStore((s) => s.editorConfig);
+  const searchFormConfig = useEditorStore((s) => s.searchFormConfig);
   const { organisationFramework } = useFramework(
     config?.context?.framework as string | undefined,
     config?.context?.targetFWIds as string[] | undefined,
   );
   const [local, setLocal] = useState<LibraryFilters>(filters);
+
+  // Drive the framework-category filter sections from the API search form when
+  // available (codes + labels), else fall back to the hardcoded defaults.
+  const filterSections: Array<{ key: keyof LibraryFilters; label: string }> =
+    searchFormConfig?.length
+      ? searchFormConfig
+          .filter((f) => FRAMEWORK_FILTER_KEYS.has(f.code))
+          .map((f) => ({ key: f.code as keyof LibraryFilters, label: f.label || f.code }))
+      : DEFAULT_FILTER_SECTIONS;
 
   useEffect(() => {
     setLocal(filters);
@@ -96,18 +117,12 @@ export const LibraryFilterPanel: React.FC<LibraryFilterPanelProps> = ({
       </div>
 
       <div className={styles.body}>
-        {(['board', 'medium', 'gradeLevel', 'subject'] as const).map((key) => {
+        {filterSections.map(({ key, label }) => {
           const terms = getTerms(key);
           if (!terms.length) return null;
-          const labels: Record<string, string> = {
-            board: 'Board',
-            medium: 'Medium',
-            gradeLevel: 'Class',
-            subject: 'Subject',
-          };
           return (
             <div key={key} className={styles.section}>
-              <div className={styles.sectionLabel}>{labels[key]}</div>
+              <div className={styles.sectionLabel}>{label}</div>
               <div className={styles.chips}>
                 {terms.slice(0, 20).map((t) => (
                   <button

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react';
+import { X } from 'lucide-react';
+import { useEditorStore } from '../../store/editor.store';
+import { useFramework } from '../../hooks/useFramework';
+import { useAllowedCategories } from '../../hooks/useLibrary';
+import styles from './LibraryFilterPanel.module.scss';
+
+export interface LibraryFilters {
+  board?: string[];
+  medium?: string[];
+  gradeLevel?: string[];
+  subject?: string[];
+  primaryCategory?: string[];
+  contentType?: string[];
+}
+
+interface LibraryFilterPanelProps {
+  isOpen: boolean;
+  filters: LibraryFilters;
+  onApply: (filters: LibraryFilters) => void;
+  onClose: () => void;
+}
+
+// Sub-component so it can call useAllowedCategories (a hook) at the top level
+const AllowedCategorySection: React.FC<{
+  local: LibraryFilters;
+  toggle: (key: keyof LibraryFilters, val: string) => void;
+}> = ({ local, toggle }) => {
+  const categories = useAllowedCategories();
+  if (!categories.length) return null;
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionLabel}>Primary Category</div>
+      <div className={styles.chips}>
+        {categories.map((cat) => (
+          <button
+            key={cat}
+            type="button"
+            className={[
+              styles.chip,
+              (local.primaryCategory ?? []).includes(cat) ? styles.active : '',
+            ].join(' ')}
+            onClick={() => toggle('primaryCategory', cat)}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const LibraryFilterPanel: React.FC<LibraryFilterPanelProps> = ({
+  isOpen,
+  filters,
+  onApply,
+  onClose,
+}) => {
+  const config = useEditorStore((s) => s.editorConfig);
+  const { organisationFramework } = useFramework(
+    config?.context?.framework as string | undefined,
+    config?.context?.targetFWIds as string[] | undefined,
+  );
+  const [local, setLocal] = useState<LibraryFilters>(filters);
+
+  useEffect(() => {
+    setLocal(filters);
+  }, [filters]);
+
+  const toggle = (key: keyof LibraryFilters, val: string) => {
+    setLocal((prev) => {
+      const arr = prev[key] ?? [];
+      const next = arr.includes(val) ? arr.filter((v) => v !== val) : [...arr, val];
+      return { ...prev, [key]: next };
+    });
+  };
+
+  const categories = organisationFramework?.categories ?? [];
+  const getTerms = (code: string) =>
+    categories.find((c) => c.code === code)?.terms ?? [];
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles.panel} role="dialog" aria-label="Filter library" aria-modal="true">
+      <div className={styles.header}>
+        <span className={styles.headerTitle}>Filters</span>
+        <button
+          type="button"
+          className={styles.closeBtn}
+          onClick={onClose}
+          aria-label="Close filters"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        {(['board', 'medium', 'gradeLevel', 'subject'] as const).map((key) => {
+          const terms = getTerms(key);
+          if (!terms.length) return null;
+          const labels: Record<string, string> = {
+            board: 'Board',
+            medium: 'Medium',
+            gradeLevel: 'Class',
+            subject: 'Subject',
+          };
+          return (
+            <div key={key} className={styles.section}>
+              <div className={styles.sectionLabel}>{labels[key]}</div>
+              <div className={styles.chips}>
+                {terms.slice(0, 20).map((t) => (
+                  <button
+                    key={t.identifier}
+                    type="button"
+                    className={[
+                      styles.chip,
+                      (local[key] ?? []).includes(t.name) ? styles.active : '',
+                    ].join(' ')}
+                    onClick={() => toggle(key, t.name)}
+                  >
+                    {t.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+
+        <AllowedCategorySection local={local} toggle={toggle} />
+      </div>
+
+      <div className={styles.footer}>
+        <button
+          type="button"
+          className={styles.resetBtn}
+          onClick={() => setLocal({})}
+        >
+          Reset
+        </button>
+        <button
+          type="button"
+          className={styles.applyBtn}
+          onClick={() => {
+            onApply(local);
+            onClose();
+          }}
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryFilterPanel.tsx
@@ -69,9 +69,11 @@ export const LibraryFilterPanel: React.FC<LibraryFilterPanelProps> = ({
 }) => {
   const config = useEditorStore((s) => s.editorConfig);
   const searchFormConfig = useEditorStore((s) => s.searchFormConfig);
+  const contentFramework = useEditorStore((s) => s.contentFramework);
+  const contentTargetFWIds = useEditorStore((s) => s.contentTargetFWIds);
   const { organisationFramework } = useFramework(
-    config?.context?.framework as string | undefined,
-    config?.context?.targetFWIds as string[] | undefined,
+    (contentFramework ?? config?.context?.framework) as string | undefined,
+    (contentTargetFWIds ?? config?.context?.targetFWIds) as string[] | undefined,
   );
   const [local, setLocal] = useState<LibraryFilters>(filters);
 

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.module.scss
@@ -58,6 +58,9 @@
   flex: 1;
   overflow: hidden;
   min-height: 0;
+  // Must be a flex column so the ContentPlayer (flex:1 1 auto root) gets height.
+  display: flex;
+  flex-direction: column;
 }
 
 .footer {

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.module.scss
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.module.scss
@@ -1,0 +1,115 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: white;
+  border-left: 1px solid var(--sbx-gray-200);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--sbx-gray-100);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sbx-gray-800);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.iconBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--sbx-gray-500);
+  border-radius: var(--sbx-r-sm);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-800);
+  }
+}
+
+.playerArea {
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid var(--sbx-gray-100);
+  flex-shrink: 0;
+}
+
+.addBtn {
+  padding: 8px 20px;
+  font-size: 13px;
+  font-family: var(--sbx-font);
+  font-weight: 600;
+  border: none;
+  border-radius: var(--sbx-r-md);
+  background: var(--sbx-primary);
+  color: white;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:active {
+    opacity: 0.8;
+  }
+}
+
+// Expanded modal overlay
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.modalPanel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 900px;
+  height: 90vh;
+  background: white;
+  border-radius: var(--sbx-r-lg, 10px);
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+}

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
@@ -6,6 +6,8 @@ import type { INode } from '../../types/editor';
 import { ContentPlayer } from '../ContentPlayer';
 import styles from './LibraryPreviewPanel.module.scss';
 
+const QUESTIONSET_MIME = 'application/vnd.sunbird.questionset';
+
 interface LibraryPreviewPanelProps {
   content: IContent | null;
   onAdd: (item: IContent) => void;
@@ -64,7 +66,13 @@ export const LibraryPreviewPanel: React.FC<LibraryPreviewPanelProps> = ({
         </div>
 
         <div className={styles.playerArea}>
-          <ContentPlayer node={node} editorMode="read" type="content" />
+          {/* QuestionSets preview via the QuML player (whole set); everything
+              else goes through the content players. */}
+          <ContentPlayer
+            node={node}
+            editorMode="read"
+            type={content.mimeType === QUESTIONSET_MIME ? 'quml' : 'content'}
+          />
         </div>
 
         <div className={styles.footer}>

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { X, Maximize2, Minimize2 } from 'lucide-react';
+import type { IContent } from '../../types/content';
+import type { INode } from '../../types/editor';
+import { ContentPlayer } from '../ContentPlayer';
+import styles from './LibraryPreviewPanel.module.scss';
+
+interface LibraryPreviewPanelProps {
+  content: IContent | null;
+  onAdd: (item: IContent) => void;
+  onClose: () => void;
+}
+
+export const LibraryPreviewPanel: React.FC<LibraryPreviewPanelProps> = ({
+  content,
+  onAdd,
+  onClose,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!content) return null;
+
+  // Convert IContent to INode shape for ContentPlayer
+  const node: INode = {
+    id: content.identifier,
+    identifier: content.identifier,
+    name: content.name ?? '',
+    mimeType: content.mimeType,
+    primaryCategory: content.primaryCategory,
+    contentType: content.contentType,
+    appIcon: content.appIcon,
+    status: content.status,
+    isFolder: false,
+    children: [],
+    metadata: content as unknown as Record<string, unknown>,
+  };
+
+  const panelContent = (
+    <>
+      <div className={styles.header}>
+        <span className={styles.title} title={content.name}>
+          {content.name}
+        </span>
+        <div className={styles.headerActions}>
+          <button
+            type="button"
+            className={styles.iconBtn}
+            onClick={() => setExpanded(v => !v)}
+            aria-label={expanded ? 'Collapse preview' : 'Expand preview'}
+            title={expanded ? 'Collapse' : 'Expand'}
+          >
+            {expanded ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
+          </button>
+          <button
+            type="button"
+            className={styles.iconBtn}
+            onClick={onClose}
+            aria-label="Close preview"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.playerArea}>
+        <ContentPlayer node={node} editorMode="read" type="content" />
+      </div>
+
+      <div className={styles.footer}>
+        <button
+          type="button"
+          className={styles.addBtn}
+          onClick={() => onAdd(content)}
+        >
+          + Add to Unit
+        </button>
+      </div>
+    </>
+  );
+
+  if (expanded) {
+    return (
+      <div className={styles.modalOverlay} role="dialog" aria-modal="true" aria-label="Content preview">
+        <div className={styles.modalPanel}>
+          {panelContent}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.panel}>
+      {panelContent}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { createPortal } from 'react-dom';
-import { X, Maximize2, Minimize2 } from 'lucide-react';
+import { X } from 'lucide-react';
 import type { IContent } from '../../types/content';
 import type { INode } from '../../types/editor';
 import { ContentPlayer } from '../ContentPlayer';
@@ -12,16 +12,18 @@ interface LibraryPreviewPanelProps {
   onClose: () => void;
 }
 
+/**
+ * Content preview shown when a library item is selected. Opens directly as a
+ * centered modal (portaled to body so it escapes the dock's stacking context).
+ */
 export const LibraryPreviewPanel: React.FC<LibraryPreviewPanelProps> = ({
   content,
   onAdd,
   onClose,
 }) => {
-  const [expanded, setExpanded] = useState(false);
-
   if (!content) return null;
 
-  // Convert IContent to INode — ContentPlayer will fetch full details by identifier
+  // Convert IContent to INode — ContentPlayer fetches full details by identifier
   const node: INode = {
     id: content.identifier,
     identifier: content.identifier,
@@ -36,65 +38,46 @@ export const LibraryPreviewPanel: React.FC<LibraryPreviewPanelProps> = ({
     metadata: content as unknown as Record<string, unknown>,
   };
 
-  const panelContent = (
-    <>
-      <div className={styles.header}>
-        <span className={styles.title} title={content.name}>
-          {content.name}
-        </span>
-        <div className={styles.headerActions}>
+  return createPortal(
+    <div
+      className={styles.modalOverlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Content preview"
+      onClick={onClose}
+    >
+      <div className={styles.modalPanel} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <span className={styles.title} title={content.name}>
+            {content.name}
+          </span>
+          <div className={styles.headerActions}>
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={onClose}
+              aria-label="Close preview"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+
+        <div className={styles.playerArea}>
+          <ContentPlayer node={node} editorMode="read" type="content" />
+        </div>
+
+        <div className={styles.footer}>
           <button
             type="button"
-            className={styles.iconBtn}
-            onClick={() => setExpanded(v => !v)}
-            aria-label={expanded ? 'Collapse preview' : 'Expand preview'}
-            title={expanded ? 'Collapse' : 'Expand'}
+            className={styles.addBtn}
+            onClick={() => onAdd(content)}
           >
-            {expanded ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
-          </button>
-          <button
-            type="button"
-            className={styles.iconBtn}
-            onClick={onClose}
-            aria-label="Close preview"
-          >
-            <X size={16} />
+            + Add to Unit
           </button>
         </div>
       </div>
-
-      <div className={styles.playerArea}>
-        <ContentPlayer node={node} editorMode="read" type="content" />
-      </div>
-
-      <div className={styles.footer}>
-        <button
-          type="button"
-          className={styles.addBtn}
-          onClick={() => onAdd(content)}
-        >
-          + Add to Unit
-        </button>
-      </div>
-    </>
-  );
-
-  if (expanded) {
-    // Portal to body so the modal escapes the library dock's stacking context
-    // (.sidePanelOverlay is a positioned, z-indexed ancestor that would otherwise trap it).
-    return createPortal(
-      <div className={styles.modalOverlay} role="dialog" aria-modal="true" aria-label="Content preview">
-        <div className={styles.modalPanel}>
-          {panelContent}
-        </div>
-      </div>,
-      document.body,
-    );
-  }
-
-  return (
-    <div className={styles.panel}>
-      {panelContent}
-    </div>
+    </div>,
+    document.body,
   );
 };

--- a/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
+++ b/projects/collection-editor-react/src/components/LibraryDock/LibraryPreviewPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { X, Maximize2, Minimize2 } from 'lucide-react';
 import type { IContent } from '../../types/content';
 import type { INode } from '../../types/editor';
@@ -20,7 +21,7 @@ export const LibraryPreviewPanel: React.FC<LibraryPreviewPanelProps> = ({
 
   if (!content) return null;
 
-  // Convert IContent to INode shape for ContentPlayer
+  // Convert IContent to INode — ContentPlayer will fetch full details by identifier
   const node: INode = {
     id: content.identifier,
     identifier: content.identifier,
@@ -79,12 +80,15 @@ export const LibraryPreviewPanel: React.FC<LibraryPreviewPanelProps> = ({
   );
 
   if (expanded) {
-    return (
+    // Portal to body so the modal escapes the library dock's stacking context
+    // (.sidePanelOverlay is a positioned, z-indexed ancestor that would otherwise trap it).
+    return createPortal(
       <div className={styles.modalOverlay} role="dialog" aria-modal="true" aria-label="Content preview">
         <div className={styles.modalPanel}>
           {panelContent}
         </div>
-      </div>
+      </div>,
+      document.body,
     );
   }
 

--- a/projects/collection-editor-react/src/components/LibraryDock/index.ts
+++ b/projects/collection-editor-react/src/components/LibraryDock/index.ts
@@ -1,0 +1,1 @@
+export { LibraryDock } from './LibraryDock';

--- a/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.module.scss
+++ b/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.module.scss
@@ -1,0 +1,122 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+// ── Header bar ────────────────────────────────────────────────
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 6px;
+  height: 40px;
+  border-bottom: 1px solid var(--sbx-gray-200);
+  flex-shrink: 0;
+  background: white;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--sbx-r-sm);
+  color: var(--sbx-gray-500);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-800);
+  }
+}
+
+// ── 3-dot dropdown ────────────────────────────────────────────
+.menuWrap {
+  position: relative;
+}
+
+.dropdownMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 200;
+  min-width: 220px;
+  background: white;
+  border: 1px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-md);
+  box-shadow: var(--sbx-shadow-2, 0 4px 16px rgba(0,0,0,0.12));
+  padding: 4px 0;
+  overflow: hidden;
+
+  button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 9px 14px;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--sbx-gray-700);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.1s;
+
+    &:hover {
+      background: var(--sbx-gray-50);
+      color: var(--sbx-gray-900);
+    }
+  }
+}
+
+// ── Tree area ─────────────────────────────────────────────────
+.treeWrapper {
+  flex: 1;
+  overflow: hidden;
+  padding: 4px 0;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--sbx-gray-300);
+    border-radius: 2px;
+  }
+}
+
+// ── CSV modal overlay ─────────────────────────────────────────
+.csvModal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// ── Footer ────────────────────────────────────────────────────
+.footer {
+  border-top: 1px solid var(--sbx-gray-200);
+  padding: 10px 12px;
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}

--- a/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
@@ -10,6 +10,7 @@ import { TreeNode } from './TreeNode';
 import { Button } from '../shared/Button';
 import { CsvUpload } from '../BulkUpload/CsvUpload';
 import { exportFolderCsv } from '../../api/bulkUpload';
+import { readHierarchy } from '../../api/hierarchy';
 import styles from './OutlineTree.module.scss';
 
 interface OutlineTreeProps {
@@ -31,11 +32,14 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
   const [showCsvUpload, setShowCsvUpload] = useState(false);
   const [csvMode, setCsvMode] = useState<'create' | 'update'>('create');
 
-  const { treeData, selectedNodeId, selectNode, addNode, deleteNode, reorderChildren } = useTreeStore();
+  const { treeData, selectedNodeId, selectNode, addNode, deleteNode, reorderChildren, setTreeData } = useTreeStore();
   const isEditable = editorMode === 'edit';
   const isDraft = useIsDraftStatus();
   // Adding units/content is only allowed while the collection is in Draft.
   const canAdd = isEditable && isDraft;
+  // Mirror Angular: "Create" is only useful when no folders exist yet;
+  // "Download/Update" only make sense when folders already exist.
+  const hasFolders = (treeData[0]?.children ?? []).some(c => c.isFolder);
   const contentId = useEditorStore(
     s => s.editorConfig?.context?.contentId ?? s.editorConfig?.context?.identifier ?? '',
   );
@@ -117,19 +121,36 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
     setShowMenu(false);
     if (!contentId) return;
     try {
-      // The export API returns a pre-signed URL to the generated CSV.
       const tocUrl = await exportFolderCsv(contentId);
+      // Blob-convert so download works regardless of server Content-Disposition header
+      const blob = await fetch(tocUrl).then(r => r.blob());
+      const objectUrl = URL.createObjectURL(blob);
       const a = document.createElement('a');
-      a.href = tocUrl;
+      a.href = objectUrl;
       a.download = `${contentId}-folders.csv`;
-      a.target = '_blank';
+      a.style.display = 'none';
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
+      URL.revokeObjectURL(objectUrl);
     } catch {
       toast.error('Failed to download CSV');
     }
   }, [contentId]);
+
+  // After CSV upload succeeds, re-fetch the hierarchy so the tree reflects
+  // the newly created/updated folders without requiring a page reload.
+  const handleCsvComplete = useCallback(async () => {
+    setShowCsvUpload(false);
+    if (!contentId) return;
+    try {
+      const { rootNode } = await readHierarchy(contentId);
+      setTreeData([rootNode]);
+      toast.success('Course outline refreshed.');
+    } catch {
+      toast.error('Outline could not be refreshed automatically. Please reload the page.');
+    }
+  }, [contentId, setTreeData]);
 
   return (
     <div className={styles.container}>
@@ -155,6 +176,8 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
                   <button
                     role="menuitem"
                     type="button"
+                    disabled={hasFolders}
+                    title={hasFolders ? 'Folders already exist — use "Update" instead' : undefined}
                     onClick={() => { setShowMenu(false); setCsvMode('create'); setShowCsvUpload(true); }}
                   >
                     Create folders using csv file
@@ -162,6 +185,8 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
                   <button
                     role="menuitem"
                     type="button"
+                    disabled={!hasFolders}
+                    title={!hasFolders ? 'No folders yet — use "Create" first' : undefined}
                     onClick={handleDownloadCsv}
                   >
                     Download folders as csv file
@@ -169,6 +194,8 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
                   <button
                     role="menuitem"
                     type="button"
+                    disabled={!hasFolders}
+                    title={!hasFolders ? 'No folders yet — use "Create" first' : undefined}
                     onClick={() => { setShowMenu(false); setCsvMode('update'); setShowCsvUpload(true); }}
                   >
                     Update folder metadata using csv file
@@ -243,7 +270,7 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
           <CsvUpload
             contentId={contentId}
             mode={csvMode}
-            onComplete={() => setShowCsvUpload(false)}
+            onComplete={handleCsvComplete}
             onClose={() => setShowCsvUpload(false)}
           />
         </div>

--- a/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
@@ -44,6 +44,13 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
     s => s.editorConfig?.context?.contentId ?? s.editorConfig?.context?.identifier ?? '',
   );
 
+  // enableBulkUpload from sourcingSettings controls CSV menu visibility.
+  // Default to true when the category definition hasn't loaded yet.
+  const enableBulkUpload = useEditorStore(s => {
+    const sourcing = s.categoryMeta?.sourcingSettings?.collection as Record<string, unknown> | undefined;
+    return sourcing?.enableBulkUpload !== false;
+  });
+
   // Measure wrapper height for react-arborist virtualization
   useEffect(() => {
     const el = wrapperRef.current;
@@ -173,33 +180,37 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
 
               {showMenu && (
                 <div className={styles.dropdownMenu} role="menu">
-                  <button
-                    role="menuitem"
-                    type="button"
-                    disabled={hasFolders}
-                    title={hasFolders ? 'Folders already exist — use "Update" instead' : undefined}
-                    onClick={() => { setShowMenu(false); setCsvMode('create'); setShowCsvUpload(true); }}
-                  >
-                    Create folders using csv file
-                  </button>
-                  <button
-                    role="menuitem"
-                    type="button"
-                    disabled={!hasFolders}
-                    title={!hasFolders ? 'No folders yet — use "Create" first' : undefined}
-                    onClick={handleDownloadCsv}
-                  >
-                    Download folders as csv file
-                  </button>
-                  <button
-                    role="menuitem"
-                    type="button"
-                    disabled={!hasFolders}
-                    title={!hasFolders ? 'No folders yet — use "Create" first' : undefined}
-                    onClick={() => { setShowMenu(false); setCsvMode('update'); setShowCsvUpload(true); }}
-                  >
-                    Update folder metadata using csv file
-                  </button>
+                  {enableBulkUpload && (
+                    <>
+                      <button
+                        role="menuitem"
+                        type="button"
+                        disabled={hasFolders}
+                        title={hasFolders ? 'Folders already exist — use "Update" instead' : undefined}
+                        onClick={() => { setShowMenu(false); setCsvMode('create'); setShowCsvUpload(true); }}
+                      >
+                        Create folders using csv file
+                      </button>
+                      <button
+                        role="menuitem"
+                        type="button"
+                        disabled={!hasFolders}
+                        title={!hasFolders ? 'No folders yet — use "Create" first' : undefined}
+                        onClick={handleDownloadCsv}
+                      >
+                        Download folders as csv file
+                      </button>
+                      <button
+                        role="menuitem"
+                        type="button"
+                        disabled={!hasFolders}
+                        title={!hasFolders ? 'No folders yet — use "Create" first' : undefined}
+                        onClick={() => { setShowMenu(false); setCsvMode('update'); setShowCsvUpload(true); }}
+                      >
+                        Update folder metadata using csv file
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
@@ -8,7 +8,7 @@ import { useEditorStore } from '../../store/editor.store';
 import { TreeNode } from './TreeNode';
 import { Button } from '../shared/Button';
 import { CsvUpload } from '../BulkUpload/CsvUpload';
-import { downloadSampleCsv } from '../../api/bulkUpload';
+import { exportFolderCsv } from '../../api/bulkUpload';
 import styles from './OutlineTree.module.scss';
 
 interface OutlineTreeProps {
@@ -113,15 +113,15 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
     setShowMenu(false);
     if (!contentId) return;
     try {
-      const blob = await downloadSampleCsv(contentId);
-      const url = URL.createObjectURL(blob);
+      // The export API returns a pre-signed URL to the generated CSV.
+      const tocUrl = await exportFolderCsv(contentId);
       const a = document.createElement('a');
-      a.href = url;
+      a.href = tocUrl;
       a.download = `${contentId}-folders.csv`;
+      a.target = '_blank';
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
-      URL.revokeObjectURL(url);
     } catch {
       toast.error('Failed to download CSV');
     }

--- a/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast';
 import type { INode, EditorMode } from '../../types/editor';
 import { useTreeStore } from '../../store/tree.store';
 import { useEditorStore } from '../../store/editor.store';
+import { useIsDraftStatus } from '../../hooks/useContentStatus';
 import { TreeNode } from './TreeNode';
 import { Button } from '../shared/Button';
 import { CsvUpload } from '../BulkUpload/CsvUpload';
@@ -32,6 +33,9 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
 
   const { treeData, selectedNodeId, selectNode, addNode, deleteNode, reorderChildren } = useTreeStore();
   const isEditable = editorMode === 'edit';
+  const isDraft = useIsDraftStatus();
+  // Adding units/content is only allowed while the collection is in Draft.
+  const canAdd = isEditable && isDraft;
   const contentId = useEditorStore(
     s => s.editorConfig?.context?.contentId ?? s.editorConfig?.context?.identifier ?? '',
   );
@@ -215,14 +219,19 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
 
       {isEditable && (
         <div className={styles.footer}>
-          <Button variant="ghost" size="sm" onClick={handleAddUnit}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleAddUnit}
+            disabled={!canAdd}
+          >
             <Plus size={14} /> Add Unit
           </Button>
           <Button
             variant="ghost"
             size="sm"
             onClick={handleAddSubunit}
-            disabled={!selectedNodeId}
+            disabled={!canAdd || !selectedNodeId}
           >
             <FolderPlus size={14} /> Add Sub-unit
           </Button>

--- a/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
@@ -32,7 +32,7 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
   const [showCsvUpload, setShowCsvUpload] = useState(false);
   const [csvMode, setCsvMode] = useState<'create' | 'update'>('create');
 
-  const { treeData, selectedNodeId, selectNode, addNode, deleteNode, reorderChildren, setTreeData } = useTreeStore();
+  const { treeData, selectedNodeId, selectNode, addNode, deleteNode, reorderChildren, moveNode, setTreeData } = useTreeStore();
   const isEditable = editorMode === 'edit';
   const isDraft = useIsDraftStatus();
   // Adding units/content is only allowed while the collection is in Draft.
@@ -81,13 +81,23 @@ export const OutlineTree: React.FC<OutlineTreeProps> = ({
     ({ parentId, index, dragIds }: { parentId: string | null; index: number; dragIds: string[] }) => {
       if (!parentId) return;
       const nodeId = dragIds[0];
-      const parent = findNode(treeData, parentId);
-      if (!parent?.children) return;
-      const fromIndex = parent.children.findIndex((c) => c.id === nodeId);
-      if (fromIndex < 0) return;
-      reorderChildren(parentId, fromIndex, index > fromIndex ? index - 1 : index);
+      const sourceNode = findNode(treeData, nodeId);
+      if (!sourceNode) return;
+      const sourceParentId = sourceNode.parent;
+
+      if (sourceParentId === parentId) {
+        // Same parent: reorder within the folder
+        const parent = findNode(treeData, parentId);
+        if (!parent?.children) return;
+        const fromIndex = parent.children.findIndex((c) => c.id === nodeId);
+        if (fromIndex < 0) return;
+        reorderChildren(parentId, fromIndex, index > fromIndex ? index - 1 : index);
+      } else {
+        // Cross-folder: move to destination parent
+        moveNode(nodeId, sourceParentId ?? '', parentId);
+      }
     },
-    [treeData, reorderChildren],
+    [treeData, reorderChildren, moveNode],
   );
 
   const handleDelete = useCallback(

--- a/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/OutlineTree.tsx
@@ -1,0 +1,255 @@
+import React, { useCallback, useRef, useState, useEffect } from 'react';
+import { Tree, type NodeRendererProps, type TreeApi } from 'react-arborist';
+import { Plus, FolderPlus, MoreVertical, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import toast from 'react-hot-toast';
+import type { INode, EditorMode } from '../../types/editor';
+import { useTreeStore } from '../../store/tree.store';
+import { useEditorStore } from '../../store/editor.store';
+import { TreeNode } from './TreeNode';
+import { Button } from '../shared/Button';
+import { CsvUpload } from '../BulkUpload/CsvUpload';
+import { downloadSampleCsv } from '../../api/bulkUpload';
+import styles from './OutlineTree.module.scss';
+
+interface OutlineTreeProps {
+  editorMode: EditorMode;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}
+
+export const OutlineTree: React.FC<OutlineTreeProps> = ({
+  editorMode,
+  collapsed = false,
+  onToggleCollapse,
+}) => {
+  const treeRef = useRef<TreeApi<INode>>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [treeHeight, setTreeHeight] = useState(400);
+  const [showMenu, setShowMenu] = useState(false);
+  const [showCsvUpload, setShowCsvUpload] = useState(false);
+  const [csvMode, setCsvMode] = useState<'create' | 'update'>('create');
+
+  const { treeData, selectedNodeId, selectNode, addNode, deleteNode, reorderChildren } = useTreeStore();
+  const isEditable = editorMode === 'edit';
+  const contentId = useEditorStore(
+    s => s.editorConfig?.context?.contentId ?? s.editorConfig?.context?.identifier ?? '',
+  );
+
+  // Measure wrapper height for react-arborist virtualization
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      setTreeHeight(el.clientHeight || 400);
+    });
+    ro.observe(el);
+    setTreeHeight(el.clientHeight || 400);
+    return () => ro.disconnect();
+  }, []);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!showMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setShowMenu(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showMenu]);
+
+  const handleSelect = useCallback((nodes: { data: INode }[]) => {
+    if (nodes.length > 0) selectNode(nodes[0].data.id);
+  }, [selectNode]);
+
+  const handleMove = useCallback(
+    ({ parentId, index, dragIds }: { parentId: string | null; index: number; dragIds: string[] }) => {
+      if (!parentId) return;
+      const nodeId = dragIds[0];
+      const parent = findNode(treeData, parentId);
+      if (!parent?.children) return;
+      const fromIndex = parent.children.findIndex((c) => c.id === nodeId);
+      if (fromIndex < 0) return;
+      reorderChildren(parentId, fromIndex, index > fromIndex ? index - 1 : index);
+    },
+    [treeData, reorderChildren],
+  );
+
+  const handleDelete = useCallback(
+    ({ ids }: { ids: string[] }) => { ids.forEach((id) => deleteNode(id)); },
+    [deleteNode],
+  );
+
+  const handleCreate = useCallback(
+    ({ parentId }: { parentId: string | null; index?: number; type?: string }) => {
+      const resolvedParentId = parentId ?? treeData[0]?.id ?? '';
+      if (!resolvedParentId) return { id: crypto.randomUUID() };
+      const id = addNode(resolvedParentId, 'unit');
+      if (!id) {
+        toast.error('Maximum depth reached');
+        return { id: crypto.randomUUID() };
+      }
+      return { id };
+    },
+    [addNode, treeData],
+  );
+
+  const handleAddUnit = useCallback(() => {
+    const rootId = treeData[0]?.id;
+    if (rootId) {
+      const id = addNode(rootId, 'unit');
+      if (!id) toast.error('Maximum depth reached');
+    }
+  }, [treeData, addNode]);
+
+  const handleAddSubunit = useCallback(() => {
+    if (selectedNodeId) {
+      const id = addNode(selectedNodeId, 'subunit');
+      if (!id) toast.error('Maximum depth reached');
+    }
+  }, [selectedNodeId, addNode]);
+
+  const handleDownloadCsv = useCallback(async () => {
+    setShowMenu(false);
+    if (!contentId) return;
+    try {
+      const blob = await downloadSampleCsv(contentId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${contentId}-folders.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      toast.error('Failed to download CSV');
+    }
+  }, [contentId]);
+
+  return (
+    <div className={styles.container}>
+      {/* Header bar */}
+      <div className={styles.header}>
+        <div className={styles.headerActions}>
+          {isEditable && (
+            <div className={styles.menuWrap} ref={menuRef}>
+              <button
+                type="button"
+                className={styles.iconBtn}
+                onClick={() => setShowMenu(v => !v)}
+                aria-label="More options"
+                title="More options"
+                aria-haspopup="true"
+                aria-expanded={showMenu}
+              >
+                <MoreVertical size={15} />
+              </button>
+
+              {showMenu && (
+                <div className={styles.dropdownMenu} role="menu">
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={() => { setShowMenu(false); setCsvMode('create'); setShowCsvUpload(true); }}
+                  >
+                    Create folders using csv file
+                  </button>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={handleDownloadCsv}
+                  >
+                    Download folders as csv file
+                  </button>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={() => { setShowMenu(false); setCsvMode('update'); setShowCsvUpload(true); }}
+                  >
+                    Update folder metadata using csv file
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {onToggleCollapse && (
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={onToggleCollapse}
+              aria-label={collapsed ? 'Expand outline' : 'Collapse outline'}
+              title={collapsed ? 'Expand outline' : 'Collapse outline'}
+            >
+              {collapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.treeWrapper} ref={wrapperRef}>
+        <Tree
+          ref={treeRef}
+          data={treeData}
+          idAccessor="id"
+          childrenAccessor="children"
+          onSelect={handleSelect}
+          onMove={isEditable ? handleMove : undefined}
+          onDelete={isEditable ? handleDelete : undefined}
+          onCreate={isEditable ? handleCreate : undefined}
+          disableEdit={!isEditable}
+          disableDrop={!isEditable}
+          selection={selectedNodeId ?? undefined}
+          rowHeight={40}
+          indent={20}
+          paddingBottom={16}
+          height={treeHeight}
+          width="100%"
+        >
+          {(props: NodeRendererProps<INode>) => (
+            <TreeNode {...props} editorMode={editorMode} />
+          )}
+        </Tree>
+      </div>
+
+      {isEditable && (
+        <div className={styles.footer}>
+          <Button variant="ghost" size="sm" onClick={handleAddUnit}>
+            <Plus size={14} /> Add Unit
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleAddSubunit}
+            disabled={!selectedNodeId}
+          >
+            <FolderPlus size={14} /> Add Sub-unit
+          </Button>
+        </div>
+      )}
+
+      {showCsvUpload && (
+        <div className={styles.csvModal}>
+          <CsvUpload
+            contentId={contentId}
+            mode={csvMode}
+            onComplete={() => setShowCsvUpload(false)}
+            onClose={() => setShowCsvUpload(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+function findNode(nodes: INode[], id: string): INode | undefined {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    if (node.children) {
+      const found = findNode(node.children, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}

--- a/projects/collection-editor-react/src/components/OutlineTree/TreeNode.module.scss
+++ b/projects/collection-editor-react/src/components/OutlineTree/TreeNode.module.scss
@@ -88,6 +88,7 @@
 
 .title {
   flex: 1;
+  min-width: 0;
   font-size: 13px;
   color: var(--sbx-gray-700);
   overflow: hidden;

--- a/projects/collection-editor-react/src/components/OutlineTree/TreeNode.module.scss
+++ b/projects/collection-editor-react/src/components/OutlineTree/TreeNode.module.scss
@@ -80,6 +80,12 @@
   font-size: 10px;
 }
 
+// Root (Book) and Unit/Sub-Unit (Folder) icons — neutral accent.
+.folderIcon {
+  background: var(--sbx-primary, #2563eb);
+  color: white;
+}
+
 .title {
   flex: 1;
   font-size: 13px;

--- a/projects/collection-editor-react/src/components/OutlineTree/TreeNode.module.scss
+++ b/projects/collection-editor-react/src/components/OutlineTree/TreeNode.module.scss
@@ -1,0 +1,168 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  cursor: pointer;
+  border-radius: var(--sbx-r-sm);
+  margin: 1px 4px;
+  position: relative;
+  transition: background 0.1s;
+  height: 38px;
+
+  &:hover {
+    background: var(--sbx-gray-50);
+
+    .grip {
+      opacity: 1;
+    }
+
+    .menuBtn {
+      opacity: 1;
+    }
+  }
+}
+
+.selected {
+  background: var(--sbx-primary-light);
+  border-left: 3px solid var(--sbx-primary);
+  padding-left: 5px;
+
+  .title {
+    color: var(--sbx-primary);
+    font-weight: 600;
+  }
+}
+
+.dropTarget {
+  background: var(--sbx-primary-light);
+  border: 1.5px dashed var(--sbx-primary);
+}
+
+.grip {
+  color: var(--sbx-gray-300);
+  cursor: grab;
+  display: flex;
+  opacity: 0;
+  flex-shrink: 0;
+  transition: opacity 0.1s;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  color: var(--sbx-gray-500);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  border-radius: var(--sbx-r-xs);
+
+  &:hover {
+    background: var(--sbx-gray-200);
+  }
+}
+
+.ctIcon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--sbx-r-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 10px;
+}
+
+.title {
+  flex: 1;
+  font-size: 13px;
+  color: var(--sbx-gray-700);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.renameInput {
+  flex: 1;
+  font-size: 13px;
+  border: 1.5px solid var(--sbx-primary);
+  border-radius: var(--sbx-r-xs);
+  padding: 2px 6px;
+  outline: none;
+}
+
+.dropHere {
+  font-size: 11px;
+  color: var(--sbx-primary);
+  font-weight: 600;
+  flex-shrink: 0;
+  background: var(--sbx-primary-light);
+  padding: 2px 8px;
+  border-radius: var(--sbx-r-xl);
+}
+
+.menuWrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.menuBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: var(--sbx-gray-400);
+  display: flex;
+  align-items: center;
+  border-radius: var(--sbx-r-xs);
+  opacity: 0;
+  transition: opacity 0.1s;
+
+  &:hover {
+    background: var(--sbx-gray-100);
+    color: var(--sbx-gray-700);
+  }
+}
+
+.menu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 100;
+  background: white;
+  border: 1px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-md);
+  box-shadow: var(--sbx-shadow-3);
+  min-width: 160px;
+  padding: 4px;
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 12px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--sbx-gray-700);
+    border-radius: var(--sbx-r-sm);
+    text-align: left;
+
+    &:hover {
+      background: var(--sbx-gray-50);
+    }
+  }
+}
+
+.dangerItem {
+  color: var(--sbx-error) !important;
+}

--- a/projects/collection-editor-react/src/components/OutlineTree/TreeNode.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/TreeNode.tsx
@@ -1,0 +1,215 @@
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { type NodeRendererProps } from 'react-arborist';
+import {
+  ChevronRight,
+  ChevronDown,
+  GripVertical,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Trash2,
+  FolderPlus,
+  Video,
+  FileText,
+  Layers,
+  Package,
+  Music,
+  HelpCircle,
+  File,
+} from 'lucide-react';
+import type { INode, EditorMode } from '../../types/editor';
+import { getCtStyle } from '../../hooks/useContentType';
+import styles from './TreeNode.module.scss';
+
+const CT_ICON_COMPONENTS: Record<string, React.ElementType> = {
+  video: Video,
+  pdf: FileText,
+  h5p: Layers,
+  scorm: Package,
+  audio: Music,
+  quiz: HelpCircle,
+  default: File,
+};
+
+interface TreeNodeProps extends NodeRendererProps<INode> {
+  editorMode: EditorMode;
+}
+
+export const TreeNode: React.FC<TreeNodeProps> = ({
+  node,
+  style,
+  dragHandle,
+  editorMode,
+}) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameVal, setRenameVal] = useState(node.data.name);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const isEditable = editorMode === 'edit';
+  const ctStyle = getCtStyle(node.data);
+  const CtIcon = CT_ICON_COMPONENTS[ctStyle.key] ?? File;
+  const isSelected = node.isSelected;
+  const isFolder =
+    node.data.isFolder ?? (node.children && node.children.length > 0);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [menuOpen]);
+
+  const handleRenameSubmit = useCallback(() => {
+    if (renameVal.trim()) node.submit(renameVal.trim());
+    setIsRenaming(false);
+  }, [renameVal, node]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') handleRenameSubmit();
+      if (e.key === 'Escape') {
+        setRenameVal(node.data.name);
+        setIsRenaming(false);
+      }
+    },
+    [handleRenameSubmit, node.data.name],
+  );
+
+  return (
+    <div
+      className={[
+        styles.row,
+        isSelected ? styles.selected : '',
+        (node.state as unknown as Record<string, boolean>).isOver && isFolder ? styles.dropTarget : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={style}
+      onClick={() => node.select()}
+      data-node-id={node.data.id}
+      data-droppable={isFolder ? 'true' : undefined}
+      role="treeitem"
+      aria-selected={isSelected}
+      aria-expanded={isFolder ? !node.isClosed : undefined}
+    >
+      {/* Drag handle */}
+      {isEditable && (
+        <span ref={dragHandle} className={styles.grip} aria-hidden="true">
+          <GripVertical size={14} />
+        </span>
+      )}
+
+      {/* Expand toggle */}
+      <button
+        className={styles.toggle}
+        onClick={(e) => {
+          e.stopPropagation();
+          node.toggle();
+        }}
+        aria-label={node.isClosed ? 'Expand' : 'Collapse'}
+        style={{ visibility: isFolder ? 'visible' : 'hidden' }}
+      >
+        {node.isClosed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {/* Content-type icon */}
+      <span
+        className={`${styles.ctIcon} ${ctStyle.bgClass}`}
+        aria-hidden="true"
+      >
+        <CtIcon size={12} />
+      </span>
+
+      {/* Title or rename input */}
+      {isRenaming ? (
+        <input
+          className={styles.renameInput}
+          value={renameVal}
+          autoFocus
+          onChange={(e) => setRenameVal(e.target.value)}
+          onBlur={handleRenameSubmit}
+          onKeyDown={handleKeyDown}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        <span
+          className={styles.title}
+          onDoubleClick={() => isEditable && setIsRenaming(true)}
+        >
+          {node.data.name}
+        </span>
+      )}
+
+      {/* "Drop here" marker (visible when drag is over this folder) */}
+      {(node.state as unknown as Record<string, boolean>).isOver && isFolder && (
+        <span className={styles.dropHere} aria-hidden="true">
+          Drop here
+        </span>
+      )}
+
+      {/* Context menu button */}
+      {isEditable && (
+        <div className={styles.menuWrap} ref={menuRef}>
+          <button
+            className={styles.menuBtn}
+            onClick={(e) => {
+              e.stopPropagation();
+              setMenuOpen((v) => !v);
+            }}
+            aria-label="Node options"
+          >
+            <MoreVertical size={14} />
+          </button>
+          {menuOpen && (
+            <div className={styles.menu} role="menu">
+              <button
+                role="menuitem"
+                onClick={() => {
+                  setIsRenaming(true);
+                  setMenuOpen(false);
+                }}
+              >
+                <Pencil size={13} /> Rename
+              </button>
+              {isFolder && (
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    node.tree.create({ parentId: node.id });
+                    setMenuOpen(false);
+                  }}
+                >
+                  <FolderPlus size={13} /> Add sub-unit
+                </button>
+              )}
+              {node.data.parent && (
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    node.tree.create({ parentId: node.data.parent as string });
+                    setMenuOpen(false);
+                  }}
+                >
+                  <Plus size={13} /> Add Sibling
+                </button>
+              )}
+              <button
+                role="menuitem"
+                className={styles.dangerItem}
+                onClick={() => {
+                  node.tree.delete(node.id);
+                  setMenuOpen(false);
+                }}
+              >
+                <Trash2 size={13} /> Delete
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/OutlineTree/TreeNode.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/TreeNode.tsx
@@ -144,9 +144,10 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
       ) : (
         <span
           className={styles.title}
+          title={node.data.name}
           onDoubleClick={() => isEditable && setIsRenaming(true)}
         >
-          {node.data.name}
+          {node.data.name.length > 25 ? `${node.data.name.slice(0, 25)}...` : node.data.name}
         </span>
       )}
 

--- a/projects/collection-editor-react/src/components/OutlineTree/TreeNode.tsx
+++ b/projects/collection-editor-react/src/components/OutlineTree/TreeNode.tsx
@@ -9,6 +9,8 @@ import {
   Plus,
   Trash2,
   FolderPlus,
+  Book,
+  Folder,
   Video,
   FileText,
   Layers,
@@ -19,6 +21,7 @@ import {
 } from 'lucide-react';
 import type { INode, EditorMode } from '../../types/editor';
 import { getCtStyle } from '../../hooks/useContentType';
+import { useIsDraftStatus } from '../../hooks/useContentStatus';
 import styles from './TreeNode.module.scss';
 
 const CT_ICON_COMPONENTS: Record<string, React.ElementType> = {
@@ -46,11 +49,15 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
   const [renameVal, setRenameVal] = useState(node.data.name);
   const menuRef = useRef<HTMLDivElement>(null);
   const isEditable = editorMode === 'edit';
+  const isDraft = useIsDraftStatus();
   const ctStyle = getCtStyle(node.data);
   const CtIcon = CT_ICON_COMPONENTS[ctStyle.key] ?? File;
   const isSelected = node.isSelected;
+  const isRoot = node.level === 0;
   const isFolder =
     node.data.isFolder ?? (node.children && node.children.length > 0);
+  // Root (Course) → Book, Unit/Sub-Unit (folders) → Folder, leaf → content-type icon.
+  const NodeIcon = isRoot ? Book : isFolder ? Folder : CtIcon;
 
   // Close menu on outside click
   useEffect(() => {
@@ -115,12 +122,12 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         {node.isClosed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
       </button>
 
-      {/* Content-type icon */}
+      {/* Node icon: Book (root) / Folder (unit) / content-type (leaf) */}
       <span
-        className={`${styles.ctIcon} ${ctStyle.bgClass}`}
+        className={`${styles.ctIcon} ${isRoot || isFolder ? styles.folderIcon ?? '' : ctStyle.bgClass}`}
         aria-hidden="true"
       >
-        <CtIcon size={12} />
+        <NodeIcon size={12} />
       </span>
 
       {/* Title or rename input */}
@@ -174,7 +181,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
               >
                 <Pencil size={13} /> Rename
               </button>
-              {isFolder && (
+              {isFolder && isDraft && (
                 <button
                   role="menuitem"
                   onClick={() => {
@@ -185,7 +192,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
                   <FolderPlus size={13} /> Add sub-unit
                 </button>
               )}
-              {node.data.parent && (
+              {node.data.parent && isDraft && (
                 <button
                   role="menuitem"
                   onClick={() => {

--- a/projects/collection-editor-react/src/components/OutlineTree/index.ts
+++ b/projects/collection-editor-react/src/components/OutlineTree/index.ts
@@ -1,0 +1,1 @@
+export { OutlineTree } from './OutlineTree';

--- a/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.module.scss
+++ b/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.module.scss
@@ -1,0 +1,11 @@
+.container { background: #fafafa; border: 1px solid #e8e8e8; border-radius: 6px; margin-top: 12px; }
+.toggle { display: flex; align-items: center; gap: 6px; width: 100%; padding: 10px 12px; background: none; border: none; cursor: pointer; font-size: 13px; font-weight: 500; }
+.dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.green { background: #52c41a; }
+.yellow { background: #faad14; }
+.list { padding: 4px 12px 12px; }
+.row { margin-bottom: 10px; }
+.rowLabel { display: flex; justify-content: space-between; font-size: 12px; margin-bottom: 4px; }
+.count { color: #888; }
+.track { height: 6px; background: #f0f0f0; border-radius: 3px; overflow: hidden; }
+.bar { height: 100%; border-radius: 3px; transition: width 0.3s; }

--- a/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.module.scss
+++ b/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.module.scss
@@ -1,11 +1,11 @@
-.container { background: #fafafa; border: 1px solid #e8e8e8; border-radius: 6px; margin-top: 12px; }
+.container { background: var(--sbx-gray-50); border: 1px solid var(--sbx-gray-200); border-radius: var(--sbx-r-sm); margin-top: 12px; }
 .toggle { display: flex; align-items: center; gap: 6px; width: 100%; padding: 10px 12px; background: none; border: none; cursor: pointer; font-size: 13px; font-weight: 500; }
 .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-.green { background: #52c41a; }
-.yellow { background: #faad14; }
+.green { background: var(--sbx-success); }
+.yellow { background: var(--sbx-warning); }
 .list { padding: 4px 12px 12px; }
 .row { margin-bottom: 10px; }
 .rowLabel { display: flex; justify-content: space-between; font-size: 12px; margin-bottom: 4px; }
-.count { color: #888; }
-.track { height: 6px; background: #f0f0f0; border-radius: 3px; overflow: hidden; }
+.count { color: var(--sbx-gray-500); }
+.track { height: 6px; background: var(--sbx-gray-100); border-radius: 3px; overflow: hidden; }
 .bar { height: 100%; border-radius: 3px; transition: width 0.3s; }

--- a/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.tsx
+++ b/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.tsx
@@ -42,9 +42,9 @@ export const ProgressStatus: React.FC<ProgressStatusProps> = ({ criteria }) => {
 
   const allGood = computed.every(c => c.current >= c.required);
   const barColor = (c: Criterion) => {
-    if (c.current >= c.required) return '#52c41a';
-    if (c.current / c.required > 0.5) return '#faad14';
-    return '#ff4d4f';
+    if (c.current >= c.required) return 'var(--sbx-success)';
+    if (c.current / c.required > 0.5) return 'var(--sbx-warning)';
+    return 'var(--sbx-error)';
   };
 
   return (

--- a/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.tsx
+++ b/projects/collection-editor-react/src/components/ProgressStatus/ProgressStatus.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useTreeStore } from '../../store/tree.store';
+import type { INode } from '../../types/editor';
+import styles from './ProgressStatus.module.scss';
+
+interface Criterion {
+  label: string;
+  current: number;
+  required: number;
+}
+
+interface ProgressStatusProps {
+  criteria?: Criterion[];
+}
+
+function countNodes(nodes: INode[], isFolder: boolean): number {
+  let count = 0;
+  const walk = (ns: INode[]) => {
+    for (const n of ns) {
+      if (!!n.isFolder === isFolder) count++;
+      if (n.children?.length) walk(n.children);
+    }
+  };
+  walk(nodes);
+  return count;
+}
+
+export const ProgressStatus: React.FC<ProgressStatusProps> = ({ criteria }) => {
+  const [open, setOpen] = useState(false);
+  const { treeData } = useTreeStore();
+
+  const computed = useMemo<Criterion[]>(() => {
+    if (criteria) return criteria;
+    const units = countNodes(treeData, true);
+    const content = countNodes(treeData, false);
+    return [
+      { label: 'Units added', current: units, required: 1 },
+      { label: 'Content items', current: content, required: 1 },
+    ];
+  }, [criteria, treeData]);
+
+  const allGood = computed.every(c => c.current >= c.required);
+  const barColor = (c: Criterion) => {
+    if (c.current >= c.required) return '#52c41a';
+    if (c.current / c.required > 0.5) return '#faad14';
+    return '#ff4d4f';
+  };
+
+  return (
+    <div className={styles.container}>
+      <button className={styles.toggle} onClick={() => setOpen(v => !v)}>
+        <span className={`${styles.dot} ${allGood ? styles.green : styles.yellow}`} />
+        <span>Progress</span>
+        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+      </button>
+      {open && (
+        <div className={styles.list}>
+          {computed.map(c => (
+            <div key={c.label} className={styles.row}>
+              <div className={styles.rowLabel}>
+                <span>{c.label}</span>
+                <span className={styles.count}>{c.current} / {c.required}</span>
+              </div>
+              <div className={styles.track}>
+                <div
+                  className={styles.bar}
+                  style={{
+                    width: `${Math.min(100, (c.current / Math.max(c.required, 1)) * 100)}%`,
+                    background: barColor(c),
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/ProgressStatus/index.ts
+++ b/projects/collection-editor-react/src/components/ProgressStatus/index.ts
@@ -1,0 +1,1 @@
+export { ProgressStatus } from './ProgressStatus';

--- a/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.module.scss
+++ b/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.module.scss
@@ -1,13 +1,13 @@
 .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; }
-.modal { background: #fff; border-radius: 8px; width: 440px; max-height: 70vh; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
-.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid #e8e8e8; }
+.modal { background: #fff; border-radius: var(--sbx-r-md); width: 440px; max-height: 70vh; display: flex; flex-direction: column; box-shadow: var(--sbx-shadow-3); }
+.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid var(--sbx-gray-200); }
 .header button { background: none; border: none; cursor: pointer; }
 .body { padding: 16px; overflow-y: auto; flex: 1; }
-.hint { font-size: 13px; color: #555; margin-bottom: 12px; }
+.hint { font-size: 13px; color: var(--sbx-gray-600); margin-bottom: 12px; }
 .list { list-style: none; margin: 0; padding: 0; }
-.item { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-radius: 6px; cursor: pointer; font-size: 14px; &:hover { background: #f0f7ff; } }
-.selected { background: #e6f4ff; border: 1px solid #91caff; }
-.empty { padding: 16px; color: #888; font-size: 13px; }
-.footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid #e8e8e8; }
-.cancelBtn { padding: 8px 16px; background: none; border: 1px solid #d9d9d9; border-radius: 4px; cursor: pointer; }
-.moveBtn { padding: 8px 16px; background: #1890ff; color: #fff; border: none; border-radius: 4px; cursor: pointer; &:disabled { background: #b0d4f9; cursor: not-allowed; } }
+.item { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-radius: var(--sbx-r-sm); cursor: pointer; font-size: 14px; &:hover { background: var(--sbx-primary-light); } }
+.selected { background: var(--sbx-primary-light); border: 1px solid var(--sbx-status-info-border); }
+.empty { padding: 16px; color: var(--sbx-gray-500); font-size: 13px; }
+.footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid var(--sbx-gray-200); }
+.cancelBtn { padding: 8px 16px; background: none; border: 1px solid var(--sbx-gray-300); border-radius: var(--sbx-r-xs); cursor: pointer; }
+.moveBtn { padding: 8px 16px; background: var(--sbx-primary); color: #fff; border: none; border-radius: var(--sbx-r-xs); cursor: pointer; &:disabled { opacity: 0.45; cursor: not-allowed; } }

--- a/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.module.scss
+++ b/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.module.scss
@@ -1,0 +1,13 @@
+.overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center; }
+.modal { background: #fff; border-radius: 8px; width: 440px; max-height: 70vh; display: flex; flex-direction: column; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
+.header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; font-weight: 600; font-size: 16px; border-bottom: 1px solid #e8e8e8; }
+.header button { background: none; border: none; cursor: pointer; }
+.body { padding: 16px; overflow-y: auto; flex: 1; }
+.hint { font-size: 13px; color: #555; margin-bottom: 12px; }
+.list { list-style: none; margin: 0; padding: 0; }
+.item { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-radius: 6px; cursor: pointer; font-size: 14px; &:hover { background: #f0f7ff; } }
+.selected { background: #e6f4ff; border: 1px solid #91caff; }
+.empty { padding: 16px; color: #888; font-size: 13px; }
+.footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid #e8e8e8; }
+.cancelBtn { padding: 8px 16px; background: none; border: 1px solid #d9d9d9; border-radius: 4px; cursor: pointer; }
+.moveBtn { padding: 8px 16px; background: #1890ff; color: #fff; border: none; border-radius: 4px; cursor: pointer; &:disabled { background: #b0d4f9; cursor: not-allowed; } }

--- a/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.tsx
+++ b/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { X, FolderOpen } from 'lucide-react';
+import { useTreeStore } from '../../store/tree.store';
+import type { INode } from '../../types/editor';
+import styles from './ResourceReorderDialog.module.scss';
+
+interface ResourceReorderDialogProps {
+  resourceId: string;
+  resourceName: string;
+  currentUnitId: string;
+  onClose: () => void;
+}
+
+function collectFolders(nodes: INode[], exclude?: string): INode[] {
+  const folders: INode[] = [];
+  const walk = (ns: INode[]) => {
+    for (const n of ns) {
+      if (n.isFolder && n.id !== exclude) folders.push(n);
+      if (n.children?.length) walk(n.children);
+    }
+  };
+  walk(nodes);
+  return folders;
+}
+
+export const ResourceReorderDialog: React.FC<ResourceReorderDialogProps> = ({
+  resourceId, resourceName, currentUnitId, onClose,
+}) => {
+  const { treeData, moveNode } = useTreeStore();
+  const folders = collectFolders(treeData, currentUnitId);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const handleMove = () => {
+    if (!selected) return;
+    moveNode(resourceId, currentUnitId, selected);
+    onClose();
+  };
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-label="Move resource">
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <span>Move &quot;{resourceName}&quot;</span>
+          <button onClick={onClose} aria-label="Close"><X size={16} /></button>
+        </div>
+        <div className={styles.body}>
+          <p className={styles.hint}>Select a unit to move this content to:</p>
+          <ul className={styles.list}>
+            {folders.map(f => (
+              <li
+                key={f.id}
+                className={`${styles.item} ${selected === f.id ? styles.selected : ''}`}
+                onClick={() => setSelected(f.id)}
+              >
+                <FolderOpen size={14} />
+                <span>{f.name}</span>
+              </li>
+            ))}
+            {folders.length === 0 && <li className={styles.empty}>No other units available</li>}
+          </ul>
+        </div>
+        <div className={styles.footer}>
+          <button className={styles.cancelBtn} onClick={onClose}>Cancel</button>
+          <button className={styles.moveBtn} onClick={handleMove} disabled={!selected}>Move here</button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.tsx
+++ b/projects/collection-editor-react/src/components/ResourceReorder/ResourceReorderDialog.tsx
@@ -11,11 +11,11 @@ interface ResourceReorderDialogProps {
   onClose: () => void;
 }
 
-function collectFolders(nodes: INode[], exclude?: string): INode[] {
+function collectFolders(nodes: INode[], rootId: string, exclude?: string): INode[] {
   const folders: INode[] = [];
   const walk = (ns: INode[]) => {
     for (const n of ns) {
-      if (n.isFolder && n.id !== exclude) folders.push(n);
+      if (n.isFolder && n.id !== exclude && n.id !== rootId) folders.push(n);
       if (n.children?.length) walk(n.children);
     }
   };
@@ -27,7 +27,7 @@ export const ResourceReorderDialog: React.FC<ResourceReorderDialogProps> = ({
   resourceId, resourceName, currentUnitId, onClose,
 }) => {
   const { treeData, moveNode } = useTreeStore();
-  const folders = collectFolders(treeData, currentUnitId);
+  const folders = collectFolders(treeData, treeData[0]?.id ?? '', currentUnitId);
   const [selected, setSelected] = useState<string | null>(null);
 
   const handleMove = () => {

--- a/projects/collection-editor-react/src/components/ResourceReorder/index.ts
+++ b/projects/collection-editor-react/src/components/ResourceReorder/index.ts
@@ -1,0 +1,1 @@
+export { ResourceReorderDialog } from './ResourceReorderDialog';

--- a/projects/collection-editor-react/src/components/SparkMetaForm/FormSection.module.scss
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/FormSection.module.scss
@@ -1,0 +1,44 @@
+.section {
+  background: #fff;
+  border-radius: var(--sbx-r-md);
+  box-shadow: var(--sbx-shadow-1);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--sbx-gray-900);
+  margin: 0;
+}
+
+.description {
+  font-size: 13px;
+  color: var(--sbx-gray-500);
+  margin: 0;
+}
+
+.divider {
+  border: none;
+  border-top: 1px solid var(--sbx-gray-100);
+  margin: 0;
+}
+
+.fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+
+  @media (max-width: 700px) {
+    grid-template-columns: 1fr;
+  }
+}

--- a/projects/collection-editor-react/src/components/SparkMetaForm/FormSection.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/FormSection.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './FormSection.module.scss';
+
+interface FormSectionProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+export const FormSection: React.FC<FormSectionProps> = ({ title, description, children }) => (
+  <div className={styles.section}>
+    <div className={styles.header}>
+      <h3 className={styles.title}>{title}</h3>
+      {description && <p className={styles.description}>{description}</p>}
+    </div>
+    <hr className={styles.divider} />
+    <div className={styles.fields}>
+      {children}
+    </div>
+  </div>
+);

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.module.scss
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.module.scss
@@ -1,4 +1,10 @@
 .form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.ungrouped {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px 24px;
@@ -7,7 +13,6 @@
 }
 
 .noFields {
-  grid-column: 1 / -1;
   color: var(--sbx-gray-400);
   font-size: 13px;
   font-style: italic;

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.module.scss
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.module.scss
@@ -1,0 +1,14 @@
+.form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+
+  @media (max-width: 700px) { grid-template-columns: 1fr; }
+}
+
+.noFields {
+  grid-column: 1 / -1;
+  color: var(--sbx-gray-400);
+  font-size: 13px;
+  font-style: italic;
+}

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -7,6 +7,7 @@ import { useEditorStore } from '../../store/editor.store';
 import { useFramework } from '../../hooks/useFramework';
 import { useFrameworkOptions } from '../../hooks/useFrameworkOptions';
 import { useChannelData } from '../../hooks/useChannelData';
+import { useUserFullName } from '../../hooks/useUserFullName';
 import { useFieldPrepare, SECTION_DISPLAY } from './hooks/useFieldPrepare';
 import type { IPrepareContext } from './hooks/useFieldPrepare';
 import { transformEmit, transformFieldPatch } from './hooks/emitTransform';
@@ -58,6 +59,11 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
     defaultLicense: channelDefaultLicense,
     name: channelName,
   } = useChannelData(config?.context?.channel as string | undefined);
+  // Current user's display name — auto-fills the author field when the host
+  // app doesn't pass context.user.fullName.
+  const fetchedUserFullName = useUserFullName(
+    (config?.context?.userId ?? config?.context?.uid) as string | undefined,
+  );
   // Course Type options: channel frameworks filtered/extended by orgFWType.
   const orgFrameworks = useFrameworkOptions(
     channelFrameworks,
@@ -98,7 +104,8 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
     setDefaultCopyRight: cfg.setDefaultCopyRight === true,
     defaultLicense: (ctxCtx.defaultLicense as string | undefined) ?? channelDefaultLicense,
     contextAdditionalCategories: ctxCtx.additionalCategories as string[] | undefined,
-    userFullName: (ctxCtx.user as { fullName?: string } | undefined)?.fullName,
+    // Host-provided name wins; otherwise resolved from the user-read API.
+    userFullName: (ctxCtx.user as { fullName?: string } | undefined)?.fullName ?? fetchedUserFullName,
     channelName,
     collectionAdditionalCategories,
     contentAdditionalCategories,
@@ -238,6 +245,22 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
     return () => sub.unsubscribe();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form]);
+
+  // Late-arriving defaults: RHF captures defaultValues at mount, but the user
+  // name (user-read API) and channel name resolve async. When they land, seed
+  // any still-empty licensing fields so the values are visible and persisted
+  // (setValue fires the watch subscription → treeCache patch).
+  useEffect(() => {
+    for (const code of ['author', 'creator', 'copyright', 'copyrightYear', 'license'] as const) {
+      const field = allFieldsRef.current.find(f => f.code === code);
+      if (!field || field.currentValue === undefined || field.currentValue === null || field.currentValue === '') continue;
+      const formValue = form.getValues(code);
+      if (formValue === undefined || formValue === null || formValue === '') {
+        form.setValue(code, field.currentValue, { shouldDirty: false });
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchedUserFullName, channelName, form]);
 
   // Per-field editability is computed in useFieldPrepare (computeEditable):
   // outside review modes a field is editable unless the API says otherwise;

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useRef } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
+import toast from 'react-hot-toast';
 import type { EditorMode } from '../../types/editor';
 import { useTreeStore } from '../../store/tree.store';
 import { useEditorStore } from '../../store/editor.store';
 import { useFramework } from '../../hooks/useFramework';
+import { useFrameworkOptions } from '../../hooks/useFrameworkOptions';
 import { useChannelData } from '../../hooks/useChannelData';
 import { useFieldPrepare, SECTION_DISPLAY } from './hooks/useFieldPrepare';
+import type { IPrepareContext } from './hooks/useFieldPrepare';
+import { transformEmit, transformFieldPatch } from './hooks/emitTransform';
 import { useCascade } from './hooks/useCascade';
 import { FormSection } from './FormSection';
 import { TextField } from './fields/TextField';
@@ -38,18 +42,33 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
   const config = useEditorStore(s => s.editorConfig);
   const rootFormConfig = useEditorStore(s => s.rootFormConfig);
   const unitFormConfig = useEditorStore(s => s.unitFormConfig);
+  const categoryMeta = useEditorStore(s => s.categoryMeta);
+  // Framework resolved from the loaded content (rootNode.framework) wins over
+  // the editor context — mirrors Angular's `collection.framework || context.framework`.
+  const contentFramework = useEditorStore(s => s.contentFramework);
+  const contentTargetFWIds = useEditorStore(s => s.contentTargetFWIds);
   const { organisationFramework, targetFrameworks, isLoading: fwLoading } = useFramework(
-    config?.context?.framework as string | undefined,
-    config?.context?.targetFWIds as string[] | undefined,
+    (contentFramework ?? config?.context?.framework) as string | undefined,
+    (contentTargetFWIds ?? config?.context?.targetFWIds) as string[] | undefined,
   );
-  const { frameworks: channelFrameworks, collectionAdditionalCategories } = useChannelData(
+  const {
+    frameworks: channelFrameworks,
+    collectionAdditionalCategories,
+    contentAdditionalCategories,
+    defaultLicense: channelDefaultLicense,
+    name: channelName,
+  } = useChannelData(config?.context?.channel as string | undefined);
+  // Course Type options: channel frameworks filtered/extended by orgFWType.
+  const orgFrameworks = useFrameworkOptions(
+    channelFrameworks,
+    categoryMeta?.frameworkMetadata?.orgFWType,
     config?.context?.channel as string | undefined,
   );
-  const orgFrameworks = channelFrameworks?.map(f => ({ label: f.name, value: f.identifier }));
   const frameworkDetails = { organisationFramework, targetFrameworks, orgFrameworks, channelAdditionalCategories: collectionAdditionalCategories };
 
   // selectedNodeId must be declared before it is used in effectiveMeta
   const selectedNodeId = useTreeStore(s => s.selectedNodeId);
+  const treeData = useTreeStore(s => s.treeData);
 
   // Merge treeCache edits on top of nodeMetadata so the form restores user edits
   // when switching back to a previously-edited node (avoids reset-on-reselect).
@@ -57,12 +76,41 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
   const cachedEdits = selectedNodeId ? (treeCache[selectedNodeId] ?? {}) : {};
   const effectiveMeta = { ...nodeMetadata, ...cachedEdits };
 
+  // Count the active node's direct children — feeds the maxQuestions range.
+  const childCount = React.useMemo(() => {
+    if (!selectedNodeId) return 0;
+    const queue = [...treeData];
+    while (queue.length) {
+      const n = queue.shift()!;
+      if (n.id === selectedNodeId) return n.children?.length ?? 0;
+      if (n.children) queue.push(...n.children);
+    }
+    return 0;
+  }, [treeData, selectedNodeId]);
+
+  // Extra inputs Angular reads from EditorService / channelInfo / ConfigService.
+  const cfg = (config?.config ?? {}) as Record<string, unknown>;
+  const ctxCtx = (config?.context ?? {}) as Record<string, unknown>;
+  const prepareCtx: IPrepareContext = {
+    editorMode,
+    editableFields: cfg.editableFields as Record<string, string[]> | undefined,
+    objectType: cfg.objectType as string | undefined,
+    setDefaultCopyRight: cfg.setDefaultCopyRight === true,
+    defaultLicense: (ctxCtx.defaultLicense as string | undefined) ?? channelDefaultLicense,
+    contextAdditionalCategories: ctxCtx.additionalCategories as string[] | undefined,
+    userFullName: (ctxCtx.user as { fullName?: string } | undefined)?.fullName,
+    channelName,
+    collectionAdditionalCategories,
+    contentAdditionalCategories,
+    childCount,
+  };
+
   // Use category-definition API fields if available, fall back to static config
   const apiFields = isRoot ? rootFormConfig : unitFormConfig;
   const formConfig = apiFields
     ? (apiFields as Array<Record<string, unknown>>)
     : ((config?.config.hierarchy as Record<string, unknown>)?.formConfig as Array<Record<string, unknown>> ?? []);
-  const allFields = useFieldPrepare(formConfig, effectiveMeta, frameworkDetails, isRoot);
+  const allFields = useFieldPrepare(formConfig, effectiveMeta, frameworkDetails, isRoot, prepareCtx);
   // appIcon is always rendered in the title row (TitleAppIcon), never in the form grid.
   // Fields with visible === false (e.g. dialcodes when QR code is "No") are excluded.
   const tabFields = allFields.filter(f => f.tab === activeTab && f.inputType !== 'appIcon' && f.visible !== false);
@@ -93,6 +141,16 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
   onFormValueChangeRef.current = onFormValueChange;
   const onFormStatusChangeRef = useRef(onFormStatusChange);
   onFormStatusChangeRef.current = onFormStatusChange;
+  // Track previous shuffle so we can fire the "shuffling enabled" toast only on
+  // the false→true transition (mirrors Angular showShuffleMessage).
+  const prevShuffleRef = useRef<boolean | undefined>(
+    typeof effectiveMeta.shuffle === 'boolean' ? (effectiveMeta.shuffle as boolean) : undefined,
+  );
+  const nodeTitleRef = useRef<string>((effectiveMeta.name as string) ?? '');
+  nodeTitleRef.current = (effectiveMeta.name as string) ?? '';
+  const editorModeRef = useRef(editorMode);
+  editorModeRef.current = editorMode;
+  const REVIEW_MODES = ['review', 'read', 'sourcingreview', 'orgreview'];
 
   // Report initial validity on mount — mirrors Angular's setTimeout(() => emitStatus(), 0).
   // This ensures the parent (SplitBuilderShell) knows the form is invalid from the start
@@ -141,14 +199,30 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
         if (changedField === 'dialcodes') {
           value = Array.isArray(value) ? value : (value ? [value] : []);
         }
-        updateNode(nodeId, { [changedField]: value });
-        onFormValueChangeRef.current({ [changedField]: value });
+        // Shuffle false→true shows an info toast (Angular showShuffleMessage).
+        if (changedField === 'shuffle') {
+          if (value === true && prevShuffleRef.current === false) {
+            toast('Shuffling is enabled for this question set.', { icon: 'ℹ️' });
+          }
+          prevShuffleRef.current = value as boolean;
+        }
+        // transformFieldPatch omits UI-only keys (allowECM/setPeriod → null) and
+        // maps levels→outcomeDeclaration, instances→{label}.
+        const patch = transformFieldPatch(changedField, value);
+        if (patch) {
+          updateNode(nodeId, patch);
+          onFormValueChangeRef.current(patch);
+        }
       } else if (!changedField) {
-        // Batch / cascade update — write all valid codes
+        // Batch / cascade update — write all valid codes, transformed.
         const allValues = form.getValues();
-        const patch = Object.fromEntries(
+        const valid = Object.fromEntries(
           Object.entries(allValues).filter(([k]) => validCodes.has(k))
         );
+        const patch = transformEmit(valid, {
+          isReview: REVIEW_MODES.includes(editorModeRef.current),
+          nodeTitle: nodeTitleRef.current,
+        });
         if (Object.keys(patch).length > 0) {
           updateNode(nodeId, patch);
           onFormValueChangeRef.current(patch);
@@ -165,7 +239,10 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form]);
 
-  const isReadOnly = editorMode !== 'edit';
+  // Per-field editability is computed in useFieldPrepare (computeEditable):
+  // outside review modes a field is editable unless the API says otherwise;
+  // inside review/read/sourcingreview/orgreview only editableFields[mode] codes
+  // stay editable. So a field is disabled iff its computed `editable` is false.
 
   // Group consecutive fields with the same section key into boxes.
   const sectionGroups = tabFields.reduce<Array<{ section: string | undefined; fields: typeof tabFields }>>(
@@ -187,7 +264,7 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
       name: field.code,
       label: field.label,
       required: field.required,
-      disabled: isReadOnly || field.editable === false,
+      disabled: field.editable === false,
     };
     switch (field.inputType) {
       case 'textarea':

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -4,6 +4,7 @@ import type { EditorMode } from '../../types/editor';
 import { useTreeStore } from '../../store/tree.store';
 import { useEditorStore } from '../../store/editor.store';
 import { useFramework } from '../../hooks/useFramework';
+import { useChannelData } from '../../hooks/useChannelData';
 import { useFieldPrepare, SECTION_DISPLAY } from './hooks/useFieldPrepare';
 import { useCascade } from './hooks/useCascade';
 import { FormSection } from './FormSection';
@@ -41,7 +42,11 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
     config?.context?.framework as string | undefined,
     config?.context?.targetFWIds as string[] | undefined,
   );
-  const frameworkDetails = { organisationFramework, targetFrameworks };
+  const { frameworks: channelFrameworks, collectionAdditionalCategories } = useChannelData(
+    config?.context?.channel as string | undefined,
+  );
+  const orgFrameworks = channelFrameworks?.map(f => ({ label: f.name, value: f.identifier }));
+  const frameworkDetails = { organisationFramework, targetFrameworks, orgFrameworks, channelAdditionalCategories: collectionAdditionalCategories };
 
   // selectedNodeId must be declared before it is used in effectiveMeta
   const selectedNodeId = useTreeStore(s => s.selectedNodeId);

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -88,6 +88,23 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
   const onFormStatusChangeRef = useRef(onFormStatusChange);
   onFormStatusChangeRef.current = onFormStatusChange;
 
+  // Report initial validity on mount — mirrors Angular's setTimeout(() => emitStatus(), 0).
+  // This ensures the parent (SplitBuilderShell) knows the form is invalid from the start
+  // when required fields are empty, so Save is disabled before the user touches anything.
+  useEffect(() => {
+    // RHF doesn't trigger validation on mount with defaultValues; run it manually so
+    // formState.errors is populated before we read it.
+    form.trigger().then(() => {
+      const errors = form.formState.errors;
+      const fields = allFieldsRef.current;
+      const errorTabs = Array.from(new Set(
+        Object.keys(errors).map(code => fields.find(f => f.code === code)?.tab).filter(Boolean)
+      )) as Array<'details' | 'audience' | 'licensing'>;
+      onFormStatusChangeRef.current(Object.keys(errors).length === 0, errorTabs);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // once per form instance (form re-mounts per node via key={selectedNodeId})
+
   // Subscribe once per form instance (key={selectedNodeId} gives a fresh form per node).
   // Write only the specific field that changed — avoids the RHF timing issue where
   // formState.dirtyFields is not yet updated when the watch callback fires for

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useRef } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import type { EditorMode } from '../../types/editor';
+import { useTreeStore } from '../../store/tree.store';
+import { useEditorStore } from '../../store/editor.store';
+import { useFramework } from '../../hooks/useFramework';
+import { useFieldPrepare } from './hooks/useFieldPrepare';
+import { useCascade } from './hooks/useCascade';
+import { TextField } from './fields/TextField';
+import { SelectField } from './fields/SelectField';
+import { MultiSelectField } from './fields/MultiSelectField';
+import { ChipGroupField } from './fields/ChipGroupField';
+import { RadioField } from './fields/RadioField';
+import { AppIconField } from './fields/AppIconField';
+import { DateTimeField } from './fields/DateTimeField';
+import { KeywordSuggestField } from './fields/KeywordSuggestField';
+import { NestedSelectField } from './fields/NestedSelectField';
+import { LicenseSelectField } from './fields/LicenseSelectField';
+import { DialcodeInputField } from './fields/DialcodeInputField';
+import styles from './SparkMetaForm.module.scss';
+
+interface SparkMetaFormProps {
+  nodeMetadata: Record<string, unknown>;
+  activeTab: 'details' | 'audience' | 'licensing';
+  isRoot: boolean;
+  isFolder: boolean;
+  editorMode: EditorMode;
+  onFormValueChange: (data: unknown) => void;
+  onFormStatusChange: (isValid: boolean, errorTabs: Array<'details' | 'audience' | 'licensing'>) => void;
+}
+
+export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
+  nodeMetadata, activeTab, isRoot, isFolder, editorMode,
+  onFormValueChange, onFormStatusChange,
+}) => {
+  const config = useEditorStore(s => s.editorConfig);
+  const rootFormConfig = useEditorStore(s => s.rootFormConfig);
+  const unitFormConfig = useEditorStore(s => s.unitFormConfig);
+  const { organisationFramework, targetFrameworks, isLoading: fwLoading } = useFramework(
+    config?.context?.framework as string | undefined,
+    config?.context?.targetFWIds as string[] | undefined,
+  );
+  const frameworkDetails = { organisationFramework, targetFrameworks };
+
+  // selectedNodeId must be declared before it is used in effectiveMeta
+  const selectedNodeId = useTreeStore(s => s.selectedNodeId);
+
+  // Merge treeCache edits on top of nodeMetadata so the form restores user edits
+  // when switching back to a previously-edited node (avoids reset-on-reselect).
+  const treeCache = useTreeStore(s => s.treeCache);
+  const cachedEdits = selectedNodeId ? (treeCache[selectedNodeId] ?? {}) : {};
+  const effectiveMeta = { ...nodeMetadata, ...cachedEdits };
+
+  // Use category-definition API fields if available, fall back to static config
+  const apiFields = isRoot ? rootFormConfig : unitFormConfig;
+  const formConfig = apiFields
+    ? (apiFields as Array<Record<string, unknown>>)
+    : ((config?.config.hierarchy as Record<string, unknown>)?.formConfig as Array<Record<string, unknown>> ?? []);
+  const allFields = useFieldPrepare(formConfig, effectiveMeta, frameworkDetails, isRoot);
+  const tabFields = allFields.filter(f => f.tab === activeTab);
+
+  const form = useForm<Record<string, unknown>>({
+    mode: 'onChange',
+    defaultValues: Object.fromEntries(
+      allFields.map(f => {
+        const arrayTypes = ['multiselect', 'chips', 'keywords', 'tagsinput'];
+        const objectTypes = ['nestedselect'];
+        if (arrayTypes.includes(f.inputType)) return [f.code, f.currentValue ?? f.defaultValue ?? []];
+        if (objectTypes.includes(f.inputType)) return [f.code, f.currentValue ?? f.defaultValue ?? {}];
+        return [f.code, f.currentValue ?? f.defaultValue ?? ''];
+      })
+    ),
+  });
+
+  useCascade(form, allFields);
+
+  // Keep refs pointing at the latest values so the watch callback (subscribed once
+  // per form instance) never closes over stale data.
+  const { updateNode } = useTreeStore();
+  const allFieldsRef = useRef(allFields);
+  allFieldsRef.current = allFields;
+  const selectedNodeIdRef = useRef(selectedNodeId);
+  selectedNodeIdRef.current = selectedNodeId;
+  const onFormValueChangeRef = useRef(onFormValueChange);
+  onFormValueChangeRef.current = onFormValueChange;
+  const onFormStatusChangeRef = useRef(onFormStatusChange);
+  onFormStatusChangeRef.current = onFormStatusChange;
+
+  // Subscribe once per form instance (key={selectedNodeId} gives a fresh form per node).
+  // Write only the specific field that changed — avoids the RHF timing issue where
+  // formState.dirtyFields is not yet updated when the watch callback fires for
+  // setValue-based fields (SelectField / MultiSelectField).
+  useEffect(() => {
+    const sub = form.watch((_, { name: changedField }) => {
+      const nodeId = selectedNodeIdRef.current;
+      if (!nodeId) return;
+      const fields = allFieldsRef.current;
+      const validCodes = new Set(fields.map(f => f.code));
+
+      if (changedField && validCodes.has(changedField)) {
+        // Single field changed — write just that field to treeCache
+        const value = form.getValues(changedField as string);
+        updateNode(nodeId, { [changedField]: value });
+        onFormValueChangeRef.current({ [changedField]: value });
+      } else if (!changedField) {
+        // Batch / cascade update — write all valid codes
+        const allValues = form.getValues();
+        const patch = Object.fromEntries(
+          Object.entries(allValues).filter(([k]) => validCodes.has(k))
+        );
+        if (Object.keys(patch).length > 0) {
+          updateNode(nodeId, patch);
+          onFormValueChangeRef.current(patch);
+        }
+      }
+
+      const errors = form.formState.errors;
+      const errorTabs = Array.from(new Set(
+        Object.keys(errors).map(code => fields.find(f => f.code === code)?.tab).filter(Boolean)
+      )) as Array<'details' | 'audience' | 'licensing'>;
+      onFormStatusChangeRef.current(Object.keys(errors).length === 0, errorTabs);
+    });
+    return () => sub.unsubscribe();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form]);
+
+  const isReadOnly = editorMode !== 'edit';
+
+  return (
+    <FormProvider {...form}>
+      <div className={styles.form}>
+        {tabFields.map(field => {
+          const commonProps = {
+            key: field.code,
+            name: field.code,
+            label: field.label,
+            required: field.required,
+            disabled: isReadOnly || field.editable === false,
+          };
+          switch (field.inputType) {
+            case 'textarea':
+              return <TextField {...commonProps} multiline maxLength={field.maxLength} />;
+            case 'select':
+              return <SelectField {...commonProps} options={field.options ?? []} />;
+            case 'multiselect':
+              return <MultiSelectField {...commonProps} options={field.options ?? []} />;
+            case 'chips':
+              return <ChipGroupField {...commonProps} />;
+            case 'radio':
+              return <RadioField {...commonProps} options={field.options ?? []} />;
+            case 'appIcon':
+              return <AppIconField {...commonProps} nodeId={selectedNodeId ?? ''} />;
+            case 'datepicker':
+            case 'datetime':
+              return <DateTimeField {...commonProps} />;
+            case 'keywords':
+            case 'tagsinput':
+              return <KeywordSuggestField {...commonProps} />;
+            case 'nestedselect':
+              return <NestedSelectField {...commonProps} levels={field.levels ?? []} />;
+            case 'license':
+              return <LicenseSelectField {...commonProps} />;
+            case 'dialcode':
+              return <DialcodeInputField {...commonProps} />;
+            default:
+              return <TextField {...commonProps} maxLength={field.maxLength} />;
+          }
+        })}
+        {tabFields.length === 0 && !fwLoading && (
+          <p className={styles.noFields}>No fields configured for this tab.</p>
+        )}
+      </div>
+    </FormProvider>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -4,8 +4,9 @@ import type { EditorMode } from '../../types/editor';
 import { useTreeStore } from '../../store/tree.store';
 import { useEditorStore } from '../../store/editor.store';
 import { useFramework } from '../../hooks/useFramework';
-import { useFieldPrepare } from './hooks/useFieldPrepare';
+import { useFieldPrepare, SECTION_DISPLAY } from './hooks/useFieldPrepare';
 import { useCascade } from './hooks/useCascade';
+import { FormSection } from './FormSection';
 import { TextField } from './fields/TextField';
 import { SelectField } from './fields/SelectField';
 import { MultiSelectField } from './fields/MultiSelectField';
@@ -57,7 +58,8 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
     ? (apiFields as Array<Record<string, unknown>>)
     : ((config?.config.hierarchy as Record<string, unknown>)?.formConfig as Array<Record<string, unknown>> ?? []);
   const allFields = useFieldPrepare(formConfig, effectiveMeta, frameworkDetails, isRoot);
-  const tabFields = allFields.filter(f => f.tab === activeTab);
+  // appIcon is always rendered in the title row (TitleAppIcon), never in the form grid
+  const tabFields = allFields.filter(f => f.tab === activeTab && f.inputType !== 'appIcon');
 
   const form = useForm<Record<string, unknown>>({
     mode: 'onChange',
@@ -126,45 +128,76 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
 
   const isReadOnly = editorMode !== 'edit';
 
+  // Group consecutive fields with the same section key into boxes.
+  const sectionGroups = tabFields.reduce<Array<{ section: string | undefined; fields: typeof tabFields }>>(
+    (acc, field) => {
+      const last = acc[acc.length - 1];
+      if (last && last.section === field.section) {
+        last.fields.push(field);
+      } else {
+        acc.push({ section: field.section, fields: [field] });
+      }
+      return acc;
+    },
+    [],
+  );
+
+  const renderField = (field: typeof tabFields[number]) => {
+    const commonProps = {
+      key: field.code,
+      name: field.code,
+      label: field.label,
+      required: field.required,
+      disabled: isReadOnly || field.editable === false,
+    };
+    switch (field.inputType) {
+      case 'textarea':
+        return <TextField {...commonProps} multiline maxLength={field.maxLength} />;
+      case 'select':
+        return <SelectField {...commonProps} options={field.options ?? []} />;
+      case 'multiselect':
+        return <MultiSelectField {...commonProps} options={field.options ?? []} />;
+      case 'chips':
+        return <ChipGroupField {...commonProps} />;
+      case 'radio':
+        return <RadioField {...commonProps} options={field.options ?? []} />;
+      case 'appIcon':
+        return <AppIconField {...commonProps} nodeId={selectedNodeId ?? ''} />;
+      case 'datepicker':
+      case 'datetime':
+        return <DateTimeField {...commonProps} />;
+      case 'keywords':
+      case 'tagsinput':
+        return <KeywordSuggestField {...commonProps} />;
+      case 'nestedselect':
+        return <NestedSelectField {...commonProps} levels={field.levels ?? []} />;
+      case 'license':
+        return <LicenseSelectField {...commonProps} />;
+      case 'dialcode':
+        return <DialcodeInputField {...commonProps} />;
+      default:
+        return <TextField {...commonProps} maxLength={field.maxLength} />;
+    }
+  };
+
   return (
     <FormProvider {...form}>
       <div className={styles.form}>
-        {tabFields.map(field => {
-          const commonProps = {
-            key: field.code,
-            name: field.code,
-            label: field.label,
-            required: field.required,
-            disabled: isReadOnly || field.editable === false,
-          };
-          switch (field.inputType) {
-            case 'textarea':
-              return <TextField {...commonProps} multiline maxLength={field.maxLength} />;
-            case 'select':
-              return <SelectField {...commonProps} options={field.options ?? []} />;
-            case 'multiselect':
-              return <MultiSelectField {...commonProps} options={field.options ?? []} />;
-            case 'chips':
-              return <ChipGroupField {...commonProps} />;
-            case 'radio':
-              return <RadioField {...commonProps} options={field.options ?? []} />;
-            case 'appIcon':
-              return <AppIconField {...commonProps} nodeId={selectedNodeId ?? ''} />;
-            case 'datepicker':
-            case 'datetime':
-              return <DateTimeField {...commonProps} />;
-            case 'keywords':
-            case 'tagsinput':
-              return <KeywordSuggestField {...commonProps} />;
-            case 'nestedselect':
-              return <NestedSelectField {...commonProps} levels={field.levels ?? []} />;
-            case 'license':
-              return <LicenseSelectField {...commonProps} />;
-            case 'dialcode':
-              return <DialcodeInputField {...commonProps} />;
-            default:
-              return <TextField {...commonProps} maxLength={field.maxLength} />;
+        {sectionGroups.map((group, idx) => {
+          const display = group.section ? SECTION_DISPLAY[group.section] : undefined;
+          if (display) {
+            return (
+              <FormSection key={group.section ?? idx} title={display.title} description={display.description}>
+                {group.fields.map(renderField)}
+              </FormSection>
+            );
           }
+          // Fields with no known section: render flat inside an unstyled wrapper
+          return (
+            <div key={idx} className={styles.ungrouped}>
+              {group.fields.map(renderField)}
+            </div>
+          );
         })}
         {tabFields.length === 0 && !fwLoading && (
           <p className={styles.noFields}>No fields configured for this tab.</p>

--- a/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -63,8 +63,9 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
     ? (apiFields as Array<Record<string, unknown>>)
     : ((config?.config.hierarchy as Record<string, unknown>)?.formConfig as Array<Record<string, unknown>> ?? []);
   const allFields = useFieldPrepare(formConfig, effectiveMeta, frameworkDetails, isRoot);
-  // appIcon is always rendered in the title row (TitleAppIcon), never in the form grid
-  const tabFields = allFields.filter(f => f.tab === activeTab && f.inputType !== 'appIcon');
+  // appIcon is always rendered in the title row (TitleAppIcon), never in the form grid.
+  // Fields with visible === false (e.g. dialcodes when QR code is "No") are excluded.
+  const tabFields = allFields.filter(f => f.tab === activeTab && f.inputType !== 'appIcon' && f.visible !== false);
 
   const form = useForm<Record<string, unknown>>({
     mode: 'onChange',
@@ -96,7 +97,19 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
   // Report initial validity on mount — mirrors Angular's setTimeout(() => emitStatus(), 0).
   // This ensures the parent (SplitBuilderShell) knows the form is invalid from the start
   // when required fields are empty, so Save is disabled before the user touches anything.
+  // Also syncs normalized currentValues to treeCache so multiselect fields like medium
+  // are stored as arrays from the first load, even if the user never changes them.
   useEffect(() => {
+    const nodeId = selectedNodeIdRef.current;
+    if (nodeId) {
+      const patch = Object.fromEntries(
+        allFieldsRef.current
+          .filter(f => f.currentValue !== undefined && f.currentValue !== null)
+          .map(f => [f.code, f.currentValue])
+      );
+      if (Object.keys(patch).length > 0) updateNode(nodeId, patch);
+    }
+
     // RHF doesn't trigger validation on mount with defaultValues; run it manually so
     // formState.errors is populated before we read it.
     form.trigger().then(() => {
@@ -122,8 +135,12 @@ export const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
       const validCodes = new Set(fields.map(f => f.code));
 
       if (changedField && validCodes.has(changedField)) {
-        // Single field changed — write just that field to treeCache
-        const value = form.getValues(changedField as string);
+        // Single field changed — write just that field to treeCache.
+        // dialcodes must always be stored as an array (API expects string[]).
+        let value = form.getValues(changedField as string);
+        if (changedField === 'dialcodes') {
+          value = Array.isArray(value) ? value : (value ? [value] : []);
+        }
         updateNode(nodeId, { [changedField]: value });
         onFormValueChangeRef.current({ [changedField]: value });
       } else if (!changedField) {

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconField.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { ImageIcon, Trash2 } from 'lucide-react';
+import { AppIconPickerModal } from './AppIconPickerModal';
+import styles from './Field.module.scss';
+
+interface AppIconFieldProps {
+  name: string;
+  label: string;
+  nodeId: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+export const AppIconField: React.FC<AppIconFieldProps> = ({ name, label, nodeId, required, disabled }) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { watch, setValue, register, formState: { errors } } = useFormContext();
+  const value = watch(name) as string | undefined;
+  const error = errors[name];
+
+  const handleSelect = (url: string) => {
+    setValue(name, url, { shouldDirty: true, shouldValidate: true });
+    setPickerOpen(false);
+  };
+
+  const handleRemove = () => {
+    setValue(name, '', { shouldDirty: true, shouldValidate: true });
+  };
+
+  return (
+    <div className={styles.field}>
+      <label className={styles.label}>
+        {label}{required && <span className={styles.required}>*</span>}
+      </label>
+      <input
+        type="hidden"
+        {...register(name, { required: required ? `${label} is required` : false })}
+      />
+      <div
+        className={styles.iconWrap}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-label="Select app icon"
+        onClick={() => !disabled && setPickerOpen(true)}
+        onKeyDown={e => { if ((e.key === 'Enter' || e.key === ' ') && !disabled) setPickerOpen(true); }}
+      >
+        {value ? (
+          <img src={value} alt="App icon" className={styles.iconPreview} />
+        ) : (
+          <div className={styles.iconPlaceholder}>
+            <ImageIcon size={20} />
+            <span>Select icon</span>
+          </div>
+        )}
+      </div>
+      {value && !disabled && (
+        <button
+          type="button"
+          className={styles.removeIconBtn}
+          onClick={handleRemove}
+          aria-label="Remove app icon"
+        >
+          <Trash2 size={13} />
+          <span>Remove</span>
+        </button>
+      )}
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+
+      {pickerOpen && (
+        <AppIconPickerModal
+          nodeId={nodeId}
+          currentValue={value}
+          onSelect={handleSelect}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.module.scss
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.module.scss
@@ -1,0 +1,374 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  width: 760px;
+  max-width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--sbx-gray-100, #f0f0f0);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--sbx-gray-900, #111);
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  color: var(--sbx-gray-500, #6b7280);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sbx-gray-100, #f3f4f6);
+    color: var(--sbx-gray-800, #1f2937);
+  }
+}
+
+.tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--sbx-gray-100, #f0f0f0);
+  flex-shrink: 0;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  padding: 10px 18px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--sbx-gray-500, #6b7280);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: var(--sbx-primary, #1890ff);
+  }
+}
+
+.activeTab {
+  color: var(--sbx-primary, #1890ff);
+  border-bottom-color: var(--sbx-primary, #1890ff);
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 20px;
+  gap: 12px;
+}
+
+/* Search row */
+.searchWrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--sbx-gray-400, #9ca3af);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 8px 12px 8px 32px;
+  border: 1.5px solid var(--sbx-gray-200, #e5e7eb);
+  border-radius: 20px;
+  font-size: 13px;
+  font-family: var(--sbx-font, inherit);
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+
+  &:focus {
+    border-color: var(--sbx-primary, #1890ff);
+  }
+
+  &::placeholder {
+    color: var(--sbx-gray-400, #9ca3af);
+  }
+}
+
+/* Image grid */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 10px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+
+  &::-webkit-scrollbar { width: 4px; }
+  &::-webkit-scrollbar-thumb {
+    background: var(--sbx-gray-300, #d1d5db);
+    border-radius: 2px;
+  }
+}
+
+.imgCell {
+  aspect-ratio: 1;
+  border: 2px solid var(--sbx-gray-200, #e5e7eb);
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--sbx-gray-50, #f9fafb);
+  padding: 0;
+  transition: border-color 0.15s;
+
+  &:hover {
+    border-color: var(--sbx-primary, #1890ff);
+  }
+}
+
+.imgCellSelected {
+  border-color: var(--sbx-primary, #1890ff);
+  box-shadow: 0 0 0 1px var(--sbx-primary, #1890ff);
+}
+
+.thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.noThumb {
+  font-size: 10px;
+  color: var(--sbx-gray-400, #9ca3af);
+  font-weight: 500;
+}
+
+.checkBadge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 20px;
+  height: 20px;
+  background: var(--sbx-primary, #1890ff);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+
+/* Load more */
+.loadMoreBtn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 8px 0;
+  background: none;
+  border: 1px solid var(--sbx-primary, #1890ff);
+  border-radius: 4px;
+  color: var(--sbx-primary, #1890ff);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--sbx-font, inherit);
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--sbx-primary-light, #e6f4ff);
+  }
+}
+
+/* Loading / empty */
+.loadingRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px;
+  color: var(--sbx-gray-500, #6b7280);
+  font-size: 13px;
+}
+
+.empty {
+  text-align: center;
+  color: var(--sbx-gray-400, #9ca3af);
+  font-size: 13px;
+  padding: 32px;
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Upload tab */
+.uploadArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  justify-content: center;
+}
+
+.dropZone {
+  width: 100%;
+  max-width: 420px;
+  min-height: 200px;
+  border: 2px dashed var(--sbx-gray-300, #d1d5db);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  padding: 20px;
+  box-sizing: border-box;
+
+  &:hover {
+    border-color: var(--sbx-primary, #1890ff);
+    background: var(--sbx-primary-light, #e6f4ff);
+  }
+}
+
+.uploadIcon {
+  color: var(--sbx-gray-400, #9ca3af);
+}
+
+.dropText {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--sbx-gray-700, #374151);
+}
+
+.dropSubtext {
+  margin: 0;
+  font-size: 12px;
+  color: var(--sbx-gray-400, #9ca3af);
+}
+
+.uploadPreview {
+  max-width: 100%;
+  max-height: 180px;
+  object-fit: contain;
+  border-radius: 6px;
+}
+
+.hiddenInput {
+  display: none;
+}
+
+.fileName {
+  margin: 0;
+  font-size: 12px;
+  color: var(--sbx-gray-600, #4b5563);
+}
+
+.errorText {
+  margin: 0;
+  font-size: 12px;
+  color: #dc2626;
+}
+
+/* Footer */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--sbx-gray-100, #f0f0f0);
+  flex-shrink: 0;
+}
+
+.cancelBtn {
+  padding: 8px 20px;
+  background: none;
+  border: 1.5px solid var(--sbx-gray-300, #d1d5db);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--sbx-font, inherit);
+  color: var(--sbx-gray-700, #374151);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+
+  &:hover {
+    border-color: var(--sbx-gray-500, #6b7280);
+    background: var(--sbx-gray-50, #f9fafb);
+  }
+}
+
+.confirmBtn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 20px;
+  background: var(--sbx-primary, #1890ff);
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--sbx-font, inherit);
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.15s;
+
+  &:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.module.scss
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.module.scss
@@ -316,7 +316,7 @@
 .errorText {
   margin: 0;
   font-size: 12px;
-  color: #dc2626;
+  color: var(--sbx-error);
 }
 
 /* Footer */

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.tsx
@@ -1,0 +1,282 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { Search, Upload, X, Check, Loader } from 'lucide-react';
+import { apiClient } from '../../../api/client';
+import { useEditorStore } from '../../../store/editor.store';
+import styles from './AppIconPickerModal.module.scss';
+
+interface ImageAsset {
+  identifier: string;
+  name: string;
+  appIcon?: string;
+  artifactUrl?: string;
+  downloadUrl?: string;
+}
+
+interface AppIconPickerModalProps {
+  nodeId: string;
+  currentValue?: string;
+  onSelect: (url: string) => void;
+  onClose: () => void;
+}
+
+const PAGE_SIZE = 18;
+
+export const AppIconPickerModal: React.FC<AppIconPickerModalProps> = ({
+  nodeId,
+  currentValue,
+  onSelect,
+  onClose,
+}) => {
+  const [tab, setTab] = useState<'my' | 'all' | 'upload'>('my');
+  const [query, setQuery] = useState('');
+  const [images, setImages] = useState<ImageAsset[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selected, setSelected] = useState<ImageAsset | null>(null);
+  const [offset, setOffset] = useState(0);
+
+  // Upload tab state
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [uploadPreview, setUploadPreview] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const channel = useEditorStore(s => s.editorConfig?.context?.channel ?? '');
+  const uid = useEditorStore(s => s.editorConfig?.context?.uid ?? '');
+
+  const searchImages = useCallback(async (q: string, off: number, append = false) => {
+    setIsLoading(true);
+    try {
+      const filters: Record<string, unknown> = {
+        status: ['Live'],
+        mediaType: ['image'],
+        mimeType: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/svg+xml'],
+      };
+      if (tab === 'my' && uid) filters['createdBy'] = uid;
+      if (channel) filters['channel'] = channel;
+
+      const resp = await apiClient.post('/action/composite/v3/search', {
+        request: {
+          filters,
+          query: q,
+          limit: PAGE_SIZE,
+          offset: off,
+          sort_by: { createdOn: 'desc' },
+          fields: ['identifier', 'name', 'appIcon', 'artifactUrl', 'downloadUrl'],
+        },
+      }, { headers: { 'X-Source': 'web' } });
+
+      const result = resp.data?.result ?? {};
+      const items = (result.content ?? []) as ImageAsset[];
+      setTotalCount(result.count ?? 0);
+      setImages(prev => append ? [...prev, ...items] : items);
+    } catch {
+      // silent
+    } finally {
+      setIsLoading(false);
+    }
+  }, [tab, uid, channel]);
+
+  // Initial load
+  useEffect(() => {
+    if (tab !== 'upload') {
+      setImages([]);
+      setOffset(0);
+      searchImages(query, 0);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab]);
+
+  // Debounced search
+  const searchTimer = useRef<ReturnType<typeof setTimeout>>();
+  const handleQueryChange = (q: string) => {
+    setQuery(q);
+    clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => {
+      setImages([]);
+      setOffset(0);
+      searchImages(q, 0);
+    }, 400);
+  };
+
+  const handleLoadMore = () => {
+    const newOffset = offset + PAGE_SIZE;
+    setOffset(newOffset);
+    searchImages(query, newOffset, true);
+  };
+
+  const handleConfirmSelect = () => {
+    const url = selected?.artifactUrl ?? selected?.appIcon ?? selected?.downloadUrl ?? '';
+    if (url) onSelect(url);
+  };
+
+  // Upload tab handlers
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setUploadError('Only image files are accepted.');
+      return;
+    }
+    if (file.size > 4 * 1024 * 1024) {
+      setUploadError('Image must be under 4 MB.');
+      return;
+    }
+    setUploadFile(file);
+    setUploadPreview(URL.createObjectURL(file));
+    setUploadError('');
+  };
+
+  const handleUpload = async () => {
+    if (!uploadFile) return;
+    setIsUploading(true);
+    setUploadError('');
+    try {
+      const formData = new FormData();
+      formData.append('file', uploadFile);
+      const resp = await apiClient.post(
+        `/action/content/v3/upload/${nodeId}?fileType=image`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } },
+      );
+      const url = resp.data?.result?.artifactUrl as string | undefined;
+      if (!url) throw new Error('No URL in response');
+      onSelect(url);
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Upload failed.');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const hasMore = images.length < totalCount;
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-label="Select App Icon">
+      <div className={styles.modal}>
+        {/* Header */}
+        <div className={styles.header}>
+          <span className={styles.title}>Select App Icon</span>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className={styles.tabs} role="tablist">
+          <button role="tab" aria-selected={tab === 'my'} className={`${styles.tab} ${tab === 'my' ? styles.activeTab : ''}`} onClick={() => setTab('my')}>My Images</button>
+          <button role="tab" aria-selected={tab === 'all'} className={`${styles.tab} ${tab === 'all' ? styles.activeTab : ''}`} onClick={() => setTab('all')}>All Images</button>
+          <button role="tab" aria-selected={tab === 'upload'} className={`${styles.tab} ${tab === 'upload' ? styles.activeTab : ''}`} onClick={() => setTab('upload')}>
+            <Upload size={13} style={{ marginRight: 4 }} />
+            Upload
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          {tab !== 'upload' ? (
+            <>
+              {/* Search */}
+              <div className={styles.searchWrap}>
+                <Search size={14} className={styles.searchIcon} />
+                <input
+                  type="search"
+                  className={styles.searchInput}
+                  placeholder="Search images…"
+                  value={query}
+                  onChange={e => handleQueryChange(e.target.value)}
+                />
+              </div>
+
+              {/* Image grid */}
+              {isLoading && images.length === 0 ? (
+                <div className={styles.loadingRow}>
+                  <Loader size={20} className={styles.spinner} />
+                  <span>Loading…</span>
+                </div>
+              ) : images.length === 0 ? (
+                <div className={styles.empty}>No images found</div>
+              ) : (
+                <div className={styles.grid}>
+                  {images.map(img => {
+                    const thumb = img.appIcon ?? img.artifactUrl ?? img.downloadUrl ?? '';
+                    const isSelected = selected?.identifier === img.identifier;
+                    return (
+                      <button
+                        key={img.identifier}
+                        type="button"
+                        className={`${styles.imgCell} ${isSelected ? styles.imgCellSelected : ''}`}
+                        onClick={() => setSelected(img)}
+                        title={img.name}
+                      >
+                        {thumb ? (
+                          <img src={thumb} alt={img.name} className={styles.thumb} />
+                        ) : (
+                          <div className={styles.noThumb}>IMG</div>
+                        )}
+                        {isSelected && <div className={styles.checkBadge}><Check size={12} /></div>}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              {hasMore && !isLoading && (
+                <button className={styles.loadMoreBtn} onClick={handleLoadMore}>Load More</button>
+              )}
+              {isLoading && images.length > 0 && (
+                <div className={styles.loadingRow}><Loader size={16} className={styles.spinner} /></div>
+              )}
+            </>
+          ) : (
+            /* Upload tab */
+            <div className={styles.uploadArea}>
+              <div
+                className={styles.dropZone}
+                onClick={() => fileRef.current?.click()}
+                onDragOver={e => e.preventDefault()}
+                onDrop={e => { e.preventDefault(); const f = e.dataTransfer.files[0]; if (f) handleFileChange({ target: { files: [f], value: '' } } as unknown as React.ChangeEvent<HTMLInputElement>); }}
+              >
+                {uploadPreview ? (
+                  <img src={uploadPreview} alt="Preview" className={styles.uploadPreview} />
+                ) : (
+                  <>
+                    <Upload size={32} className={styles.uploadIcon} />
+                    <p className={styles.dropText}>Drag &amp; drop or click to browse</p>
+                    <p className={styles.dropSubtext}>PNG, JPG, SVG · max 4 MB</p>
+                  </>
+                )}
+              </div>
+              <input ref={fileRef} type="file" accept="image/*" className={styles.hiddenInput} onChange={handleFileChange} />
+              {uploadFile && <p className={styles.fileName}>{uploadFile.name}</p>}
+              {uploadError && <p className={styles.errorText}>{uploadError}</p>}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className={styles.footer}>
+          <button className={styles.cancelBtn} onClick={onClose}>Cancel</button>
+          {tab === 'upload' ? (
+            <button
+              className={styles.confirmBtn}
+              disabled={!uploadFile || isUploading}
+              onClick={handleUpload}
+            >
+              {isUploading ? <><Loader size={14} className={styles.spinner} /> Uploading…</> : 'Upload & Use'}
+            </button>
+          ) : (
+            <button
+              className={styles.confirmBtn}
+              disabled={!selected}
+              onClick={handleConfirmSelect}
+            >
+              Use Selected
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.tsx
@@ -48,6 +48,9 @@ export const AppIconPickerModal: React.FC<AppIconPickerModalProps> = ({
   const presignedHeaders = useEditorStore(
     s => (s.editorConfig?.context?.cloudStorage?.presigned_headers ?? {}) as Record<string, string>,
   );
+  // Read tenant-configured asset limits; default to 1 MB / png+jpeg (no SVG — XSS risk)
+  const assetMaxBytes = useEditorStore(s => s.editorConfig?.config?.assetConfig?.size ?? 1 * 1024 * 1024);
+  const assetAccept = useEditorStore(s => s.editorConfig?.config?.assetConfig?.accepted ?? 'image/png,image/jpeg');
 
   const searchImages = useCallback(async (q: string, off: number, append = false) => {
     setIsLoading(true);
@@ -115,19 +118,33 @@ export const AppIconPickerModal: React.FC<AppIconPickerModalProps> = ({
     if (url) onSelect(url);
   };
 
+  // Revoke the Object URL when the component unmounts or when preview changes
+  React.useEffect(() => {
+    return () => {
+      if (uploadPreview) URL.revokeObjectURL(uploadPreview);
+    };
+  }, [uploadPreview]);
+
   // Upload tab handlers
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     e.target.value = '';
     if (!file) return;
-    if (!file.type.startsWith('image/')) {
-      setUploadError('Only image files are accepted.');
+
+    // Validate MIME type against the configured allowlist (default: png + jpeg, no SVG)
+    const allowedTypes = assetAccept.split(',').map(t => t.trim());
+    if (!allowedTypes.includes(file.type)) {
+      const readableTypes = allowedTypes.map(t => t.replace('image/', '').toUpperCase()).join(', ');
+      setUploadError(`Only ${readableTypes} files are accepted.`);
       return;
     }
-    if (file.size > 4 * 1024 * 1024) {
-      setUploadError('Image must be under 4 MB.');
+    if (file.size > assetMaxBytes) {
+      const mb = (assetMaxBytes / (1024 * 1024)).toFixed(0);
+      setUploadError(`Image must be under ${mb} MB.`);
       return;
     }
+    // Revoke previous preview before creating a new one to avoid blob URL leaks
+    if (uploadPreview) URL.revokeObjectURL(uploadPreview);
     setUploadFile(file);
     setUploadPreview(URL.createObjectURL(file));
     setUploadError('');
@@ -253,11 +270,11 @@ export const AppIconPickerModal: React.FC<AppIconPickerModalProps> = ({
                   <>
                     <Upload size={32} className={styles.uploadIcon} />
                     <p className={styles.dropText}>Drag &amp; drop or click to browse</p>
-                    <p className={styles.dropSubtext}>PNG, JPG, SVG · max 4 MB</p>
+                    <p className={styles.dropSubtext}>{assetAccept.split(',').map(t => t.replace('image/', '').toUpperCase()).join(', ')} · max {(assetMaxBytes / (1024 * 1024)).toFixed(0)} MB</p>
                   </>
                 )}
               </div>
-              <input ref={fileRef} type="file" accept="image/*" className={styles.hiddenInput} onChange={handleFileChange} />
+              <input ref={fileRef} type="file" accept={assetAccept} className={styles.hiddenInput} onChange={handleFileChange} />
               {uploadFile && <p className={styles.fileName}>{uploadFile.name}</p>}
               {uploadError && <p className={styles.errorText}>{uploadError}</p>}
             </div>

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/AppIconPickerModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Search, Upload, X, Check, Loader } from 'lucide-react';
 import { apiClient } from '../../../api/client';
+import { createMediaAsset, getPreSignedUrl, uploadToBlob, finalizeAssetUpload } from '../../../api/asset';
 import { useEditorStore } from '../../../store/editor.store';
 import styles from './AppIconPickerModal.module.scss';
 
@@ -44,6 +45,9 @@ export const AppIconPickerModal: React.FC<AppIconPickerModalProps> = ({
 
   const channel = useEditorStore(s => s.editorConfig?.context?.channel ?? '');
   const uid = useEditorStore(s => s.editorConfig?.context?.uid ?? '');
+  const presignedHeaders = useEditorStore(
+    s => (s.editorConfig?.context?.cloudStorage?.presigned_headers ?? {}) as Record<string, string>,
+  );
 
   const searchImages = useCallback(async (q: string, off: number, append = false) => {
     setIsLoading(true);
@@ -134,16 +138,21 @@ export const AppIconPickerModal: React.FC<AppIconPickerModalProps> = ({
     setIsUploading(true);
     setUploadError('');
     try {
-      const formData = new FormData();
-      formData.append('file', uploadFile);
-      const resp = await apiClient.post(
-        `/action/content/v3/upload/${nodeId}?fileType=image`,
-        formData,
-        { headers: { 'Content-Type': 'multipart/form-data' } },
+      // Step 1: Register a new asset node in Sunbird
+      const assetId = await createMediaAsset(
+        uploadFile.name.split('.').slice(0, -1).join('.') || uploadFile.name,
+        uploadFile.type,
+        uid,
+        channel,
       );
-      const url = resp.data?.result?.artifactUrl as string | undefined;
-      if (!url) throw new Error('No URL in response');
-      onSelect(url);
+      // Step 2: Get Azure pre-signed upload URL
+      const signedUrl = await getPreSignedUrl(assetId, uploadFile.name);
+      // Step 3: PUT raw file bytes directly to blob storage
+      await uploadToBlob(signedUrl, uploadFile, presignedHeaders);
+      // Step 4: Finalize — link blob URL to asset, get CDN content_url
+      const fileUrl = signedUrl.split('?')[0];
+      const contentUrl = await finalizeAssetUpload(assetId, fileUrl, uploadFile.type);
+      onSelect(contentUrl);
     } catch (err) {
       setUploadError(err instanceof Error ? err.message : 'Upload failed.');
     } finally {

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/ChipGroupField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/ChipGroupField.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useRef } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Plus } from 'lucide-react';
+import styles from './Field.module.scss';
+
+interface ChipGroupFieldProps { name: string; label: string; required?: boolean; disabled?: boolean; placeholder?: string; }
+
+export const ChipGroupField: React.FC<ChipGroupFieldProps> = ({ name, label, required, disabled, placeholder = 'Add…' }) => {
+  const [inputVal, setInputVal] = useState('');
+  const [adding, setAdding] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { watch, setValue, formState: { errors } } = useFormContext();
+  const values = (watch(name) as string[]) ?? [];
+  const error = errors[name];
+
+  const add = () => {
+    const v = inputVal.trim();
+    if (v && !values.includes(v)) setValue(name, [...values, v], { shouldDirty: true });
+    setInputVal('');
+    setAdding(false);
+  };
+
+  const remove = (v: string) => setValue(name, values.filter(x => x !== v), { shouldDirty: true });
+
+  return (
+    <div className={[styles.field, styles.fullWidth].join(' ')}>
+      <label className={styles.label}>{label}{required && <span className={styles.required}>*</span>}</label>
+      <div className={styles.chipGroup}>
+        {values.map(v => (
+          <span key={v} className="sbx-chip filled">
+            {v}
+            {!disabled && <button type="button" className="sbx-chip-remove" onClick={() => remove(v)} aria-label={`Remove ${v}`}>×</button>}
+          </span>
+        ))}
+        {!disabled && (
+          adding ? (
+            <input ref={inputRef} autoFocus className={styles.chipInput} value={inputVal}
+              onChange={e => setInputVal(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } if (e.key === 'Escape') { setInputVal(''); setAdding(false); } }}
+              onBlur={add} placeholder={placeholder}
+            />
+          ) : (
+            <button type="button" className={styles.addChipBtn} onClick={() => { setAdding(true); setTimeout(() => inputRef.current?.focus(), 50); }}>
+              <Plus size={12} /> Add
+            </button>
+          )
+        )}
+      </div>
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/DateTimeField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/DateTimeField.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import styles from './Field.module.scss';
+
+interface DateTimeFieldProps {
+  name: string;
+  label: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+export const DateTimeField: React.FC<DateTimeFieldProps> = ({ name, label, required, disabled }) => {
+  const { control } = useFormContext();
+  const {
+    field,
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules: { required: required ? `${label} is required` : false },
+  });
+
+  return (
+    <div className={styles.field}>
+      <label className={styles.label} htmlFor={name}>
+        {label}{required && <span className={styles.required}>*</span>}
+      </label>
+      <input
+        id={name}
+        type="datetime-local"
+        className={[styles.input, error ? styles.inputError : ''].join(' ')}
+        disabled={disabled}
+        value={field.value as string ?? ''}
+        onChange={field.onChange}
+        onBlur={field.onBlur}
+        ref={field.ref}
+      />
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/DialcodeInputField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/DialcodeInputField.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import { CheckCircle, XCircle, Loader } from 'lucide-react';
+import { checkDialCode } from '../../../api/dialcode';
+import styles from './Field.module.scss';
+
+type ValidationStatus = 'idle' | 'loading' | 'valid' | 'invalid';
+
+interface DialcodeInputFieldProps {
+  name: string;
+  label: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+export const DialcodeInputField: React.FC<DialcodeInputFieldProps> = ({ name, label, required, disabled }) => {
+  const { control } = useFormContext();
+  const {
+    field,
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules: { required: required ? `${label} is required` : false },
+    defaultValue: '',
+  });
+
+  const [status, setStatus] = useState<ValidationStatus>('idle');
+  const [validationMessage, setValidationMessage] = useState('');
+
+  const handleValidate = async () => {
+    const code = (field.value as string ?? '').trim();
+    if (!code) {
+      setStatus('invalid');
+      setValidationMessage('Enter a dial code to validate.');
+      return;
+    }
+    setStatus('loading');
+    setValidationMessage('');
+    try {
+      const data = await checkDialCode(code) as Record<string, unknown>;
+      const result = data?.result as Record<string, unknown> | undefined;
+      const dialcodes = result?.dialcodes as unknown[];
+      if (Array.isArray(dialcodes) && dialcodes.length > 0) {
+        setStatus('valid');
+        setValidationMessage('Dial code is valid.');
+      } else {
+        setStatus('invalid');
+        setValidationMessage('Dial code not found.');
+      }
+    } catch {
+      setStatus('invalid');
+      setValidationMessage('Validation failed. Please try again.');
+    }
+  };
+
+  const statusIcon = () => {
+    if (status === 'loading') return <Loader size={16} className={styles.dialcodeSpinner} />;
+    if (status === 'valid') return <CheckCircle size={16} color="var(--sbx-success, #2e7d32)" />;
+    if (status === 'invalid') return <XCircle size={16} color="var(--sbx-error)" />;
+    return null;
+  };
+
+  return (
+    <div className={styles.field}>
+      <label className={styles.label} htmlFor={name}>
+        {label}{required && <span className={styles.required}>*</span>}
+      </label>
+      <div className={styles.dialcodeRow}>
+        <input
+          id={name}
+          type="text"
+          className={[styles.input, error ? styles.inputError : ''].join(' ')}
+          disabled={disabled}
+          value={field.value as string ?? ''}
+          onChange={e => {
+            field.onChange(e);
+            setStatus('idle');
+            setValidationMessage('');
+          }}
+          onBlur={field.onBlur}
+          ref={field.ref}
+          placeholder="e.g. A1B2C3"
+          style={{ flex: 1 }}
+        />
+        <button
+          type="button"
+          className={styles.validateBtn}
+          onClick={handleValidate}
+          disabled={disabled || status === 'loading'}
+          aria-label="Validate dial code"
+        >
+          {status === 'loading' ? 'Validating…' : 'Validate'}
+        </button>
+        {statusIcon()}
+      </div>
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+      {!error && validationMessage && (
+        <span className={status === 'valid' ? styles.dialcodeValid : styles.error}>
+          {validationMessage}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/Field.module.scss
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/Field.module.scss
@@ -135,7 +135,7 @@
   background: none; border: 1px solid var(--sbx-error);
   border-radius: var(--sbx-r-sm); padding: 3px 8px;
   font-size: 12px; color: var(--sbx-error); cursor: pointer;
-  &:hover { background: #fff0f0; }
+  &:hover { background: var(--sbx-status-err-bg); }
 }
 
 // Tag chips used by KeywordSuggestField

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/Field.module.scss
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/Field.module.scss
@@ -1,0 +1,190 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fullWidth { grid-column: 1 / -1; }
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--sbx-gray-600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.required { color: var(--sbx-error); margin-left: 2px; }
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-sm);
+  font-size: 14px;
+  color: var(--sbx-gray-900);
+  font-family: var(--sbx-font);
+  outline: none;
+  transition: border-color 0.15s;
+  background: white;
+  &:focus { border-color: var(--sbx-primary); }
+  &:disabled { background: var(--sbx-gray-50); color: var(--sbx-gray-400); cursor: not-allowed; }
+}
+
+.textarea { resize: vertical; min-height: 80px; }
+
+.inputError { border-color: var(--sbx-error); }
+
+.error { font-size: 12px; color: var(--sbx-error); }
+
+.selectBtn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 12px;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-sm);
+  background: white;
+  cursor: pointer;
+  font-size: 14px;
+  font-family: var(--sbx-font);
+  color: var(--sbx-gray-900);
+  transition: border-color 0.15s;
+  &:hover:not(:disabled) { border-color: var(--sbx-primary); }
+  &:disabled { background: var(--sbx-gray-50); cursor: not-allowed; opacity: 0.7; }
+}
+
+.selectOpen { border-color: var(--sbx-primary); }
+.placeholder { color: var(--sbx-gray-400); }
+.selectedVal { color: var(--sbx-gray-900); }
+.chevronUp { transform: rotate(180deg); transition: transform 0.15s; }
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0; right: 0;
+  z-index: 200;
+  background: white;
+  border: 1px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-md);
+  box-shadow: var(--sbx-shadow-3);
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 4px;
+  margin-top: 4px;
+}
+
+.option {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; padding: 8px 12px; border: none; background: none;
+  cursor: pointer; font-size: 14px; color: var(--sbx-gray-700);
+  border-radius: var(--sbx-r-sm); text-align: left;
+  &:hover { background: var(--sbx-gray-50); }
+}
+
+.optionSelected { color: var(--sbx-primary); font-weight: 500; }
+.noOpts { display: block; padding: 8px 12px; color: var(--sbx-gray-400); font-size: 13px; }
+
+.chipGroup {
+  display: flex; flex-wrap: wrap; gap: 8px; align-items: center;
+  padding: 8px;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-sm);
+  min-height: 40px;
+  background: white;
+}
+
+.chipInput {
+  border: 1px solid var(--sbx-primary);
+  border-radius: var(--sbx-r-xl);
+  padding: 3px 10px;
+  font-size: 13px;
+  outline: none;
+  width: 120px;
+}
+
+.addChipBtn {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: none; border: 1px dashed var(--sbx-gray-300);
+  border-radius: var(--sbx-r-xl); padding: 3px 10px;
+  font-size: 12px; color: var(--sbx-gray-500); cursor: pointer;
+  &:hover { border-color: var(--sbx-primary); color: var(--sbx-primary); }
+}
+
+.radioGroup { display: flex; gap: 16px; flex-wrap: wrap; padding: 4px 0; }
+.radioLabel { display: flex; align-items: center; gap: 6px; font-size: 14px; cursor: pointer; }
+
+.iconWrap {
+  width: 80px; height: 80px;
+  border-radius: var(--sbx-r-md);
+  border: 2px dashed var(--sbx-gray-300);
+  cursor: pointer; overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+  &:hover { border-color: var(--sbx-primary); }
+}
+
+.iconPreview { width: 100%; height: 100%; object-fit: cover; }
+.iconPlaceholder { display: flex; flex-direction: column; align-items: center; gap: 4px; color: var(--sbx-gray-400); font-size: 11px; }
+.hidden { display: none; }
+
+.removeIconBtn {
+  display: flex; align-items: center; justify-content: center; gap: 4px;
+  width: 80px;
+  margin-top: 4px;
+  background: none; border: 1px solid var(--sbx-error);
+  border-radius: var(--sbx-r-sm); padding: 3px 8px;
+  font-size: 12px; color: var(--sbx-error); cursor: pointer;
+  &:hover { background: #fff0f0; }
+}
+
+// Tag chips used by KeywordSuggestField
+.tagChip {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: var(--sbx-primary-light, #e8f4fd);
+  color: var(--sbx-primary);
+  border-radius: var(--sbx-r-xl);
+  padding: 3px 10px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.tagChipRemove {
+  display: inline-flex; align-items: center;
+  background: none; border: none; padding: 0 0 0 2px;
+  cursor: pointer; color: var(--sbx-primary); line-height: 1;
+  &:hover { color: var(--sbx-error); }
+}
+
+// Nested selects row
+.nestedSelectRow {
+  display: flex; gap: 12px; flex-wrap: wrap;
+  & > * { min-width: 140px; }
+}
+
+// Dialcode input row
+.dialcodeRow {
+  display: flex; align-items: center; gap: 8px;
+}
+
+.validateBtn {
+  flex-shrink: 0;
+  padding: 8px 14px;
+  background: var(--sbx-primary);
+  color: white;
+  border: none;
+  border-radius: var(--sbx-r-sm);
+  font-size: 13px;
+  font-family: var(--sbx-font);
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+  &:hover:not(:disabled) { background: var(--sbx-primary-dark, #0056b3); }
+  &:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.dialcodeValid { font-size: 12px; color: var(--sbx-success, #2e7d32); }
+
+@keyframes spin { to { transform: rotate(360deg); } }
+.dialcodeSpinner { animation: spin 1s linear infinite; }

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/KeywordSuggestField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/KeywordSuggestField.tsx
@@ -1,0 +1,98 @@
+import React, { useState, useRef } from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import { X } from 'lucide-react';
+import styles from './Field.module.scss';
+
+interface KeywordSuggestFieldProps {
+  name: string;
+  label: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+export const KeywordSuggestField: React.FC<KeywordSuggestFieldProps> = ({ name, label, required, disabled }) => {
+  const { control } = useFormContext();
+  const {
+    field,
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules: { required: required ? `${label} is required` : false },
+    defaultValue: [],
+  });
+
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const tags = (field.value as string[]) ?? [];
+
+  const addTag = (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed || tags.includes(trimmed)) return;
+    field.onChange([...tags, trimmed]);
+  };
+
+  const removeTag = (tag: string) => {
+    field.onChange(tags.filter(t => t !== tag));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag(inputValue);
+      setInputValue('');
+    } else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  };
+
+  const handleBlur = () => {
+    if (inputValue.trim()) {
+      addTag(inputValue);
+      setInputValue('');
+    }
+    field.onBlur();
+  };
+
+  return (
+    <div className={[styles.field, styles.fullWidth].join(' ')}>
+      <label className={styles.label}>
+        {label}{required && <span className={styles.required}>*</span>}
+      </label>
+      <div
+        className={[styles.chipGroup, error ? styles.inputError : ''].join(' ')}
+        onClick={() => !disabled && inputRef.current?.focus()}
+        style={{ cursor: disabled ? 'not-allowed' : 'text' }}
+      >
+        {tags.map(tag => (
+          <span key={tag} className={styles.tagChip}>
+            {tag}
+            {!disabled && (
+              <button
+                type="button"
+                className={styles.tagChipRemove}
+                onClick={e => { e.stopPropagation(); removeTag(tag); }}
+                aria-label={`Remove ${tag}`}
+              >
+                <X size={11} />
+              </button>
+            )}
+          </span>
+        ))}
+        {!disabled && (
+          <input
+            ref={inputRef}
+            className={styles.chipInput}
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            placeholder={tags.length === 0 ? 'Type and press Enter or comma…' : ''}
+            style={{ flexGrow: 1, minWidth: 120 }}
+          />
+        )}
+      </div>
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/LicenseSelectField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/LicenseSelectField.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { ChevronDown, Check } from 'lucide-react';
+import styles from './Field.module.scss';
+
+const LICENSE_OPTIONS = [
+  { label: 'CC BY 4.0', value: 'CC BY 4.0' },
+  { label: 'CC BY-SA 4.0', value: 'CC BY-SA 4.0' },
+  { label: 'CC BY-NC 4.0', value: 'CC BY-NC 4.0' },
+  { label: 'CC BY-NC-SA 4.0', value: 'CC BY-NC-SA 4.0' },
+  { label: 'CC BY-ND 4.0', value: 'CC BY-ND 4.0' },
+  { label: 'CC0 1.0 (Public Domain)', value: 'CC0 1.0' },
+];
+
+interface LicenseSelectFieldProps {
+  name: string;
+  label: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+export const LicenseSelectField: React.FC<LicenseSelectFieldProps> = ({ name, label, required, disabled }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { register, watch, setValue, formState: { errors } } = useFormContext();
+  const value = watch(name) as string;
+  const selectedOption = LICENSE_OPTIONS.find(o => o.value === value);
+  const selectedLabel = selectedOption?.label ?? 'Select license…';
+  const error = errors[name];
+
+  useEffect(() => {
+    if (!open) return;
+    const fn = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', fn);
+    return () => document.removeEventListener('mousedown', fn);
+  }, [open]);
+
+  return (
+    <div className={styles.field} ref={ref} style={{ position: 'relative' }}>
+      <label className={styles.label}>
+        {label}{required && <span className={styles.required}>*</span>}
+      </label>
+      <input
+        type="hidden"
+        {...register(name, { required: required ? `${label} is required` : false })}
+      />
+      <button
+        type="button"
+        disabled={disabled}
+        className={[styles.selectBtn, error ? styles.inputError : '', open ? styles.selectOpen : ''].join(' ')}
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className={value ? styles.selectedVal : styles.placeholder}>{selectedLabel}</span>
+        <ChevronDown size={14} className={open ? styles.chevronUp : ''} />
+      </button>
+      {open && (
+        <div className={styles.dropdown} role="listbox">
+          {LICENSE_OPTIONS.map(opt => (
+            <button
+              key={opt.value}
+              type="button"
+              role="option"
+              aria-selected={value === opt.value}
+              className={[styles.option, value === opt.value ? styles.optionSelected : ''].join(' ')}
+              onClick={() => {
+                setValue(name, opt.value, { shouldDirty: true, shouldValidate: true });
+                setOpen(false);
+              }}
+            >
+              <span>{opt.label}</span>
+              {value === opt.value && <Check size={13} />}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/MultiSelectField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/MultiSelectField.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { ChevronDown, Check } from 'lucide-react';
+import styles from './Field.module.scss';
+
+interface Option { label: string; value: string; }
+interface MultiSelectFieldProps { name: string; label: string; options: Option[]; required?: boolean; disabled?: boolean; }
+
+export const MultiSelectField: React.FC<MultiSelectFieldProps> = ({ name, label, options, required, disabled }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { register, watch, setValue, formState: { errors } } = useFormContext();
+  const values = (watch(name) as string[]) ?? [];
+  const error = errors[name];
+  const displayText = values.length ? `${values.length} selected` : 'Select…';
+
+  useEffect(() => {
+    if (!open) return;
+    const fn = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false); };
+    document.addEventListener('mousedown', fn);
+    return () => document.removeEventListener('mousedown', fn);
+  }, [open]);
+
+  const toggle = (v: string) => {
+    const next = values.includes(v) ? values.filter(x => x !== v) : [...values, v];
+    setValue(name, next, { shouldDirty: true, shouldValidate: true });
+  };
+
+  return (
+    <div className={styles.field} ref={ref} style={{ position: 'relative' }}>
+      <label className={styles.label}>{label}{required && <span className={styles.required}>*</span>}</label>
+      <input type="hidden" {...register(name, { required: required ? `${label} is required` : false })} />
+      <button type="button" disabled={disabled} className={[styles.selectBtn, error ? styles.inputError : '', open ? styles.selectOpen : ''].join(' ')} onClick={() => setOpen(v => !v)}>
+        <span className={values.length ? styles.selectedVal : styles.placeholder}>{displayText}</span>
+        <ChevronDown size={14} className={open ? styles.chevronUp : ''} />
+      </button>
+      {open && (
+        <div className={styles.dropdown}>
+          {options.map(opt => (
+            <button key={opt.value} type="button" className={[styles.option, values.includes(opt.value) ? styles.optionSelected : ''].join(' ')} onClick={() => toggle(opt.value)}>
+              <Check size={13} style={{ opacity: values.includes(opt.value) ? 1 : 0 }} />
+              <span>{opt.label}</span>
+            </button>
+          ))}
+          {!options.length && <span className={styles.noOpts}>No options</span>}
+        </div>
+      )}
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/NestedSelectField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/NestedSelectField.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import styles from './Field.module.scss';
+
+interface LevelOption { label: string; value: string; }
+interface Level { code: string; label: string; options: LevelOption[]; }
+
+interface NestedSelectFieldProps {
+  name: string;
+  label: string;
+  levels: Level[];
+  required?: boolean;
+  disabled?: boolean;
+}
+
+export const NestedSelectField: React.FC<NestedSelectFieldProps> = ({
+  name, label, levels, required, disabled,
+}) => {
+  const { control } = useFormContext();
+  const {
+    field,
+    fieldState: { error },
+  } = useController({
+    name,
+    control,
+    rules: { required: required ? `${label} is required` : false },
+    defaultValue: {},
+  });
+
+  // field.value is a Record<string, string> mapping level.code → selected value
+  const selections: Record<string, string> = (field.value as Record<string, string>) ?? {};
+
+  const handleChange = (levelCode: string, levelIndex: number, value: string) => {
+    const updated: Record<string, string> = {};
+    // Keep selections up to and including the changed level, reset deeper ones
+    for (let i = 0; i < levelIndex; i++) {
+      updated[levels[i].code] = selections[levels[i].code] ?? '';
+    }
+    updated[levelCode] = value;
+    // Clear child selections
+    for (let i = levelIndex + 1; i < levels.length; i++) {
+      updated[levels[i].code] = '';
+    }
+    field.onChange(updated);
+  };
+
+  return (
+    <div className={[styles.field, styles.fullWidth].join(' ')}>
+      <label className={styles.label}>
+        {label}{required && <span className={styles.required}>*</span>}
+      </label>
+      <div className={styles.nestedSelectRow}>
+        {levels.map((level, idx) => {
+          const isLocked = idx > 0 && !selections[levels[idx - 1].code];
+          return (
+            <div key={level.code} className={styles.field} style={{ flex: 1 }}>
+              <label className={styles.label} htmlFor={`${name}_${level.code}`}>
+                {level.label}
+              </label>
+              <select
+                id={`${name}_${level.code}`}
+                className={[styles.input, error ? styles.inputError : ''].join(' ')}
+                disabled={disabled || isLocked}
+                value={selections[level.code] ?? ''}
+                onChange={e => handleChange(level.code, idx, e.target.value)}
+                onBlur={field.onBlur}
+              >
+                <option value="">Select…</option>
+                {level.options.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+          );
+        })}
+      </div>
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/RadioField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/RadioField.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import styles from './Field.module.scss';
+
+interface Option { label: string; value: string; }
+interface RadioFieldProps { name: string; label: string; options: Option[]; required?: boolean; disabled?: boolean; }
+
+export const RadioField: React.FC<RadioFieldProps> = ({ name, label, options, required, disabled }) => {
+  const { register, formState: { errors } } = useFormContext();
+  const error = errors[name];
+  return (
+    <div className={styles.field}>
+      <label className={styles.label}>{label}{required && <span className={styles.required}>*</span>}</label>
+      <div className={styles.radioGroup}>
+        {options.map(opt => (
+          <label key={opt.value} className={styles.radioLabel}>
+            <input type="radio" value={opt.value} disabled={disabled} {...register(name, { required: required ? `${label} is required` : false })} />
+            {opt.label}
+          </label>
+        ))}
+      </div>
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/SelectField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/SelectField.tsx
@@ -1,0 +1,47 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { ChevronDown, Check } from 'lucide-react';
+import styles from './Field.module.scss';
+
+interface Option { label: string; value: string; }
+interface SelectFieldProps { name: string; label: string; options: Option[]; required?: boolean; disabled?: boolean; }
+
+export const SelectField: React.FC<SelectFieldProps> = ({ name, label, options, required, disabled }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { register, watch, setValue, formState: { errors } } = useFormContext();
+  const value = watch(name) as string;
+  const selectedLabel = options.find(o => o.value === value)?.label ?? 'Select…';
+  const error = errors[name];
+
+  useEffect(() => {
+    if (!open) return;
+    const fn = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) setOpen(false); };
+    document.addEventListener('mousedown', fn);
+    return () => document.removeEventListener('mousedown', fn);
+  }, [open]);
+
+  return (
+    <div className={styles.field} ref={ref} style={{ position: 'relative' }}>
+      <label className={styles.label}>{label}{required && <span className={styles.required}>*</span>}</label>
+      <input type="hidden" {...register(name, { required: required ? `${label} is required` : false })} />
+      <button type="button" disabled={disabled} className={[styles.selectBtn, error ? styles.inputError : '', open ? styles.selectOpen : ''].join(' ')} onClick={() => setOpen(v => !v)}>
+        <span className={value ? styles.selectedVal : styles.placeholder}>{selectedLabel}</span>
+        <ChevronDown size={14} className={open ? styles.chevronUp : ''} />
+      </button>
+      {open && (
+        <div className={styles.dropdown}>
+          {options.map(opt => (
+            <button key={opt.value} type="button" className={[styles.option, value === opt.value ? styles.optionSelected : ''].join(' ')}
+              onClick={() => { setValue(name, opt.value, { shouldDirty: true, shouldValidate: true }); setOpen(false); }}>
+              <span>{opt.label}</span>
+              {value === opt.value && <Check size={13} />}
+            </button>
+          ))}
+          {!options.length && <span className={styles.noOpts}>No options</span>}
+        </div>
+      )}
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/TextField.tsx
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/TextField.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import styles from './Field.module.scss';
+
+interface TextFieldProps {
+  name: string; label: string; required?: boolean; disabled?: boolean;
+  multiline?: boolean; maxLength?: number; placeholder?: string;
+}
+
+export const TextField: React.FC<TextFieldProps> = ({ name, label, required, disabled, multiline, maxLength, placeholder }) => {
+  const { register, formState: { errors } } = useFormContext();
+  const error = errors[name];
+  const registerOpts = { required: required ? `${label} is required` : false, maxLength: maxLength ? { value: maxLength, message: `Max ${maxLength} characters` } : undefined };
+
+  return (
+    <div className={[styles.field, multiline ? styles.fullWidth : ''].join(' ')}>
+      <label className={styles.label} htmlFor={name}>
+        {label}{required && <span className={styles.required}>*</span>}
+      </label>
+      {multiline ? (
+        <textarea id={name} className={[styles.input, styles.textarea, error ? styles.inputError : ''].join(' ')} disabled={disabled} placeholder={placeholder} rows={3} {...register(name, registerOpts)} />
+      ) : (
+        <input id={name} type="text" className={[styles.input, error ? styles.inputError : ''].join(' ')} disabled={disabled} placeholder={placeholder} {...register(name, registerOpts)} />
+      )}
+      {error && <span className={styles.error}>{String(error.message)}</span>}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/SparkMetaForm/fields/index.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/fields/index.ts
@@ -1,0 +1,11 @@
+export { TextField } from './TextField';
+export { SelectField } from './SelectField';
+export { MultiSelectField } from './MultiSelectField';
+export { ChipGroupField } from './ChipGroupField';
+export { RadioField } from './RadioField';
+export { AppIconField } from './AppIconField';
+export { DateTimeField } from './DateTimeField';
+export { KeywordSuggestField } from './KeywordSuggestField';
+export { NestedSelectField } from './NestedSelectField';
+export { LicenseSelectField } from './LicenseSelectField';
+export { DialcodeInputField } from './DialcodeInputField';

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/emitTransform.test.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/emitTransform.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { transformEmit, transformFieldPatch, createLevels } from './emitTransform';
+
+describe('transformEmit (batch write — mirrors Angular emitValue)', () => {
+  it('omits UI-only keys allowECM / setPeriod / levels / instances', () => {
+    const out = transformEmit({ name: 'X', allowECM: true, setPeriod: 5, levels: [], instances: '' });
+    expect(out.allowECM).toBeUndefined();
+    expect(out.setPeriod).toBeUndefined();
+    expect(out.levels).toBeUndefined();
+    expect(out.instances).toBeUndefined();
+    expect(out.name).toBe('X');
+  });
+
+  it('maps levels[] → outcomeDeclaration.levels', () => {
+    const out = transformEmit({ levels: ['Beginner', 'Advanced'] });
+    expect(out.outcomeDeclaration).toEqual({ levels: { L1: { label: 'Beginner' }, L2: { label: 'Advanced' } } });
+  });
+
+  it('maps instances → { label }', () => {
+    const out = transformEmit({ instances: 'Set A' });
+    expect(out.instances).toEqual({ label: 'Set A' });
+  });
+
+  it('falls back to the node title for an empty name in review mode', () => {
+    const out = transformEmit({ name: '' }, { isReview: true, nodeTitle: 'My Course' });
+    expect(out.name).toBe('My Course');
+  });
+
+  it('does not override a present name in review mode', () => {
+    const out = transformEmit({ name: 'Typed' }, { isReview: true, nodeTitle: 'My Course' });
+    expect(out.name).toBe('Typed');
+  });
+});
+
+describe('transformFieldPatch (single-field write)', () => {
+  it('returns null for UI-only fields so they are never persisted', () => {
+    expect(transformFieldPatch('allowECM', true)).toBeNull();
+    expect(transformFieldPatch('setPeriod', 3)).toBeNull();
+  });
+
+  it('maps levels and instances on single-field change', () => {
+    expect(transformFieldPatch('levels', ['A'])).toEqual({ outcomeDeclaration: { levels: { L1: { label: 'A' } } } });
+    expect(transformFieldPatch('instances', 'S')).toEqual({ instances: { label: 'S' } });
+  });
+
+  it('passes ordinary fields through unchanged', () => {
+    expect(transformFieldPatch('medium', ['English'])).toEqual({ medium: ['English'] });
+  });
+});
+
+describe('createLevels', () => {
+  it('builds L1..Ln keyed labels', () => {
+    expect(createLevels(['a', 'b', 'c'])).toEqual({
+      L1: { label: 'a' }, L2: { label: 'b' }, L3: { label: 'c' },
+    });
+  });
+});

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/emitTransform.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/emitTransform.ts
@@ -1,0 +1,57 @@
+// Pure form-value transforms, ported from Angular SparkMetaFormComponent.emitValue
+// (spark-meta-form.component.ts:507-543). Keeps the watch handler in
+// SparkMetaForm thin and unit-testable.
+
+// Internal/UI-only keys that must never reach the save payload.
+export const EMIT_OMIT_KEYS = ['allowECM', 'levels', 'setPeriod', 'instances'] as const;
+
+// levels[] → { L1: { label }, L2: { label }, … } (outcomeDeclaration shape).
+export function createLevels(levels: unknown[]): Record<string, { label: unknown }> {
+  const obj: Record<string, { label: unknown }> = {};
+  levels.forEach((el, i) => { obj[`L${i + 1}`] = { label: el }; });
+  return obj;
+}
+
+/**
+ * Transform the full form value object before it is written to the node /
+ * emitted — used for batch / cascade writes (Angular emits the whole `data`).
+ */
+export function transformEmit(
+  values: Record<string, unknown>,
+  opts: { isReview?: boolean; nodeTitle?: string } = {},
+): Record<string, unknown> {
+  const data: Record<string, unknown> = { ...values };
+  for (const k of EMIT_OMIT_KEYS) delete data[k];
+
+  const levels = values.levels;
+  if (Array.isArray(levels) && levels.length) {
+    data.outcomeDeclaration = { levels: createLevels(levels) };
+  }
+  const instances = values.instances;
+  if (instances !== undefined && instances !== null && instances !== '') {
+    data.instances = { label: instances };
+  }
+  // In review modes the name field may be hidden/empty; preserve the node title.
+  if (opts.isReview && (data.name === undefined || data.name === null || data.name === '') && opts.nodeTitle) {
+    data.name = opts.nodeTitle;
+  }
+  return data;
+}
+
+/**
+ * Transform a single changed field into the patch to persist. Returns null
+ * when the field is UI-only and must not be written (allowECM / setPeriod).
+ */
+export function transformFieldPatch(
+  changedField: string,
+  value: unknown,
+): Record<string, unknown> | null {
+  if (changedField === 'allowECM' || changedField === 'setPeriod') return null;
+  if (changedField === 'levels') {
+    return { outcomeDeclaration: { levels: Array.isArray(value) ? createLevels(value) : {} } };
+  }
+  if (changedField === 'instances') {
+    return { instances: value !== undefined && value !== null && value !== '' ? { label: value } : '' };
+  }
+  return { [changedField]: value };
+}

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/index.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useFieldPrepare } from './useFieldPrepare';
+export type { PreparedField, IFieldConfig } from './useFieldPrepare';
+export { useCascade } from './useCascade';

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useCascade.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useCascade.ts
@@ -1,0 +1,128 @@
+import { useEffect } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import { getFramework } from '../../../api/framework';
+import type { IFieldConfig } from './useFieldPrepare';
+
+// Re-export IFieldConfig so callers can import it from either location.
+export type { IFieldConfig } from './useFieldPrepare';
+
+/**
+ * useCascade
+ *
+ * Watches parent fields (e.g. board → medium → gradeLevel → subject) and:
+ *   1. Resets the child field value whenever its parent changes.
+ *   2. Reloads the child field's options from the framework API, filtered by
+ *      the associations of the currently-selected parent value(s).
+ *
+ * Framework term parent-child relations are encoded in ITerm.associations —
+ * a term's associations array contains its parent terms. We therefore keep
+ * only those child terms whose associations include (by identifier or code)
+ * one of the currently-selected parent values.
+ *
+ * @param form   react-hook-form UseFormReturn instance.
+ * @param fields Mutable array of IFieldConfig objects (options/range are
+ *               patched in-place so the referencing component re-renders
+ *               when it reads them from state managed by the caller).
+ */
+export function useCascade(
+  form: UseFormReturn<Record<string, unknown>>,
+  fields: IFieldConfig[],
+): void {
+  const { watch, setValue } = form;
+  const watchAll = watch();
+
+  // ── Step 1: Reset child values when a parent field changes ──────────────
+  useEffect(() => {
+    const subscription = watch((_values, { name: changedField }) => {
+      if (!changedField) return;
+      fields.forEach(f => {
+        if (f.depends?.includes(changedField)) {
+          setValue(
+            f.code,
+            f.inputType === 'multiselect' || f.inputType === 'chips' ? [] : '',
+            { shouldDirty: true },
+          );
+        }
+      });
+    });
+    return () => subscription.unsubscribe();
+  }, [watch, setValue, fields]);
+
+  // ── Step 2: Reload options for framework-backed dependent fields ─────────
+  useEffect(() => {
+    const dependentFields = fields.filter(
+      f => f.depends && f.depends.length > 0 && f.frameworkId && f.categoryCode,
+    );
+    if (!dependentFields.length) return;
+
+    let cancelled = false;
+
+    const reload = async () => {
+      for (const field of dependentFields) {
+        if (!field.frameworkId || !field.categoryCode) continue;
+
+        try {
+          const fw = await getFramework(field.frameworkId);
+          if (cancelled) return;
+
+          const category = fw.categories?.find(c => c.code === field.categoryCode);
+          if (!category) continue;
+
+          let terms = category.terms ?? [];
+
+          // Filter by parent association if a parent value is selected.
+          // Sunbird encodes parent↔child relations in ITerm.associations:
+          // a term's associations[] contains its parent term objects.
+          if (field.depends && field.depends.length > 0) {
+            const parentCode = field.depends[0];
+            const parentValue = watchAll[parentCode];
+
+            if (parentValue !== undefined && parentValue !== null && parentValue !== '') {
+              const parentValues = (Array.isArray(parentValue) ? parentValue : [parentValue]) as string[];
+
+              if (parentValues.length > 0) {
+                terms = terms.filter(term => {
+                  const assoc = term.associations;
+                  if (!assoc || assoc.length === 0) {
+                    // Term has no associations — include it (no filtering possible)
+                    return true;
+                  }
+                  // Keep term if at least one association matches a selected parent value
+                  // (compare by identifier or code, since callers may store either)
+                  return assoc.some(
+                    a => parentValues.includes(a.identifier) || parentValues.includes(a.code),
+                  );
+                });
+              }
+            }
+          }
+
+          // Patch options and range in-place so referencing components see
+          // the updated list on their next render cycle.
+          field.range = terms.map(t => ({ name: t.name, identifier: t.identifier }));
+          field.options = terms.map(t => ({ label: t.name, value: t.identifier }));
+        } catch {
+          // Silently skip on API failure; existing options remain unchanged.
+        }
+      }
+    };
+
+    reload();
+    return () => {
+      cancelled = true;
+    };
+    // Re-run only when the parent field values change, not on every render.
+    // We build a stable JSON key from just the parent codes that matter.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    JSON.stringify(
+      Object.fromEntries(
+        fields
+          .flatMap(f => f.depends ?? [])
+          .filter((code, i, arr) => arr.indexOf(code) === i) // dedupe
+          .map(code => [code, watchAll[code]]),
+      ),
+    ),
+  ]);
+}

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useCascade.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useCascade.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
-import { getFramework } from '../../../api/framework';
 import type { IFieldConfig } from './useFieldPrepare';
 
 // Re-export IFieldConfig so callers can import it from either location.
@@ -9,29 +8,20 @@ export type { IFieldConfig } from './useFieldPrepare';
 /**
  * useCascade
  *
- * Watches parent fields (e.g. board → medium → gradeLevel → subject) and:
- *   1. Resets the child field value whenever its parent changes.
- *   2. Reloads the child field's options from the framework API, filtered by
- *      the associations of the currently-selected parent value(s).
- *
- * Framework term parent-child relations are encoded in ITerm.associations —
- * a term's associations array contains its parent terms. We therefore keep
- * only those child terms whose associations include (by identifier or code)
- * one of the currently-selected parent values.
+ * Resets a child field's value whenever one of its parent fields (declared via
+ * `depends`) changes. The child's *options* are recomputed reactively in
+ * useFieldPrepare (filtered by the parent's selected value via term
+ * associations), so this hook only has to clear the now-stale child value.
  *
  * @param form   react-hook-form UseFormReturn instance.
- * @param fields Mutable array of IFieldConfig objects (options/range are
- *               patched in-place so the referencing component re-renders
- *               when it reads them from state managed by the caller).
+ * @param fields Prepared field list (carries the `depends` graph).
  */
 export function useCascade(
   form: UseFormReturn<Record<string, unknown>>,
   fields: IFieldConfig[],
 ): void {
   const { watch, setValue } = form;
-  const watchAll = watch();
 
-  // ── Step 1: Reset child values when a parent field changes ──────────────
   useEffect(() => {
     const subscription = watch((_values, { name: changedField }) => {
       if (!changedField) return;
@@ -47,82 +37,4 @@ export function useCascade(
     });
     return () => subscription.unsubscribe();
   }, [watch, setValue, fields]);
-
-  // ── Step 2: Reload options for framework-backed dependent fields ─────────
-  useEffect(() => {
-    const dependentFields = fields.filter(
-      f => f.depends && f.depends.length > 0 && f.frameworkId && f.categoryCode,
-    );
-    if (!dependentFields.length) return;
-
-    let cancelled = false;
-
-    const reload = async () => {
-      for (const field of dependentFields) {
-        if (!field.frameworkId || !field.categoryCode) continue;
-
-        try {
-          const fw = await getFramework(field.frameworkId);
-          if (cancelled) return;
-
-          const category = fw.categories?.find(c => c.code === field.categoryCode);
-          if (!category) continue;
-
-          let terms = category.terms ?? [];
-
-          // Filter by parent association if a parent value is selected.
-          // Sunbird encodes parent↔child relations in ITerm.associations:
-          // a term's associations[] contains its parent term objects.
-          if (field.depends && field.depends.length > 0) {
-            const parentCode = field.depends[0];
-            const parentValue = watchAll[parentCode];
-
-            if (parentValue !== undefined && parentValue !== null && parentValue !== '') {
-              const parentValues = (Array.isArray(parentValue) ? parentValue : [parentValue]) as string[];
-
-              if (parentValues.length > 0) {
-                terms = terms.filter(term => {
-                  const assoc = term.associations;
-                  if (!assoc || assoc.length === 0) {
-                    // Term has no associations — include it (no filtering possible)
-                    return true;
-                  }
-                  // Keep term if at least one association matches a selected parent value
-                  // (compare by identifier or code, since callers may store either)
-                  return assoc.some(
-                    a => parentValues.includes(a.identifier) || parentValues.includes(a.code),
-                  );
-                });
-              }
-            }
-          }
-
-          // Patch options and range in-place so referencing components see
-          // the updated list on their next render cycle.
-          field.range = terms.map(t => ({ name: t.name, identifier: t.identifier }));
-          field.options = terms.map(t => ({ label: t.name, value: t.identifier }));
-        } catch {
-          // Silently skip on API failure; existing options remain unchanged.
-        }
-      }
-    };
-
-    reload();
-    return () => {
-      cancelled = true;
-    };
-    // Re-run only when the parent field values change, not on every render.
-    // We build a stable JSON key from just the parent codes that matter.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    JSON.stringify(
-      Object.fromEntries(
-        fields
-          .flatMap(f => f.depends ?? [])
-          .filter((code, i, arr) => arr.indexOf(code) === i) // dedupe
-          .map(code => [code, watchAll[code]]),
-      ),
-    ),
-  ]);
 }

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useCascade.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useCascade.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { IFieldConfig } from './useFieldPrepare';
 
@@ -8,10 +8,18 @@ export type { IFieldConfig } from './useFieldPrepare';
 /**
  * useCascade
  *
- * Resets a child field's value whenever one of its parent fields (declared via
- * `depends`) changes. The child's *options* are recomputed reactively in
- * useFieldPrepare (filtered by the parent's selected value via term
- * associations), so this hook only has to clear the now-stale child value.
+ * When a parent field changes, clear every field that depends on it —
+ * TRANSITIVELY, in a single pass (board → clears medium → grade → subject all
+ * at once). Mirrors Angular's `resetDependents` (spark-meta-form.component.ts:
+ * 449-465), which walks the full `depends` graph rather than relying on the
+ * RHF watch ripple to clear one level per microtask.
+ *
+ * The child's *options* are recomputed reactively in useFieldPrepare (filtered
+ * by the parent's selected value via term associations), so this hook only has
+ * to clear the now-stale child values.
+ *
+ * A re-entrancy guard stops the setValue calls we make here from re-triggering
+ * the watch callback and clearing the same fields again.
  *
  * @param form   react-hook-form UseFormReturn instance.
  * @param fields Prepared field list (carries the `depends` graph).
@@ -21,19 +29,34 @@ export function useCascade(
   fields: IFieldConfig[],
 ): void {
   const { watch, setValue } = form;
+  const clearingRef = useRef(false);
 
   useEffect(() => {
     const subscription = watch((_values, { name: changedField }) => {
-      if (!changedField) return;
-      fields.forEach(f => {
-        if (f.depends?.includes(changedField)) {
-          setValue(
-            f.code,
-            f.inputType === 'multiselect' || f.inputType === 'chips' ? [] : '',
-            { shouldDirty: true },
-          );
+      if (!changedField || clearingRef.current) return;
+
+      clearingRef.current = true;
+      try {
+        const cleared = new Set<string>([changedField]);
+        let progressed = true;
+        while (progressed) {
+          progressed = false;
+          for (const f of fields) {
+            if (cleared.has(f.code)) continue;
+            if (f.depends?.some(d => cleared.has(d))) {
+              setValue(
+                f.code,
+                f.inputType === 'multiselect' || f.inputType === 'chips' ? [] : '',
+                { shouldDirty: true },
+              );
+              cleared.add(f.code);
+              progressed = true;
+            }
+          }
         }
-      });
+      } finally {
+        clearingRef.current = false;
+      }
     });
     return () => subscription.unsubscribe();
   }, [watch, setValue, fields]);

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.defaults.test.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.defaults.test.ts
@@ -30,11 +30,11 @@ describe('per-field default seeding (mirrors prepareFields 180-244)', () => {
     expect(f.currentValue).toBe('Existing');
   });
 
-  it('defaults author to the user full name and locks the field', () => {
+  it('defaults author to the user full name and keeps it editable', () => {
     const cfg = [{ code: 'author', label: 'Author' }];
     const f = find(useFieldPrepare(cfg, {}, fw, true, { userFullName: 'Jane Doe', editorMode: 'edit' }), 'author');
     expect(f.currentValue).toBe('Jane Doe');
-    expect(f.editable).toBe(false);
+    expect(f.editable).toBe(true);
   });
 
   it('defaults license to the context/channel default license', () => {

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.defaults.test.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.defaults.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { useFieldPrepare } from './useFieldPrepare';
+import type { IFrameworkDetails } from '../../../types/framework';
+
+const fw: IFrameworkDetails = {};
+const find = (fields: ReturnType<typeof useFieldPrepare>, code: string) => fields.find(f => f.code === code)!;
+
+describe('per-field default seeding (mirrors prepareFields 180-244)', () => {
+  it('defaults copyright to the channel name only when setDefaultCopyRight', () => {
+    const cfg = [{ code: 'copyright', label: 'Copyright' }];
+    const seeded = find(useFieldPrepare(cfg, {}, fw, true, { setDefaultCopyRight: true, channelName: 'Acme Org' }), 'copyright');
+    expect(seeded.currentValue).toBe('Acme Org');
+    const notSeeded = find(useFieldPrepare(cfg, {}, fw, true, { channelName: 'Acme Org' }), 'copyright');
+    expect(notSeeded.currentValue).toBe('');
+  });
+
+  it('does not override an authored copyright value', () => {
+    const cfg = [{ code: 'copyright', label: 'Copyright' }];
+    const f = find(useFieldPrepare(cfg, { copyright: 'Existing' }, fw, true, { setDefaultCopyRight: true, channelName: 'Acme' }), 'copyright');
+    expect(f.currentValue).toBe('Existing');
+  });
+
+  it('defaults author to the user full name', () => {
+    const cfg = [{ code: 'author', label: 'Author' }];
+    const f = find(useFieldPrepare(cfg, {}, fw, true, { userFullName: 'Jane Doe' }), 'author');
+    expect(f.currentValue).toBe('Jane Doe');
+  });
+
+  it('defaults license to the context/channel default license', () => {
+    const cfg = [{ code: 'license', label: 'License', inputType: 'license' }];
+    const f = find(useFieldPrepare(cfg, {}, fw, true, { defaultLicense: 'CC BY 4.0' }), 'license');
+    expect(f.currentValue).toBe('CC BY 4.0');
+  });
+
+  it('reads instructions.default for the instructions field', () => {
+    const cfg = [{ code: 'instructions', label: 'Instructions', inputType: 'textarea' }];
+    const f = find(useFieldPrepare(cfg, { instructions: { default: 'Read carefully' } }, fw, true, {}), 'instructions');
+    expect(f.currentValue).toBe('Read carefully');
+  });
+
+  it('sources additionalCategories per objectType', () => {
+    const cfg = [{ code: 'additionalCategories', label: 'Additional', inputType: 'multiselect' }];
+    const collection = find(useFieldPrepare(cfg, {}, fw, true, {
+      objectType: 'Collection', collectionAdditionalCategories: ['Textbook'], contentAdditionalCategories: ['Explanation'],
+    }), 'additionalCategories');
+    expect(collection.options?.map(o => o.value)).toEqual(['Textbook']);
+
+    const qset = find(useFieldPrepare(cfg, {}, fw, true, {
+      objectType: 'QuestionSet', collectionAdditionalCategories: ['Textbook'], contentAdditionalCategories: ['Explanation'],
+    }), 'additionalCategories');
+    expect(qset.options?.map(o => o.value)).toEqual(['Explanation']);
+  });
+});
+
+describe('per-field editability (mirrors ifFieldIsEditable)', () => {
+  const cfg = [{ code: 'name', label: 'Name' }, { code: 'description', label: 'Desc', inputType: 'textarea' }];
+
+  it('is editable in edit mode unless the API marks it non-editable', () => {
+    const fields = useFieldPrepare([...cfg, { code: 'locked', label: 'L', editable: false }], {}, fw, true, { editorMode: 'edit' });
+    expect(find(fields, 'name').editable).toBe(true);
+    expect(find(fields, 'locked').editable).toBe(false);
+  });
+
+  it('in review mode only editableFields[review] codes stay editable', () => {
+    const fields = useFieldPrepare(cfg, {}, fw, true, { editorMode: 'review', editableFields: { review: ['name'] } });
+    expect(find(fields, 'name').editable).toBe(true);
+    expect(find(fields, 'description').editable).toBe(false);
+  });
+
+  it('locks all fields in read mode with no editableFields', () => {
+    const fields = useFieldPrepare(cfg, {}, fw, true, { editorMode: 'read' });
+    expect(find(fields, 'name').editable).toBe(false);
+    expect(find(fields, 'description').editable).toBe(false);
+  });
+});

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.defaults.test.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.defaults.test.ts
@@ -6,12 +6,22 @@ const fw: IFrameworkDetails = {};
 const find = (fields: ReturnType<typeof useFieldPrepare>, code: string) => fields.find(f => f.code === code)!;
 
 describe('per-field default seeding (mirrors prepareFields 180-244)', () => {
-  it('defaults copyright to the channel name only when setDefaultCopyRight', () => {
+  it('defaults copyright to the channel name whenever empty', () => {
     const cfg = [{ code: 'copyright', label: 'Copyright' }];
     const seeded = find(useFieldPrepare(cfg, {}, fw, true, { setDefaultCopyRight: true, channelName: 'Acme Org' }), 'copyright');
     expect(seeded.currentValue).toBe('Acme Org');
-    const notSeeded = find(useFieldPrepare(cfg, {}, fw, true, { channelName: 'Acme Org' }), 'copyright');
-    expect(notSeeded.currentValue).toBe('');
+    // No setDefaultCopyRight flag needed — channel name is the default.
+    const alsoSeeded = find(useFieldPrepare(cfg, {}, fw, true, { channelName: 'Acme Org' }), 'copyright');
+    expect(alsoSeeded.currentValue).toBe('Acme Org');
+  });
+
+  it('defaults copyrightYear to the current year and keeps it editable', () => {
+    const cfg = [{ code: 'copyrightYear', label: 'Copyright Year' }];
+    const f = find(useFieldPrepare(cfg, {}, fw, true, {}), 'copyrightYear');
+    expect(f.currentValue).toBe(String(new Date().getFullYear()));
+    expect(f.editable).toBe(true);
+    const authored = find(useFieldPrepare(cfg, { copyrightYear: '2020' }, fw, true, {}), 'copyrightYear');
+    expect(authored.currentValue).toBe('2020');
   });
 
   it('does not override an authored copyright value', () => {
@@ -20,10 +30,11 @@ describe('per-field default seeding (mirrors prepareFields 180-244)', () => {
     expect(f.currentValue).toBe('Existing');
   });
 
-  it('defaults author to the user full name', () => {
+  it('defaults author to the user full name and locks the field', () => {
     const cfg = [{ code: 'author', label: 'Author' }];
-    const f = find(useFieldPrepare(cfg, {}, fw, true, { userFullName: 'Jane Doe' }), 'author');
+    const f = find(useFieldPrepare(cfg, {}, fw, true, { userFullName: 'Jane Doe', editorMode: 'edit' }), 'author');
     expect(f.currentValue).toBe('Jane Doe');
+    expect(f.editable).toBe(false);
   });
 
   it('defaults license to the context/channel default license', () => {

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.test.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { __computeFieldOptionsForTest as computeOptions } from './useFieldPrepare';
+import type { IFrameworkDetails } from '../../../types/framework';
+
+// ---------------------------------------------------------------------------
+// Regression guard for the reported bug:
+//   "English is not showing in Medium while creating a Playlist."
+//
+// The framework is modelled the way Sunbird actually stores it: the BOARD term
+// carries associations down to its mediums (parent → child). The "English"
+// medium term has its OWN associations (to grades) but NO back-association to
+// the board. A *different* medium ("Hindi") happens to back-reference the board.
+//
+// Old React code filtered the medium category's own terms by whether each
+// medium pointed back at the selected board → English was dropped while Hindi
+// survived → "the One Case". The corrected code reads the board term's
+// associations directly, so English always appears.
+// ---------------------------------------------------------------------------
+
+const boardField = { code: 'board', sourceCategory: 'board', inputType: 'select' };
+const mediumField = { code: 'medium', sourceCategory: 'medium', inputType: 'multiselect', depends: ['board'] };
+
+function frameworkWithAsymmetricMediumAssociations(): IFrameworkDetails {
+  return {
+    organisationFramework: {
+      identifier: 'fw1', name: 'FW', code: 'fw1',
+      categories: [
+        {
+          identifier: 'cat_board', name: 'Board', code: 'board',
+          terms: [
+            {
+              identifier: 'cbse', name: 'CBSE', code: 'cbse', category: 'board',
+              associations: [
+                { identifier: 'eng', name: 'English', code: 'english', category: 'medium' },
+                { identifier: 'hin', name: 'Hindi', code: 'hindi', category: 'medium' },
+              ],
+            },
+          ],
+        },
+        {
+          identifier: 'cat_medium', name: 'Medium', code: 'medium',
+          terms: [
+            // English: associates DOWN to a grade, but NOT back up to the board.
+            {
+              identifier: 'eng', name: 'English', code: 'english', category: 'medium',
+              associations: [{ identifier: 'g1', name: 'Grade 1', code: 'grade1', category: 'gradeLevel' }],
+            },
+            // Hindi: happens to back-reference the board (asymmetry).
+            {
+              identifier: 'hin', name: 'Hindi', code: 'hindi', category: 'medium',
+              associations: [{ identifier: 'cbse', name: 'CBSE', code: 'cbse', category: 'board' }],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe('framework cascade (parent → child association traversal)', () => {
+  it('lists English in Medium even when its term lacks a back-association to the board', () => {
+    const fw = frameworkWithAsymmetricMediumAssociations();
+    const opts = computeOptions(mediumField, fw, { board: 'CBSE' }, [boardField, mediumField]);
+    const labels = (opts ?? []).map(o => o.label).sort();
+    expect(labels).toEqual(['English', 'Hindi']);
+  });
+
+  it('returns no options until the parent (board) is selected — matches Angular', () => {
+    const fw = frameworkWithAsymmetricMediumAssociations();
+    const opts = computeOptions(mediumField, fw, {}, [boardField, mediumField]);
+    expect(opts).toEqual([]);
+  });
+
+  it('matches the selected board by identifier as well as name', () => {
+    const fw = frameworkWithAsymmetricMediumAssociations();
+    const opts = computeOptions(mediumField, fw, { board: 'cbse' }, [boardField, mediumField]);
+    expect((opts ?? []).map(o => o.label).sort()).toEqual(['English', 'Hindi']);
+  });
+
+  it('a non-dependent field returns its own category terms', () => {
+    const fw = frameworkWithAsymmetricMediumAssociations();
+    const opts = computeOptions(boardField, fw, {}, [boardField, mediumField]);
+    expect((opts ?? []).map(o => o.value)).toEqual(['CBSE']);
+  });
+});
+
+describe('target-framework synthesis fallback', () => {
+  // Target framework whose board terms carry NO associations — Angular
+  // synthesises a cross-product so every child shows. We fall back to the
+  // child category's own terms (same observable outcome).
+  const targetMedium = {
+    code: 'targetMediumIds', sourceCategory: 'medium', inputType: 'multiselect',
+    section: 'Target Framework Terms', depends: ['targetBoardIds'],
+  };
+  const targetBoard = {
+    code: 'targetBoardIds', sourceCategory: 'board', inputType: 'select',
+    section: 'Target Framework Terms',
+  };
+
+  const fw: IFrameworkDetails = {
+    targetFrameworks: [
+      {
+        identifier: 'tfw', name: 'NCF', code: 'tfw',
+        categories: [
+          { identifier: 'tb', name: 'Board', code: 'board', terms: [{ identifier: 'tb1', name: 'State', code: 'state', category: 'board' }] },
+          {
+            identifier: 'tm', name: 'Medium', code: 'medium',
+            terms: [
+              { identifier: 'tm_en', name: 'English', code: 'english', category: 'medium' },
+              { identifier: 'tm_hi', name: 'Hindi', code: 'hindi', category: 'medium' },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('falls back to all child terms when parent terms carry no associations', () => {
+    const opts = computeOptions(targetMedium, fw, { targetBoardIds: 'tb1' }, [targetBoard, targetMedium]);
+    expect((opts ?? []).map(o => o.value).sort()).toEqual(['tm_en', 'tm_hi']);
+  });
+
+  it('uses term identifiers (not names) as values for target fields', () => {
+    const opts = computeOptions(targetMedium, fw, { targetBoardIds: 'tb1' }, [targetBoard, targetMedium]);
+    expect((opts ?? []).every(o => o.value.startsWith('tm_'))).toBe(true);
+  });
+});

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -85,11 +85,16 @@ export function useFieldPrepare(
 ): PreparedField[] {
   if (!formConfig?.length) return getDefaultFields(nodeMetadata, isRoot, frameworkDetails);
 
+  const seenCodes = new Set<string>();
   return formConfig.filter((field) => {
     // QR/Dial Code is managed via header buttons, not the root form
     if (isRoot && (field.code === 'dialCode' || field.code === 'dialcode')) return false;
     // Honor the API `visible` flag
     if (field.visible === false) return false;
+    // Deduplicate — first occurrence of each code wins
+    const code = field.code as string;
+    if (seenCodes.has(code)) return false;
+    seenCodes.add(code);
     return true;
   }).map((field): PreparedField => {
     const code = (field.code as string) ?? '';

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -1,4 +1,4 @@
-import type { IFrameworkDetails } from '../../../types/framework';
+import type { IFrameworkDetails, ITerm } from '../../../types/framework';
 
 export interface NestedSelectLevel {
   code: string;
@@ -19,9 +19,18 @@ export interface PreparedField {
   levels?: NestedSelectLevel[];
   depends?: string[];
   tab: 'details' | 'audience' | 'licensing';
+  section?: string;
   defaultValue?: unknown;
   currentValue?: unknown;
 }
+
+export const SECTION_DISPLAY: Record<string, { title: string; description?: string }> = {
+  'First Section': { title: 'Basic Information', description: 'Core details that define the content identity.' },
+  'Second Section': { title: 'Categorisation', description: 'Category and type classification for the content.' },
+  'Organisation Framework Terms': { title: 'Curriculum', description: 'Framework-aligned categorisation.' },
+  'Target Framework Terms': { title: 'Target Audience', description: 'Curriculum alignment for the intended learners.' },
+  'Fourth Section': { title: 'Licensing & Attribution', description: 'Copyright and usage rights information.' },
+};
 
 export interface IFieldConfig extends PreparedField {
   frameworkId?: string;
@@ -30,39 +39,41 @@ export interface IFieldConfig extends PreparedField {
 }
 
 // ----- Tab assignment --------------------------------------------------------
-// Org-framework fields (board, subject) live on Details as "Course Type" / "Subjects"
-// Target-framework fields live on Audience & Curriculum
+// Sections from the category-definition map to editor tabs. Falls back to a
+// per-code map, then to Details.
+const SECTION_TAB_MAP: Record<string, PreparedField['tab']> = {
+  'First Section': 'details',
+  'Second Section': 'details',
+  'Organisation Framework Terms': 'details',
+  'Target Framework Terms': 'audience',
+  'Fourth Section': 'licensing',
+};
+
 const FIELD_TAB_MAP: Record<string, PreparedField['tab']> = {
   // Details
   name: 'details', description: 'details', keywords: 'details', appIcon: 'details',
   primaryCategory: 'details', additionalCategories: 'details',
-  board: 'details', subject: 'details', medium: 'details',
-  topicsIds: 'details', topic: 'details',
+  board: 'details', subject: 'details', subjectIds: 'details', medium: 'details',
+  framework: 'details', topicsIds: 'details', topic: 'details',
   // Audience & Curriculum
   audience: 'audience',
   targetBoardIds: 'audience', targetMediumIds: 'audience',
   targetGradeLevelIds: 'audience', targetSubjectIds: 'audience',
   gradeLevel: 'audience',
   // Licensing
-  creator: 'licensing', attributions: 'licensing', license: 'licensing',
+  creator: 'licensing', author: 'licensing', attributions: 'licensing', license: 'licensing',
   copyright: 'licensing', copyrightYear: 'licensing',
 };
 
-// ----- Framework category mapping -------------------------------------------
+// ----- Framework category mapping (fallback when field has no sourceCategory) -
 const FIELD_TO_FW_CATEGORY: Record<string, string> = {
-  board: 'board',
-  medium: 'medium',
-  gradeLevel: 'gradeLevel',
-  subject: 'subject',
-  topicsIds: 'topic',
-  topic: 'topic',
-  targetBoardIds: 'board',
-  targetMediumIds: 'medium',
-  targetGradeLevelIds: 'gradeLevel',
-  targetSubjectIds: 'subject',
+  board: 'board', medium: 'medium', gradeLevel: 'gradeLevel', subject: 'subject',
+  subjectIds: 'subject', topicsIds: 'topic', topic: 'topic',
+  targetBoardIds: 'board', targetMediumIds: 'medium',
+  targetGradeLevelIds: 'gradeLevel', targetSubjectIds: 'subject',
 };
 
-// Which fields pull from the TARGET framework (not org framework)
+// Fields whose values are stored/validated as term identifiers (not names).
 const TARGET_FW_FIELDS = new Set(['targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds', 'targetSubjectIds']);
 
 // ----- Public hook -----------------------------------------------------------
@@ -77,12 +88,15 @@ export function useFieldPrepare(
   return formConfig.filter((field) => {
     // QR/Dial Code is managed via header buttons, not the root form
     if (isRoot && (field.code === 'dialCode' || field.code === 'dialcode')) return false;
+    // Honor the API `visible` flag
+    if (field.visible === false) return false;
     return true;
   }).map((field): PreparedField => {
     const code = (field.code as string) ?? '';
     const inputType = resolveInputType(field);
-    const options = resolveOptions(field, frameworkDetails);
+    const options = resolveOptions(field, frameworkDetails, nodeMetadata);
     const rawValue = nodeMetadata[code];
+    const currentValue = normalizeCurrentValue(rawValue, inputType);
     return {
       code,
       label: (field.label as string) ?? code,
@@ -91,13 +105,67 @@ export function useFieldPrepare(
       editable: field.editable !== false,
       placeholder: field.placeholder as string | undefined,
       maxLength: field.maxLength as number | undefined,
-      options,
+      // Guarantee the stored value is selectable/displayable even when the API
+      // gives no option source (primaryCategory, additionalCategories) or the
+      // cascade filter trimmed it out — otherwise the widget renders blank.
+      options: withSelectedOptions(options, currentValue, inputType, frameworkDetails),
       depends: field.depends as string[] | undefined,
-      tab: FIELD_TAB_MAP[code] ?? 'details',
-      defaultValue: field.default,
-      currentValue: normalizeCurrentValue(rawValue, inputType),
+      tab: resolveTab(field),
+      section: field.section as string | undefined,
+      defaultValue: field.defaultValue ?? field.default,
+      currentValue,
     };
   });
+}
+
+// ----- Selected-value guarantee ---------------------------------------------
+// Build a value→name lookup over every term in both frameworks so a stored
+// identifier (e.g. ncf_medium_english) can be labelled "English".
+function buildTermLabelMap(fw: IFrameworkDetails): Map<string, string> {
+  const map = new Map<string, string>();
+  const add = (terms?: ITerm[]) => terms?.forEach(t => {
+    if (t.identifier) map.set(t.identifier, t.name);
+    if (t.name) map.set(t.name, t.name);
+  });
+  fw.organisationFramework?.categories?.forEach(c => add(c.terms));
+  fw.targetFrameworks?.forEach(f => f.categories?.forEach(c => add(c.terms)));
+  return map;
+}
+
+// Ensure every selected value is present in the option list (for select /
+// multiselect / radio). Missing values are appended, labelled from the
+// framework where possible, otherwise from the value itself.
+function withSelectedOptions(
+  options: Array<{ label: string; value: string }> | undefined,
+  currentValue: unknown,
+  inputType: PreparedField['inputType'],
+  fw: IFrameworkDetails,
+): Array<{ label: string; value: string }> | undefined {
+  if (inputType !== 'select' && inputType !== 'multiselect' && inputType !== 'radio') return options;
+  const values = Array.isArray(currentValue)
+    ? currentValue
+    : (currentValue != null && currentValue !== '' ? [currentValue] : []);
+  if (!values.length) return options;
+
+  const opts = options ? [...options] : [];
+  const have = new Set(opts.map(o => o.value));
+  const labelMap = buildTermLabelMap(fw);
+  for (const v of values) {
+    const sv = String(v);
+    if (!have.has(sv)) {
+      opts.push({ label: labelMap.get(sv) ?? sv, value: sv });
+      have.add(sv);
+    }
+  }
+  return opts;
+}
+
+// ----- Tab resolver ----------------------------------------------------------
+function resolveTab(field: Record<string, unknown>): PreparedField['tab'] {
+  const section = field.section as string | undefined;
+  if (section && SECTION_TAB_MAP[section]) return SECTION_TAB_MAP[section];
+  const code = (field.code as string) ?? '';
+  return FIELD_TAB_MAP[code] ?? 'details';
 }
 
 // ----- Value normalizer ------------------------------------------------------
@@ -123,7 +191,13 @@ function normalizeCurrentValue(raw: unknown, inputType: PreparedField['inputType
 // ----- Input type resolver --------------------------------------------------
 function resolveInputType(field: Record<string, unknown>): PreparedField['inputType'] {
   const type = (field.inputType as string ?? field.dataType as string ?? '').toLowerCase();
+  const dataType = (field.dataType as string ?? '').toLowerCase();
+  const isList = dataType === 'list';
+
   if (type === 'select' || type === 'framework') return 'select';
+  // Framework category selects (subjectIds, targetMediumIds, …): list ⇒ multi
+  if (type === 'frameworkcategoryselect') return isList ? 'multiselect' : 'select';
+  if (type === 'topicselector') return 'chips';
   if (type === 'multiselect' || type === 'multi-select') return 'multiselect';
   if (type === 'keywords' || field.code === 'keywords') return 'chips';
   if (field.code === 'topic' || field.code === 'topicsIds') return 'chips';
@@ -133,7 +207,7 @@ function resolveInputType(field: Record<string, unknown>): PreparedField['inputT
   if (type === 'datepicker' || type === 'date') return 'datepicker';
   if (type === 'datetime' || type === 'datetime-local') return 'datetime';
   if (type === 'tagsinput') return 'tagsinput';
-  if (type === 'nestedselect' || type === 'nested-select') return 'nestedselect';
+  if (type === 'nestedselect' || type === 'nested-select') return isList ? 'multiselect' : 'select';
   if (type === 'license') return 'license';
   if (type === 'dialcode' || type === 'dial-code') return 'dialcode';
   return 'text';
@@ -143,45 +217,84 @@ function resolveInputType(field: Record<string, unknown>): PreparedField['inputT
 function resolveOptions(
   field: Record<string, unknown>,
   fw: IFrameworkDetails,
+  nodeMetadata: Record<string, unknown>,
 ): Array<{ label: string; value: string }> | undefined {
-  const range = field.range as Array<{ name: string; identifier: string }> | undefined;
-  if (range?.length) return range.map(r => ({ label: r.name, value: r.identifier }));
+  // 1. Explicit range — either string[] (e.g. audience) or {name, identifier}[]
+  const range = field.range as Array<unknown> | undefined;
+  if (Array.isArray(range) && range.length) {
+    if (typeof range[0] === 'string') {
+      return (range as string[]).map(v => ({ label: v, value: v }));
+    }
+    return (range as Array<{ name: string; identifier: string }>).map(r => ({ label: r.name, value: r.identifier }));
+  }
+  // 2. enum
   const enumVals = field.enum as string[] | undefined;
   if (enumVals?.length) return enumVals.map(v => ({ label: v, value: v }));
 
+  // 3. Framework-backed — use the field's own sourceCategory, falling back to
+  //    the legacy code→category map.
   const code = (field.code as string) ?? '';
-  return resolveFwOptions(code, fw);
+  const categoryCode = (field.sourceCategory as string | undefined) ?? FIELD_TO_FW_CATEGORY[code];
+  if (!categoryCode) return undefined;
+
+  return resolveFwOptions(code, categoryCode, field, fw, nodeMetadata);
 }
 
 function resolveFwOptions(
   code: string,
+  categoryCode: string,
+  field: Record<string, unknown>,
   fw: IFrameworkDetails,
+  nodeMetadata: Record<string, unknown>,
 ): Array<{ label: string; value: string }> | undefined {
-  const categoryCode = FIELD_TO_FW_CATEGORY[code];
-  if (!categoryCode) return undefined;
+  // Decide value source: target fields & explicit output:'identifier' use the
+  // term identifier; org fields default to the term name (Sunbird convention).
+  const useIdentifier =
+    TARGET_FW_FIELDS.has(code) ||
+    (field.output as string | undefined) === 'identifier' ||
+    (typeof (field.section as string) === 'string' && (field.section as string).includes('Target'));
 
-  // target* fields: API validates against term identifiers (e.g. ncf_board_cbse)
-  // org fields (board/subject/medium/gradeLevel): API validates against term names (e.g. CBSE)
-  const toIdentifier = (t: { name: string; identifier: string }) => ({ label: t.name, value: t.identifier });
-  const toName       = (t: { name: string; identifier: string }) => ({ label: t.name, value: t.name });
+  const fromTerm = (t: ITerm) => ({ label: t.name, value: useIdentifier ? t.identifier : t.name });
 
-  if (TARGET_FW_FIELDS.has(code)) {
-    const terms = fw.targetFrameworks?.[0]?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
-    if (terms.length) return terms.map(toIdentifier);
-    const orgTerms = fw.organisationFramework?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
-    return orgTerms.map(toIdentifier);
+  // Source framework: target fields prefer the target framework, then org.
+  const orgCat = fw.organisationFramework?.categories?.find(c => c.code === categoryCode);
+  const targetCat = fw.targetFrameworks?.[0]?.categories?.find(c => c.code === categoryCode);
+  let terms: ITerm[] = (TARGET_FW_FIELDS.has(code) ? targetCat?.terms : orgCat?.terms)
+    ?? targetCat?.terms ?? orgCat?.terms ?? [];
+
+  // Cascade filtering: if this field depends on parent fields, keep only terms
+  // whose associations include a currently-selected parent value. Parent values
+  // are read from nodeMetadata (which merges live form edits), so options
+  // re-filter reactively as parents change — no extra fetch needed.
+  const depends = field.depends as string[] | undefined;
+  if (depends?.length) {
+    const parentValues = depends
+      .flatMap(p => {
+        const v = nodeMetadata[p];
+        return Array.isArray(v) ? v : (v != null && v !== '' ? [v] : []);
+      })
+      .map(String);
+    if (parentValues.length) {
+      const filtered = terms.filter(t => {
+        const assoc = t.associations;
+        if (!assoc || !assoc.length) return true; // no association info ⇒ keep
+        return assoc.some(a => parentValues.includes(a.identifier) || parentValues.includes(a.code) || parentValues.includes(a.name));
+      });
+      // Only narrow when the association graph actually matched something —
+      // otherwise (associations absent or modelled the other direction) keep
+      // the full list so the dropdown isn't emptied.
+      if (filtered.length) terms = filtered;
+    }
   }
 
-  // Org framework fields — use name as value
-  const orgTerms = fw.organisationFramework?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
-  if (orgTerms.length) return orgTerms.map(toName);
-  const targetTerms = fw.targetFrameworks?.[0]?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
-  return targetTerms.map(toName);
+  return terms.map(fromTerm);
 }
 
 // ----- Helper ----------------------------------------------------------------
 function fwOpts(code: string, fw: IFrameworkDetails) {
-  return resolveFwOptions(code, fw);
+  const categoryCode = FIELD_TO_FW_CATEGORY[code];
+  if (!categoryCode) return undefined;
+  return resolveFwOptions(code, categoryCode, { code }, fw, {});
 }
 
 const AUDIENCE_OPTIONS = [
@@ -217,15 +330,15 @@ function getDefaultFields(
   const fields: PreparedField[] = [
     {
       code: 'name', label: 'Title', inputType: 'text', required: true,
-      editable: true, tab: 'details', maxLength: 200, currentValue: cv(meta, 'name', 'text'),
+      editable: true, tab: 'details', section: 'First Section', maxLength: 200, currentValue: cv(meta, 'name', 'text'),
     },
     {
       code: 'description', label: 'Description', inputType: 'textarea',
-      editable: true, tab: 'details', maxLength: 2000, currentValue: cv(meta, 'description', 'textarea'),
+      editable: true, tab: 'details', section: 'First Section', maxLength: 2000, currentValue: cv(meta, 'description', 'textarea'),
     },
     {
       code: 'keywords', label: 'Keywords', inputType: 'chips',
-      editable: true, tab: 'details', currentValue: cv(meta, 'keywords', 'chips'),
+      editable: true, tab: 'details', section: 'First Section', currentValue: cv(meta, 'keywords', 'chips'),
     },
   ];
 
@@ -234,12 +347,8 @@ function getDefaultFields(
   // ── Root (Course) node — Details tab ─────────────────────────────────────
   fields.push(
     {
-      code: 'appIcon', label: 'Icon', inputType: 'appIcon',
-      editable: true, tab: 'details', currentValue: meta.appIcon,
-    },
-    {
       code: 'primaryCategory', label: 'Category', inputType: 'select',
-      editable: false, tab: 'details', currentValue: cv(meta, 'primaryCategory', 'select'),
+      editable: false, tab: 'details', section: 'Second Section', currentValue: cv(meta, 'primaryCategory', 'select'),
       options: [
         { label: 'Course', value: 'Course' },
         { label: 'Digital Textbook', value: 'Digital Textbook' },
@@ -250,7 +359,7 @@ function getDefaultFields(
     },
     {
       code: 'additionalCategories', label: 'Additional Category', inputType: 'multiselect',
-      editable: true, tab: 'details', currentValue: cv(meta, 'additionalCategories', 'multiselect'),
+      editable: true, tab: 'details', section: 'Second Section', currentValue: cv(meta, 'additionalCategories', 'multiselect'),
       options: [
         { label: 'Lesson Plan', value: 'Lesson Plan' },
         { label: 'Textbook', value: 'Textbook' },
@@ -260,12 +369,12 @@ function getDefaultFields(
     },
     {
       code: 'board', label: 'Course Type', inputType: 'select',
-      required: true, editable: true, tab: 'details',
+      required: true, editable: true, tab: 'details', section: 'Organisation Framework Terms',
       options: fwOpts('board', fw), currentValue: cv(meta, 'board', 'select'),
     },
     {
       code: 'subject', label: 'Subjects covered in the course', inputType: 'multiselect',
-      required: true, editable: true, tab: 'details',
+      required: true, editable: true, tab: 'details', section: 'Organisation Framework Terms',
       options: fwOpts('subject', fw), currentValue: cv(meta, 'subject', 'multiselect'),
     },
   );
@@ -274,27 +383,27 @@ function getDefaultFields(
   fields.push(
     {
       code: 'audience', label: 'Audience Type', inputType: 'multiselect',
-      editable: true, tab: 'audience', options: AUDIENCE_OPTIONS,
+      editable: true, tab: 'audience', section: 'Target Framework Terms', options: AUDIENCE_OPTIONS,
       currentValue: cv(meta, 'audience', 'multiselect'),
     },
     {
       code: 'targetBoardIds', label: 'Board/Syllabus of the audience', inputType: 'select',
-      required: true, editable: true, tab: 'audience',
+      required: true, editable: true, tab: 'audience', section: 'Target Framework Terms',
       options: fwOpts('targetBoardIds', fw), currentValue: cv(meta, 'targetBoardIds', 'select'),
     },
     {
       code: 'targetMediumIds', label: 'Medium(s) of the audience', inputType: 'multiselect',
-      required: true, editable: true, tab: 'audience', depends: ['targetBoardIds'],
+      required: true, editable: true, tab: 'audience', section: 'Target Framework Terms', depends: ['targetBoardIds'],
       options: fwOpts('targetMediumIds', fw), currentValue: cv(meta, 'targetMediumIds', 'multiselect'),
     },
     {
       code: 'targetGradeLevelIds', label: 'Class(es) of the audience', inputType: 'multiselect',
-      required: true, editable: true, tab: 'audience', depends: ['targetMediumIds'],
+      required: true, editable: true, tab: 'audience', section: 'Target Framework Terms', depends: ['targetMediumIds'],
       options: fwOpts('targetGradeLevelIds', fw), currentValue: cv(meta, 'targetGradeLevelIds', 'multiselect'),
     },
     {
       code: 'targetSubjectIds', label: 'Subject(s) of the audience', inputType: 'multiselect',
-      required: true, editable: true, tab: 'audience', depends: ['targetGradeLevelIds'],
+      required: true, editable: true, tab: 'audience', section: 'Target Framework Terms', depends: ['targetGradeLevelIds'],
       options: fwOpts('targetSubjectIds', fw), currentValue: cv(meta, 'targetSubjectIds', 'multiselect'),
     },
   );
@@ -303,23 +412,23 @@ function getDefaultFields(
   fields.push(
     {
       code: 'creator', label: 'Author', inputType: 'text',
-      editable: true, tab: 'licensing', currentValue: cv(meta, 'creator', 'text'),
+      editable: true, tab: 'licensing', section: 'Fourth Section', currentValue: cv(meta, 'creator', 'text'),
     },
     {
       code: 'attributions', label: 'Attributions', inputType: 'text',
-      editable: true, tab: 'licensing', currentValue: cv(meta, 'attributions', 'text'),
+      editable: true, tab: 'licensing', section: 'Fourth Section', currentValue: cv(meta, 'attributions', 'text'),
     },
     {
       code: 'copyright', label: 'Copyright', inputType: 'text',
-      required: true, editable: true, tab: 'licensing', currentValue: cv(meta, 'copyright', 'text'),
+      required: true, editable: true, tab: 'licensing', section: 'Fourth Section', currentValue: cv(meta, 'copyright', 'text'),
     },
     {
       code: 'copyrightYear', label: 'Copyright Year', inputType: 'text',
-      required: true, editable: true, tab: 'licensing', currentValue: cv(meta, 'copyrightYear', 'text'),
+      required: true, editable: true, tab: 'licensing', section: 'Fourth Section', currentValue: cv(meta, 'copyrightYear', 'text'),
     },
     {
       code: 'license', label: 'License', inputType: 'select',
-      required: true, editable: true, tab: 'licensing',
+      required: true, editable: true, tab: 'licensing', section: 'Fourth Section',
       options: LICENSE_OPTIONS, currentValue: cv(meta, 'license', 'select'),
     },
   );

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -60,7 +60,7 @@ export interface IPrepareContext {
   contextAdditionalCategories?: string[];
   /** editorConfig.context.user.fullName */
   userFullName?: string;
-  /** channelInfo.name — used as default copyright when setDefaultCopyRight. */
+  /** channelInfo.name — default copyright whenever the field is empty. */
   channelName?: string;
   /** channelInfo.collectionAdditionalCategories */
   collectionAdditionalCategories?: string[];
@@ -168,7 +168,8 @@ export function useFieldPrepare(
         (Array.isArray(field.validations) &&
           (field.validations as Array<Record<string, unknown>>).some(v => v.type === 'required'))
       ),
-      editable: computeEditable(code, field.editable !== false, ctx),
+      // author is always auto-filled with the current user and locked.
+      editable: code === 'author' ? false : computeEditable(code, field.editable !== false, ctx),
       placeholder: field.placeholder as string | undefined,
       maxLength: field.maxLength as number | undefined,
       // Guarantee the stored value is selectable/displayable even when the API
@@ -225,7 +226,12 @@ function applyFieldDefault(
       if (isEmpty) return ctx.defaultLicense ?? '';
       return currentValue;
     case 'copyright':
-      if (isEmpty && ctx.setDefaultCopyRight && ctx.channelName) return ctx.channelName;
+      // Default to the tenant/channel name whenever empty.
+      if (isEmpty && ctx.channelName) return ctx.channelName;
+      return currentValue;
+    case 'copyrightYear':
+      // Default to the current year; stays editable.
+      if (isEmpty) return String(new Date().getFullYear());
       return currentValue;
     case 'author':
     case 'creator':

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -243,6 +243,13 @@ function resolveOptions(
   // 3. Framework-backed — use the field's own sourceCategory, falling back to
   //    the legacy code→category map.
   const code = (field.code as string) ?? '';
+
+  // Channel-derived fields: options come from the channel read API, not the framework API.
+  if (code === 'framework') return fw.orgFrameworks;
+  if (code === 'additionalCategories') {
+    return fw.channelAdditionalCategories?.map(c => ({ label: c, value: c }));
+  }
+
   const categoryCode = (field.sourceCategory as string | undefined) ?? FIELD_TO_FW_CATEGORY[code];
   if (!categoryCode) return undefined;
 

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -67,7 +67,7 @@ const FIELD_TAB_MAP: Record<string, PreparedField['tab']> = {
   // Details
   name: 'details', description: 'details', keywords: 'details', appIcon: 'details',
   primaryCategory: 'details', additionalCategories: 'details',
-  board: 'details', subject: 'details', subjectIds: 'details', medium: 'details',
+  board: 'details', boardIds: 'details', subject: 'details', subjectIds: 'details', medium: 'details',
   framework: 'details', topicsIds: 'details', topic: 'details',
   dialcodeRequired: 'details', dialcodes: 'details',
   // Audience & Curriculum
@@ -82,7 +82,7 @@ const FIELD_TAB_MAP: Record<string, PreparedField['tab']> = {
 
 // ----- Framework category mapping (fallback when field has no sourceCategory) -
 const FIELD_TO_FW_CATEGORY: Record<string, string> = {
-  board: 'board', medium: 'medium', gradeLevel: 'gradeLevel', subject: 'subject',
+  board: 'board', boardIds: 'board', medium: 'medium', gradeLevel: 'gradeLevel', subject: 'subject',
   subjectIds: 'subject', topicsIds: 'topic', topic: 'topic',
   targetBoardIds: 'board', targetMediumIds: 'medium',
   targetGradeLevelIds: 'gradeLevel', targetSubjectIds: 'subject',
@@ -232,7 +232,9 @@ function resolveInputType(field: Record<string, unknown>): PreparedField['inputT
   const dataType = (field.dataType as string ?? '').toLowerCase();
   const isList = dataType === 'list';
 
-  if (type === 'select' || type === 'framework') return 'select';
+  if (type === 'select') return 'select';
+  // 'framework' inputType: respect dataType — list means multiple boards/frameworks allowed
+  if (type === 'framework') return isList ? 'multiselect' : 'select';
   // Framework category selects (subjectIds, targetMediumIds, …): list ⇒ multi
   if (type === 'frameworkcategoryselect') return isList ? 'multiselect' : 'select';
   if (type === 'topicselector') return 'chips';

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -1,0 +1,328 @@
+import type { IFrameworkDetails } from '../../../types/framework';
+
+export interface NestedSelectLevel {
+  code: string;
+  label: string;
+  options: Array<{ label: string; value: string }>;
+}
+
+export interface PreparedField {
+  code: string;
+  label: string;
+  inputType: 'text' | 'textarea' | 'select' | 'multiselect' | 'chips' | 'radio' | 'appIcon'
+    | 'datepicker' | 'datetime' | 'keywords' | 'tagsinput' | 'nestedselect' | 'license' | 'dialcode';
+  required?: boolean;
+  editable?: boolean;
+  placeholder?: string;
+  maxLength?: number;
+  options?: Array<{ label: string; value: string }>;
+  levels?: NestedSelectLevel[];
+  depends?: string[];
+  tab: 'details' | 'audience' | 'licensing';
+  defaultValue?: unknown;
+  currentValue?: unknown;
+}
+
+export interface IFieldConfig extends PreparedField {
+  frameworkId?: string;
+  categoryCode?: string;
+  range?: Array<{ name: string; identifier: string }>;
+}
+
+// ----- Tab assignment --------------------------------------------------------
+// Org-framework fields (board, subject) live on Details as "Course Type" / "Subjects"
+// Target-framework fields live on Audience & Curriculum
+const FIELD_TAB_MAP: Record<string, PreparedField['tab']> = {
+  // Details
+  name: 'details', description: 'details', keywords: 'details', appIcon: 'details',
+  primaryCategory: 'details', additionalCategories: 'details',
+  board: 'details', subject: 'details', medium: 'details',
+  topicsIds: 'details', topic: 'details',
+  // Audience & Curriculum
+  audience: 'audience',
+  targetBoardIds: 'audience', targetMediumIds: 'audience',
+  targetGradeLevelIds: 'audience', targetSubjectIds: 'audience',
+  gradeLevel: 'audience',
+  // Licensing
+  creator: 'licensing', attributions: 'licensing', license: 'licensing',
+  copyright: 'licensing', copyrightYear: 'licensing',
+};
+
+// ----- Framework category mapping -------------------------------------------
+const FIELD_TO_FW_CATEGORY: Record<string, string> = {
+  board: 'board',
+  medium: 'medium',
+  gradeLevel: 'gradeLevel',
+  subject: 'subject',
+  topicsIds: 'topic',
+  topic: 'topic',
+  targetBoardIds: 'board',
+  targetMediumIds: 'medium',
+  targetGradeLevelIds: 'gradeLevel',
+  targetSubjectIds: 'subject',
+};
+
+// Which fields pull from the TARGET framework (not org framework)
+const TARGET_FW_FIELDS = new Set(['targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds', 'targetSubjectIds']);
+
+// ----- Public hook -----------------------------------------------------------
+export function useFieldPrepare(
+  formConfig: Array<Record<string, unknown>>,
+  nodeMetadata: Record<string, unknown>,
+  frameworkDetails: IFrameworkDetails,
+  isRoot: boolean
+): PreparedField[] {
+  if (!formConfig?.length) return getDefaultFields(nodeMetadata, isRoot, frameworkDetails);
+
+  return formConfig.filter((field) => {
+    // QR/Dial Code is managed via header buttons, not the root form
+    if (isRoot && (field.code === 'dialCode' || field.code === 'dialcode')) return false;
+    return true;
+  }).map((field): PreparedField => {
+    const code = (field.code as string) ?? '';
+    const inputType = resolveInputType(field);
+    const options = resolveOptions(field, frameworkDetails);
+    const rawValue = nodeMetadata[code];
+    return {
+      code,
+      label: (field.label as string) ?? code,
+      inputType,
+      required: !!(field.required ?? field.validations),
+      editable: field.editable !== false,
+      placeholder: field.placeholder as string | undefined,
+      maxLength: field.maxLength as number | undefined,
+      options,
+      depends: field.depends as string[] | undefined,
+      tab: FIELD_TAB_MAP[code] ?? 'details',
+      defaultValue: field.default,
+      currentValue: normalizeCurrentValue(rawValue, inputType),
+    };
+  });
+}
+
+// ----- Value normalizer ------------------------------------------------------
+// Ensures currentValue matches what the field widget expects:
+//   select/text/radio  → scalar string  (takes first element if array)
+//   multiselect/chips  → always an array
+function normalizeCurrentValue(raw: unknown, inputType: PreparedField['inputType']): unknown {
+  const arrayTypes = new Set<PreparedField['inputType']>(['multiselect', 'chips', 'keywords', 'tagsinput']);
+  const scalarTypes = new Set<PreparedField['inputType']>(['select', 'text', 'textarea', 'radio', 'datepicker', 'datetime', 'license']);
+
+  if (arrayTypes.has(inputType)) {
+    if (Array.isArray(raw)) return raw;
+    if (raw !== null && raw !== undefined && raw !== '') return [raw];
+    return [];
+  }
+  if (scalarTypes.has(inputType)) {
+    if (Array.isArray(raw)) return raw[0] ?? '';
+    return raw ?? '';
+  }
+  return raw;
+}
+
+// ----- Input type resolver --------------------------------------------------
+function resolveInputType(field: Record<string, unknown>): PreparedField['inputType'] {
+  const type = (field.inputType as string ?? field.dataType as string ?? '').toLowerCase();
+  if (type === 'select' || type === 'framework') return 'select';
+  if (type === 'multiselect' || type === 'multi-select') return 'multiselect';
+  if (type === 'keywords' || field.code === 'keywords') return 'chips';
+  if (field.code === 'topic' || field.code === 'topicsIds') return 'chips';
+  if (type === 'radio') return 'radio';
+  if (field.code === 'appIcon' || type === 'appicon') return 'appIcon';
+  if (type === 'textarea' || field.code === 'description') return 'textarea';
+  if (type === 'datepicker' || type === 'date') return 'datepicker';
+  if (type === 'datetime' || type === 'datetime-local') return 'datetime';
+  if (type === 'tagsinput') return 'tagsinput';
+  if (type === 'nestedselect' || type === 'nested-select') return 'nestedselect';
+  if (type === 'license') return 'license';
+  if (type === 'dialcode' || type === 'dial-code') return 'dialcode';
+  return 'text';
+}
+
+// ----- Options resolver -----------------------------------------------------
+function resolveOptions(
+  field: Record<string, unknown>,
+  fw: IFrameworkDetails,
+): Array<{ label: string; value: string }> | undefined {
+  const range = field.range as Array<{ name: string; identifier: string }> | undefined;
+  if (range?.length) return range.map(r => ({ label: r.name, value: r.identifier }));
+  const enumVals = field.enum as string[] | undefined;
+  if (enumVals?.length) return enumVals.map(v => ({ label: v, value: v }));
+
+  const code = (field.code as string) ?? '';
+  return resolveFwOptions(code, fw);
+}
+
+function resolveFwOptions(
+  code: string,
+  fw: IFrameworkDetails,
+): Array<{ label: string; value: string }> | undefined {
+  const categoryCode = FIELD_TO_FW_CATEGORY[code];
+  if (!categoryCode) return undefined;
+
+  // target* fields: API validates against term identifiers (e.g. ncf_board_cbse)
+  // org fields (board/subject/medium/gradeLevel): API validates against term names (e.g. CBSE)
+  const toIdentifier = (t: { name: string; identifier: string }) => ({ label: t.name, value: t.identifier });
+  const toName       = (t: { name: string; identifier: string }) => ({ label: t.name, value: t.name });
+
+  if (TARGET_FW_FIELDS.has(code)) {
+    const terms = fw.targetFrameworks?.[0]?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
+    if (terms.length) return terms.map(toIdentifier);
+    const orgTerms = fw.organisationFramework?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
+    return orgTerms.map(toIdentifier);
+  }
+
+  // Org framework fields — use name as value
+  const orgTerms = fw.organisationFramework?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
+  if (orgTerms.length) return orgTerms.map(toName);
+  const targetTerms = fw.targetFrameworks?.[0]?.categories?.find(c => c.code === categoryCode)?.terms ?? [];
+  return targetTerms.map(toName);
+}
+
+// ----- Helper ----------------------------------------------------------------
+function fwOpts(code: string, fw: IFrameworkDetails) {
+  return resolveFwOptions(code, fw);
+}
+
+const AUDIENCE_OPTIONS = [
+  { label: 'Student', value: 'Student' },
+  { label: 'Teacher', value: 'Teacher' },
+  { label: 'Administrator', value: 'Administrator' },
+  { label: 'Parent', value: 'Parent' },
+  { label: 'Other', value: 'Other' },
+];
+
+const LICENSE_OPTIONS = [
+  { label: 'CC BY 4.0', value: 'CC BY 4.0' },
+  { label: 'CC BY-SA 4.0', value: 'CC BY-SA 4.0' },
+  { label: 'CC BY-ND 4.0', value: 'CC BY-ND 4.0' },
+  { label: 'CC BY-NC 4.0', value: 'CC BY-NC 4.0' },
+  { label: 'CC BY-NC-SA 4.0', value: 'CC BY-NC-SA 4.0' },
+  { label: 'CC BY-NC-ND 4.0', value: 'CC BY-NC-ND 4.0' },
+  { label: 'CC0 1.0', value: 'CC0 1.0' },
+  { label: 'All Rights Reserved', value: 'All Rights Reserved' },
+];
+
+// ----- Default fields (used when no formConfig from API) --------------------
+function cv(meta: Record<string, unknown>, code: string, inputType: PreparedField['inputType']): unknown {
+  return normalizeCurrentValue(meta[code], inputType);
+}
+
+function getDefaultFields(
+  meta: Record<string, unknown>,
+  isRoot: boolean,
+  fw: IFrameworkDetails,
+): PreparedField[] {
+  // Fields shown for all nodes (root + units)
+  const fields: PreparedField[] = [
+    {
+      code: 'name', label: 'Title', inputType: 'text', required: true,
+      editable: true, tab: 'details', maxLength: 200, currentValue: cv(meta, 'name', 'text'),
+    },
+    {
+      code: 'description', label: 'Description', inputType: 'textarea',
+      editable: true, tab: 'details', maxLength: 2000, currentValue: cv(meta, 'description', 'textarea'),
+    },
+    {
+      code: 'keywords', label: 'Keywords', inputType: 'chips',
+      editable: true, tab: 'details', currentValue: cv(meta, 'keywords', 'chips'),
+    },
+  ];
+
+  if (!isRoot) return fields;
+
+  // ── Root (Course) node — Details tab ─────────────────────────────────────
+  fields.push(
+    {
+      code: 'appIcon', label: 'Icon', inputType: 'appIcon',
+      editable: true, tab: 'details', currentValue: meta.appIcon,
+    },
+    {
+      code: 'primaryCategory', label: 'Category', inputType: 'select',
+      editable: false, tab: 'details', currentValue: cv(meta, 'primaryCategory', 'select'),
+      options: [
+        { label: 'Course', value: 'Course' },
+        { label: 'Digital Textbook', value: 'Digital Textbook' },
+        { label: 'Teacher Resource', value: 'Teacher Resource' },
+        { label: 'Learning Resource', value: 'Learning Resource' },
+        { label: 'Practice Question Set', value: 'Practice Question Set' },
+      ],
+    },
+    {
+      code: 'additionalCategories', label: 'Additional Category', inputType: 'multiselect',
+      editable: true, tab: 'details', currentValue: cv(meta, 'additionalCategories', 'multiselect'),
+      options: [
+        { label: 'Lesson Plan', value: 'Lesson Plan' },
+        { label: 'Textbook', value: 'Textbook' },
+        { label: 'TV Lesson', value: 'TV Lesson' },
+        { label: 'Revision Material', value: 'Revision Material' },
+      ],
+    },
+    {
+      code: 'board', label: 'Course Type', inputType: 'select',
+      required: true, editable: true, tab: 'details',
+      options: fwOpts('board', fw), currentValue: cv(meta, 'board', 'select'),
+    },
+    {
+      code: 'subject', label: 'Subjects covered in the course', inputType: 'multiselect',
+      required: true, editable: true, tab: 'details',
+      options: fwOpts('subject', fw), currentValue: cv(meta, 'subject', 'multiselect'),
+    },
+  );
+
+  // ── Root (Course) node — Audience & Curriculum tab ───────────────────────
+  fields.push(
+    {
+      code: 'audience', label: 'Audience Type', inputType: 'multiselect',
+      editable: true, tab: 'audience', options: AUDIENCE_OPTIONS,
+      currentValue: cv(meta, 'audience', 'multiselect'),
+    },
+    {
+      code: 'targetBoardIds', label: 'Board/Syllabus of the audience', inputType: 'select',
+      required: true, editable: true, tab: 'audience',
+      options: fwOpts('targetBoardIds', fw), currentValue: cv(meta, 'targetBoardIds', 'select'),
+    },
+    {
+      code: 'targetMediumIds', label: 'Medium(s) of the audience', inputType: 'multiselect',
+      required: true, editable: true, tab: 'audience', depends: ['targetBoardIds'],
+      options: fwOpts('targetMediumIds', fw), currentValue: cv(meta, 'targetMediumIds', 'multiselect'),
+    },
+    {
+      code: 'targetGradeLevelIds', label: 'Class(es) of the audience', inputType: 'multiselect',
+      required: true, editable: true, tab: 'audience', depends: ['targetMediumIds'],
+      options: fwOpts('targetGradeLevelIds', fw), currentValue: cv(meta, 'targetGradeLevelIds', 'multiselect'),
+    },
+    {
+      code: 'targetSubjectIds', label: 'Subject(s) of the audience', inputType: 'multiselect',
+      required: true, editable: true, tab: 'audience', depends: ['targetGradeLevelIds'],
+      options: fwOpts('targetSubjectIds', fw), currentValue: cv(meta, 'targetSubjectIds', 'multiselect'),
+    },
+  );
+
+  // ── Root (Course) node — Licensing tab ──────────────────────────────────
+  fields.push(
+    {
+      code: 'creator', label: 'Author', inputType: 'text',
+      editable: true, tab: 'licensing', currentValue: cv(meta, 'creator', 'text'),
+    },
+    {
+      code: 'attributions', label: 'Attributions', inputType: 'text',
+      editable: true, tab: 'licensing', currentValue: cv(meta, 'attributions', 'text'),
+    },
+    {
+      code: 'copyright', label: 'Copyright', inputType: 'text',
+      required: true, editable: true, tab: 'licensing', currentValue: cv(meta, 'copyright', 'text'),
+    },
+    {
+      code: 'copyrightYear', label: 'Copyright Year', inputType: 'text',
+      required: true, editable: true, tab: 'licensing', currentValue: cv(meta, 'copyrightYear', 'text'),
+    },
+    {
+      code: 'license', label: 'License', inputType: 'select',
+      required: true, editable: true, tab: 'licensing',
+      options: LICENSE_OPTIONS, currentValue: cv(meta, 'license', 'select'),
+    },
+  );
+
+  return fields;
+}

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -106,7 +106,11 @@ export function useFieldPrepare(
       code,
       label: (field.label as string) ?? code,
       inputType,
-      required: !!(field.required ?? field.validations),
+      required: !!(
+        field.required === true ||
+        (Array.isArray(field.validations) &&
+          (field.validations as Array<Record<string, unknown>>).some(v => v.type === 'required'))
+      ),
       editable: field.editable !== false,
       placeholder: field.placeholder as string | undefined,
       maxLength: field.maxLength as number | undefined,

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -41,6 +41,37 @@ export interface IFieldConfig extends PreparedField {
   range?: Array<{ name: string; identifier: string }>;
 }
 
+/**
+ * Extra context the form needs to seed defaults / ranges and to decide
+ * per-field editability — mirrors the data Angular reads from EditorService,
+ * HelperService.channelInfo and ConfigService inside `prepareFields` /
+ * `ifFieldIsEditable`. All fields optional so existing callers keep working.
+ */
+export interface IPrepareContext {
+  editorMode?: string;
+  /** editorConfig.config.editableFields — { review: ['name', …], … }. */
+  editableFields?: Record<string, string[]>;
+  /** editorConfig.config.objectType — picks the channel additionalCategories source. */
+  objectType?: string;
+  setDefaultCopyRight?: boolean;
+  /** editorConfig.context.defaultLicense */
+  defaultLicense?: string;
+  /** editorConfig.context.additionalCategories (fallback). */
+  contextAdditionalCategories?: string[];
+  /** editorConfig.context.user.fullName */
+  userFullName?: string;
+  /** channelInfo.name — used as default copyright when setDefaultCopyRight. */
+  channelName?: string;
+  /** channelInfo.collectionAdditionalCategories */
+  collectionAdditionalCategories?: string[];
+  /** channelInfo.contentAdditionalCategories */
+  contentAdditionalCategories?: string[];
+  /** Count of the active node's direct children — feeds maxQuestions range. */
+  childCount?: number;
+}
+
+const REVIEW_MODES = new Set(['review', 'read', 'sourcingreview', 'orgreview']);
+
 // ----- Tab assignment --------------------------------------------------------
 // Sections from the category-definition map to editor tabs. Falls back to a
 // per-code map, then to Details.
@@ -96,9 +127,18 @@ export function useFieldPrepare(
   formConfig: Array<Record<string, unknown>>,
   nodeMetadata: Record<string, unknown>,
   frameworkDetails: IFrameworkDetails,
-  isRoot: boolean
+  isRoot: boolean,
+  ctx: IPrepareContext = {},
 ): PreparedField[] {
   if (!formConfig?.length) return getDefaultFields(nodeMetadata, isRoot, frameworkDetails);
+
+  // Code → raw field config, so a dependent field can read its PARENT field's
+  // sourceCategory (mirrors Angular's `findField(parentCode)`).
+  const fieldsByCode = new Map<string, Record<string, unknown>>();
+  for (const f of formConfig) {
+    const c = f.code as string;
+    if (c && !fieldsByCode.has(c)) fieldsByCode.set(c, f);
+  }
 
   const seenCodes = new Set<string>();
   return formConfig.filter((field) => {
@@ -114,9 +154,11 @@ export function useFieldPrepare(
   }).map((field): PreparedField => {
     const code = (field.code as string) ?? '';
     const inputType = resolveInputType(field);
-    const options = resolveOptions(field, frameworkDetails, nodeMetadata);
+    const options = resolveOptions(field, frameworkDetails, nodeMetadata, fieldsByCode, ctx);
     const rawValue = nodeMetadata[code];
-    const currentValue = normalizeCurrentValue(rawValue, inputType);
+    const currentValue = applyFieldDefault(
+      code, normalizeCurrentValue(rawValue, inputType), inputType, nodeMetadata, ctx,
+    );
     const base: PreparedField = {
       code,
       label: (field.label as string) ?? code,
@@ -126,7 +168,7 @@ export function useFieldPrepare(
         (Array.isArray(field.validations) &&
           (field.validations as Array<Record<string, unknown>>).some(v => v.type === 'required'))
       ),
-      editable: field.editable !== false,
+      editable: computeEditable(code, field.editable !== false, ctx),
       placeholder: field.placeholder as string | undefined,
       maxLength: field.maxLength as number | undefined,
       // Guarantee the stored value is selectable/displayable even when the API
@@ -150,6 +192,77 @@ export function useFieldPrepare(
 
     return base;
   });
+}
+
+// ----- Editability (mirrors Angular ifFieldIsEditable) -----------------------
+// Outside review modes a field is editable unless the API marked it
+// non-editable. Inside a review mode (review/read/sourcingreview/orgreview) a
+// field is editable ONLY if editorConfig.config.editableFields[mode] lists it.
+function computeEditable(code: string, apiEditable: boolean, ctx: IPrepareContext): boolean {
+  const mode = ctx.editorMode ?? 'edit';
+  if (!REVIEW_MODES.has(mode)) {
+    return apiEditable !== false;
+  }
+  const allowed = ctx.editableFields?.[mode];
+  return !!(allowed && allowed.includes(code));
+}
+
+// ----- Per-field default & range seeding (mirrors prepareFields 180-244) -----
+// Returns the effective currentValue. Only fills a value when the node has
+// none — never overrides authored metadata.
+function applyFieldDefault(
+  code: string,
+  currentValue: unknown,
+  inputType: PreparedField['inputType'],
+  meta: Record<string, unknown>,
+  ctx: IPrepareContext,
+): unknown {
+  const isEmpty = currentValue === undefined || currentValue === null || currentValue === ''
+    || (Array.isArray(currentValue) && currentValue.length === 0);
+
+  switch (code) {
+    case 'license':
+      if (isEmpty) return ctx.defaultLicense ?? '';
+      return currentValue;
+    case 'copyright':
+      if (isEmpty && ctx.setDefaultCopyRight && ctx.channelName) return ctx.channelName;
+      return currentValue;
+    case 'author':
+    case 'creator':
+      if (isEmpty && ctx.userFullName) return ctx.userFullName;
+      return currentValue;
+    case 'instructions': {
+      // metadata.instructions is an object { default: '...' }; always surface its
+      // `default` string (Angular: _.get(meta, 'instructions.default') || '').
+      const inst = meta['instructions'];
+      if (inst && typeof inst === 'object' && !Array.isArray(inst)) {
+        return ((inst as Record<string, unknown>)['default'] as string) ?? '';
+      }
+      return typeof currentValue === 'object' && currentValue !== null ? '' : currentValue;
+    }
+    case 'maxTime':
+    case 'warningTime': {
+      if (!isEmpty) return currentValue;
+      const limits = meta['timeLimits'] as Record<string, unknown> | undefined;
+      const raw = limits?.[code];
+      if (raw !== undefined && raw !== null && raw !== '') {
+        return formatDurationSeconds(Number(raw));
+      }
+      return currentValue;
+    }
+    default:
+      return currentValue;
+  }
+}
+
+// seconds → 'HH:MM:SS' (or 'MM:SS' when under an hour) — replaces moment.
+function formatDurationSeconds(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) return '';
+  const s = Math.floor(totalSeconds % 60);
+  const m = Math.floor((totalSeconds / 60) % 60);
+  const h = Math.floor(totalSeconds / 3600);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
 }
 
 // ----- Selected-value guarantee ---------------------------------------------
@@ -258,7 +371,17 @@ function resolveOptions(
   field: Record<string, unknown>,
   fw: IFrameworkDetails,
   nodeMetadata: Record<string, unknown>,
+  fieldsByCode: Map<string, Record<string, unknown>>,
+  ctx: IPrepareContext,
 ): Array<{ label: string; value: string }> | undefined {
+  const code = (field.code as string) ?? '';
+
+  // maxQuestions: range is 1..(child count) — mirrors Angular's _.times(childCount).
+  if (code === 'maxQuestions') {
+    const n = ctx.childCount ?? 0;
+    if (n > 0) return Array.from({ length: n }, (_, i) => ({ label: String(i + 1), value: String(i + 1) }));
+  }
+
   // 1. Explicit range — either string[] (e.g. audience) or {name, identifier}[]
   const range = field.range as Array<unknown> | undefined;
   if (Array.isArray(range) && range.length) {
@@ -271,77 +394,143 @@ function resolveOptions(
   const enumVals = field.enum as string[] | undefined;
   if (enumVals?.length) return enumVals.map(v => ({ label: v, value: v }));
 
-  // 3. Framework-backed — use the field's own sourceCategory, falling back to
-  //    the legacy code→category map.
-  const code = (field.code as string) ?? '';
-
   // Channel-derived fields: options come from the channel read API, not the framework API.
   if (code === 'framework') return fw.orgFrameworks;
   if (code === 'additionalCategories') {
-    return fw.channelAdditionalCategories?.map(c => ({ label: c, value: c }));
+    // Source depends on objectType: QuestionSet → contentAdditionalCategories,
+    // otherwise collectionAdditionalCategories; falls back to context list.
+    // (mirrors categoryConfig.additionalCategories[objectType] ∥ context.additionalCategories)
+    const objType = ctx.objectType ?? '';
+    const channelList = objType === 'QuestionSet'
+      ? (ctx.contentAdditionalCategories ?? ctx.collectionAdditionalCategories)
+      : (ctx.collectionAdditionalCategories ?? ctx.contentAdditionalCategories);
+    const list = (channelList && channelList.length ? channelList : ctx.contextAdditionalCategories)
+      ?? fw.channelAdditionalCategories;
+    return list?.length ? uniq(list).map(c => ({ label: c, value: c })) : undefined;
   }
 
+  // 3. Framework-backed — use the field's own sourceCategory, falling back to
+  //    the legacy code→category map.
   const categoryCode = (field.sourceCategory as string | undefined) ?? FIELD_TO_FW_CATEGORY[code];
   if (!categoryCode) return undefined;
 
-  return resolveFwOptions(code, categoryCode, field, fw, nodeMetadata);
+  return resolveFwOptions(code, categoryCode, field, fw, nodeMetadata, fieldsByCode);
 }
 
+// Decide whether a field's value is the term identifier (target fields,
+// explicit output:'identifier', Target sections) or the term name (org default).
+function usesIdentifier(code: string, field: Record<string, unknown>): boolean {
+  return (
+    TARGET_FW_FIELDS.has(code) ||
+    (field.output as string | undefined) === 'identifier' ||
+    (typeof (field.section as string) === 'string' && (field.section as string).includes('Target'))
+  );
+}
+
+function prefersTargetFramework(code: string, field: Record<string, unknown>): boolean {
+  return TARGET_FW_FIELDS.has(code) ||
+    (typeof (field.section as string) === 'string' && (field.section as string).includes('Target'));
+}
+
+// Terms of a single framework category. Org cascade reads from the org
+// framework; target cascade prefers the target framework, falling back to org.
+function categoryTerms(fw: IFrameworkDetails, categoryCode: string, preferTarget: boolean): ITerm[] {
+  const orgCat = fw.organisationFramework?.categories?.find(c => c.code === categoryCode);
+  const targetCat = fw.targetFrameworks?.[0]?.categories?.find(c => c.code === categoryCode);
+  if (preferTarget) return targetCat?.terms ?? orgCat?.terms ?? [];
+  return orgCat?.terms ?? targetCat?.terms ?? [];
+}
+
+function uniqByIdentifier(terms: ITerm[]): ITerm[] {
+  const seen = new Set<string>();
+  const out: ITerm[] = [];
+  for (const t of terms) {
+    const key = t.identifier ?? t.name;
+    if (key && !seen.has(key)) { seen.add(key); out.push(t); }
+  }
+  return out;
+}
+
+function uniq<T>(arr: T[]): T[] { return Array.from(new Set(arr)); }
+
+function asArray(v: unknown): unknown[] {
+  if (Array.isArray(v)) return v;
+  return v != null && v !== '' ? [v] : [];
+}
+
+/**
+ * Compute a framework-backed dropdown's options.
+ *
+ * Mirrors Angular `computeOptions` (spark-meta-form.component.ts:333-366):
+ * a dependent field's options come from the SELECTED PARENT term's
+ * `.associations`, filtered to this field's category — i.e. the graph is read
+ * PARENT → CHILD. (The previous React code read CHILD → PARENT, which dropped
+ * valid terms — e.g. "English" — whose own associations didn't point back at
+ * the selected board. That was the "English not in Medium" bug.)
+ *
+ * Fallback (mirrors Angular's target-framework association synthesis,
+ * prepareFields:144-178): when the matched parent terms carry no associations
+ * for this category — common for target frameworks, or frameworks modelled in
+ * reverse — fall back to this field's own category terms so the dropdown is
+ * never wrongly emptied.
+ */
 function resolveFwOptions(
   code: string,
   categoryCode: string,
   field: Record<string, unknown>,
   fw: IFrameworkDetails,
   nodeMetadata: Record<string, unknown>,
+  fieldsByCode: Map<string, Record<string, unknown>>,
 ): Array<{ label: string; value: string }> | undefined {
-  // Decide value source: target fields & explicit output:'identifier' use the
-  // term identifier; org fields default to the term name (Sunbird convention).
-  const useIdentifier =
-    TARGET_FW_FIELDS.has(code) ||
-    (field.output as string | undefined) === 'identifier' ||
-    (typeof (field.section as string) === 'string' && (field.section as string).includes('Target'));
-
+  const useIdentifier = usesIdentifier(code, field);
+  const preferTarget = prefersTargetFramework(code, field);
   const fromTerm = (t: ITerm) => ({ label: t.name, value: useIdentifier ? t.identifier : t.name });
 
-  // Source framework: target fields prefer the target framework, then org.
-  const orgCat = fw.organisationFramework?.categories?.find(c => c.code === categoryCode);
-  const targetCat = fw.targetFrameworks?.[0]?.categories?.find(c => c.code === categoryCode);
-  let terms: ITerm[] = (TARGET_FW_FIELDS.has(code) ? targetCat?.terms : orgCat?.terms)
-    ?? targetCat?.terms ?? orgCat?.terms ?? [];
-
-  // Cascade filtering: if this field depends on parent fields, keep only terms
-  // whose associations include a currently-selected parent value. Parent values
-  // are read from nodeMetadata (which merges live form edits), so options
-  // re-filter reactively as parents change — no extra fetch needed.
   const depends = field.depends as string[] | undefined;
-  if (depends?.length) {
-    const parentValues = depends
-      .flatMap(p => {
-        const v = nodeMetadata[p];
-        return Array.isArray(v) ? v : (v != null && v !== '' ? [v] : []);
-      })
-      .map(String);
-    if (parentValues.length) {
-      const filtered = terms.filter(t => {
-        const assoc = t.associations;
-        if (!assoc || !assoc.length) return true; // no association info ⇒ keep
-        return assoc.some(a => parentValues.includes(a.identifier) || parentValues.includes(a.code) || parentValues.includes(a.name));
-      });
-      // Only narrow when the association graph actually matched something —
-      // otherwise (associations absent or modelled the other direction) keep
-      // the full list so the dropdown isn't emptied.
-      if (filtered.length) terms = filtered;
-    }
+
+  // Non-dependent field → its own category terms.
+  if (!depends?.length) {
+    return categoryTerms(fw, categoryCode, preferTarget).map(fromTerm);
   }
 
-  return terms.map(fromTerm);
+  // Dependent field → read the selected parent term's associations.
+  const selected = depends.flatMap(p => asArray(nodeMetadata[p])).map(String);
+  // Empty until a parent is chosen — matches Angular (computeOptions returns []).
+  if (!selected.length) return [];
+
+  // Gather parent terms (each carries `.associations`).
+  const parentTerms: ITerm[] = [];
+  for (const pCode of depends) {
+    const pField = fieldsByCode.get(pCode);
+    const pCat = (pField?.sourceCategory as string | undefined) ?? FIELD_TO_FW_CATEGORY[pCode] ?? pCode;
+    parentTerms.push(...categoryTerms(fw, pCat, preferTarget));
+  }
+
+  // Parent terms matching the selected parent value(s) (by name / identifier / code).
+  const matched = parentTerms.filter(t =>
+    selected.includes(String(t.name)) ||
+    selected.includes(String(t.identifier)) ||
+    selected.includes(String(t.code)));
+
+  // Their associations, filtered to THIS field's category.
+  const associations = matched
+    .flatMap(t => t.associations ?? [])
+    .filter(a => String(a.category ?? '').toLowerCase() === categoryCode.toLowerCase());
+
+  const uniqueAssoc = uniqByIdentifier(associations);
+  if (uniqueAssoc.length) return uniqueAssoc.map(fromTerm);
+
+  // Fallback: parents carry no associations for this category (target frameworks
+  // / reverse-modelled data) → show the child's own terms. Equivalent outcome
+  // to Angular's cross-product synthesis, without emptying the dropdown.
+  return categoryTerms(fw, categoryCode, preferTarget).map(fromTerm);
 }
 
 // ----- Helper ----------------------------------------------------------------
 function fwOpts(code: string, fw: IFrameworkDetails) {
   const categoryCode = FIELD_TO_FW_CATEGORY[code];
   if (!categoryCode) return undefined;
-  return resolveFwOptions(code, categoryCode, { code }, fw, {});
+  return resolveFwOptions(code, categoryCode, { code }, fw, {}, new Map());
 }
 
 // ----- Default fields (used when no formConfig from API) --------------------
@@ -451,4 +640,21 @@ function getDefaultFields(
   );
 
   return fields;
+}
+
+// ----- Testable pure export --------------------------------------------------
+// Direct access to the cascade resolver for unit tests (the "English in Medium"
+// regression guard). Mirrors what useFieldPrepare computes for one field.
+export function __computeFieldOptionsForTest(
+  field: Record<string, unknown>,
+  fw: IFrameworkDetails,
+  nodeMetadata: Record<string, unknown>,
+  siblingFields: Array<Record<string, unknown>> = [],
+): Array<{ label: string; value: string }> | undefined {
+  const fieldsByCode = new Map<string, Record<string, unknown>>();
+  for (const f of siblingFields) {
+    const c = f.code as string;
+    if (c && !fieldsByCode.has(c)) fieldsByCode.set(c, f);
+  }
+  return resolveOptions(field, fw, nodeMetadata, fieldsByCode, {});
 }

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -168,8 +168,7 @@ export function useFieldPrepare(
         (Array.isArray(field.validations) &&
           (field.validations as Array<Record<string, unknown>>).some(v => v.type === 'required'))
       ),
-      // author is always auto-filled with the current user and locked.
-      editable: code === 'author' ? false : computeEditable(code, field.editable !== false, ctx),
+      editable: computeEditable(code, field.editable !== false, ctx),
       placeholder: field.placeholder as string | undefined,
       maxLength: field.maxLength as number | undefined,
       // Guarantee the stored value is selectable/displayable even when the API

--- a/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/hooks/useFieldPrepare.ts
@@ -13,6 +13,7 @@ export interface PreparedField {
     | 'datepicker' | 'datetime' | 'keywords' | 'tagsinput' | 'nestedselect' | 'license' | 'dialcode';
   required?: boolean;
   editable?: boolean;
+  visible?: boolean;
   placeholder?: string;
   maxLength?: number;
   options?: Array<{ label: string; value: string }>;
@@ -25,11 +26,13 @@ export interface PreparedField {
 }
 
 export const SECTION_DISPLAY: Record<string, { title: string; description?: string }> = {
-  'First Section': { title: 'Basic Information', description: 'Core details that define the content identity.' },
+  'First Section':  { title: 'Basic Information', description: 'Core details that define the content identity.' },
   'Second Section': { title: 'Categorisation', description: 'Category and type classification for the content.' },
+  'Third Section':  { title: 'Categorisation', description: 'Category and type classification for the content.' },
   'Organisation Framework Terms': { title: 'Curriculum', description: 'Framework-aligned categorisation.' },
   'Target Framework Terms': { title: 'Target Audience', description: 'Curriculum alignment for the intended learners.' },
   'Fourth Section': { title: 'Licensing & Attribution', description: 'Copyright and usage rights information.' },
+  'Sixth Section':  { title: 'Licensing & Attribution', description: 'Copyright and usage rights information.' },
 };
 
 export interface IFieldConfig extends PreparedField {
@@ -42,11 +45,22 @@ export interface IFieldConfig extends PreparedField {
 // Sections from the category-definition map to editor tabs. Falls back to a
 // per-code map, then to Details.
 const SECTION_TAB_MAP: Record<string, PreparedField['tab']> = {
-  'First Section': 'details',
+  'First Section':  'details',
   'Second Section': 'details',
+  'Third Section':  'details',   // Content Playlist: primaryCategory, additionalCategories
   'Organisation Framework Terms': 'details',
   'Target Framework Terms': 'audience',
   'Fourth Section': 'licensing',
+  'Sixth Section':  'licensing', // Content Playlist: author, copyright, license
+};
+
+// Alias map for live APIs that use section display title as the machine name.
+const SECTION_TITLE_ALIAS: Record<string, string> = {
+  'Categorisation':          'Second Section',
+  'Basic Information':       'First Section',
+  'Licensing & Attribution': 'Fourth Section',
+  'Curriculum':              'Organisation Framework Terms',
+  'Target Audience':         'Target Framework Terms',
 };
 
 const FIELD_TAB_MAP: Record<string, PreparedField['tab']> = {
@@ -55,6 +69,7 @@ const FIELD_TAB_MAP: Record<string, PreparedField['tab']> = {
   primaryCategory: 'details', additionalCategories: 'details',
   board: 'details', subject: 'details', subjectIds: 'details', medium: 'details',
   framework: 'details', topicsIds: 'details', topic: 'details',
+  dialcodeRequired: 'details', dialcodes: 'details',
   // Audience & Curriculum
   audience: 'audience',
   targetBoardIds: 'audience', targetMediumIds: 'audience',
@@ -102,7 +117,7 @@ export function useFieldPrepare(
     const options = resolveOptions(field, frameworkDetails, nodeMetadata);
     const rawValue = nodeMetadata[code];
     const currentValue = normalizeCurrentValue(rawValue, inputType);
-    return {
+    const base: PreparedField = {
       code,
       label: (field.label as string) ?? code,
       inputType,
@@ -124,6 +139,16 @@ export function useFieldPrepare(
       defaultValue: field.defaultValue ?? field.default,
       currentValue,
     };
+
+    // dialcodes is only visible and required when dialcodeRequired === 'Yes'.
+    // The API marks it required unconditionally; override here to respect the
+    // QR code toggle (default is "No").
+    if (code === 'dialcodes') {
+      const isQrRequired = (nodeMetadata['dialcodeRequired'] as string | undefined) === 'Yes';
+      return { ...base, required: isQrRequired, visible: isQrRequired };
+    }
+
+    return base;
   });
 }
 
@@ -172,7 +197,11 @@ function withSelectedOptions(
 // ----- Tab resolver ----------------------------------------------------------
 function resolveTab(field: Record<string, unknown>): PreparedField['tab'] {
   const section = field.section as string | undefined;
-  if (section && SECTION_TAB_MAP[section]) return SECTION_TAB_MAP[section];
+  if (section) {
+    if (SECTION_TAB_MAP[section]) return SECTION_TAB_MAP[section];
+    const alias = SECTION_TITLE_ALIAS[section];
+    if (alias && SECTION_TAB_MAP[alias]) return SECTION_TAB_MAP[alias];
+  }
   const code = (field.code as string) ?? '';
   return FIELD_TAB_MAP[code] ?? 'details';
 }
@@ -313,26 +342,9 @@ function fwOpts(code: string, fw: IFrameworkDetails) {
   return resolveFwOptions(code, categoryCode, { code }, fw, {});
 }
 
-const AUDIENCE_OPTIONS = [
-  { label: 'Student', value: 'Student' },
-  { label: 'Teacher', value: 'Teacher' },
-  { label: 'Administrator', value: 'Administrator' },
-  { label: 'Parent', value: 'Parent' },
-  { label: 'Other', value: 'Other' },
-];
-
-const LICENSE_OPTIONS = [
-  { label: 'CC BY 4.0', value: 'CC BY 4.0' },
-  { label: 'CC BY-SA 4.0', value: 'CC BY-SA 4.0' },
-  { label: 'CC BY-ND 4.0', value: 'CC BY-ND 4.0' },
-  { label: 'CC BY-NC 4.0', value: 'CC BY-NC 4.0' },
-  { label: 'CC BY-NC-SA 4.0', value: 'CC BY-NC-SA 4.0' },
-  { label: 'CC BY-NC-ND 4.0', value: 'CC BY-NC-ND 4.0' },
-  { label: 'CC0 1.0', value: 'CC0 1.0' },
-  { label: 'All Rights Reserved', value: 'All Rights Reserved' },
-];
-
 // ----- Default fields (used when no formConfig from API) --------------------
+// Structural skeleton only — no hardcoded options. All option values come from
+// the API category definition; this fallback exists only for graceful degradation.
 function cv(meta: Record<string, unknown>, code: string, inputType: PreparedField['inputType']): unknown {
   return normalizeCurrentValue(meta[code], inputType);
 }
@@ -342,7 +354,6 @@ function getDefaultFields(
   isRoot: boolean,
   fw: IFrameworkDetails,
 ): PreparedField[] {
-  // Fields shown for all nodes (root + units)
   const fields: PreparedField[] = [
     {
       code: 'name', label: 'Title', inputType: 'text', required: true,
@@ -360,46 +371,34 @@ function getDefaultFields(
 
   if (!isRoot) return fields;
 
-  // ── Root (Course) node — Details tab ─────────────────────────────────────
+  // ── Root node — Details tab ───────────────────────────────────────────────
   fields.push(
     {
       code: 'primaryCategory', label: 'Category', inputType: 'select',
       editable: false, tab: 'details', section: 'Second Section', currentValue: cv(meta, 'primaryCategory', 'select'),
-      options: [
-        { label: 'Course', value: 'Course' },
-        { label: 'Digital Textbook', value: 'Digital Textbook' },
-        { label: 'Teacher Resource', value: 'Teacher Resource' },
-        { label: 'Learning Resource', value: 'Learning Resource' },
-        { label: 'Practice Question Set', value: 'Practice Question Set' },
-      ],
     },
     {
       code: 'additionalCategories', label: 'Additional Category', inputType: 'multiselect',
       editable: true, tab: 'details', section: 'Second Section', currentValue: cv(meta, 'additionalCategories', 'multiselect'),
-      options: [
-        { label: 'Lesson Plan', value: 'Lesson Plan' },
-        { label: 'Textbook', value: 'Textbook' },
-        { label: 'TV Lesson', value: 'TV Lesson' },
-        { label: 'Revision Material', value: 'Revision Material' },
-      ],
+      options: fw.channelAdditionalCategories?.map(c => ({ label: c, value: c })),
     },
     {
-      code: 'board', label: 'Course Type', inputType: 'select',
+      code: 'framework', label: 'Course Type', inputType: 'select',
       required: true, editable: true, tab: 'details', section: 'Organisation Framework Terms',
-      options: fwOpts('board', fw), currentValue: cv(meta, 'board', 'select'),
+      options: fw.orgFrameworks, currentValue: cv(meta, 'framework', 'select'),
     },
     {
-      code: 'subject', label: 'Subjects covered in the course', inputType: 'multiselect',
+      code: 'subjectIds', label: 'Subjects covered', inputType: 'multiselect',
       required: true, editable: true, tab: 'details', section: 'Organisation Framework Terms',
-      options: fwOpts('subject', fw), currentValue: cv(meta, 'subject', 'multiselect'),
+      options: fwOpts('subjectIds', fw), currentValue: cv(meta, 'subjectIds', 'multiselect'),
     },
   );
 
-  // ── Root (Course) node — Audience & Curriculum tab ───────────────────────
+  // ── Root node — Audience & Curriculum tab ─────────────────────────────────
   fields.push(
     {
       code: 'audience', label: 'Audience Type', inputType: 'multiselect',
-      editable: true, tab: 'audience', section: 'Target Framework Terms', options: AUDIENCE_OPTIONS,
+      editable: true, tab: 'audience', section: 'Target Framework Terms',
       currentValue: cv(meta, 'audience', 'multiselect'),
     },
     {
@@ -424,7 +423,7 @@ function getDefaultFields(
     },
   );
 
-  // ── Root (Course) node — Licensing tab ──────────────────────────────────
+  // ── Root node — Licensing tab ─────────────────────────────────────────────
   fields.push(
     {
       code: 'creator', label: 'Author', inputType: 'text',
@@ -445,7 +444,7 @@ function getDefaultFields(
     {
       code: 'license', label: 'License', inputType: 'select',
       required: true, editable: true, tab: 'licensing', section: 'Fourth Section',
-      options: LICENSE_OPTIONS, currentValue: cv(meta, 'license', 'select'),
+      currentValue: cv(meta, 'license', 'select'),
     },
   );
 

--- a/projects/collection-editor-react/src/components/SparkMetaForm/index.ts
+++ b/projects/collection-editor-react/src/components/SparkMetaForm/index.ts
@@ -1,0 +1,1 @@
+export { SparkMetaForm } from './SparkMetaForm';

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.module.scss
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.module.scss
@@ -1,0 +1,166 @@
+.shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: var(--sbx-tree-w, 284px) 1fr var(--sbx-dock-w, 312px);
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+  position: relative;
+
+  &.sidebarCollapsed {
+    grid-template-columns: 0 1fr var(--sbx-dock-w, 312px);
+  }
+
+  &.dockCollapsed {
+    grid-template-columns: var(--sbx-tree-w, 284px) 1fr 0;
+  }
+
+  &.sidebarCollapsed.dockCollapsed {
+    grid-template-columns: 0 1fr 0;
+  }
+
+  @media (max-width: 1200px) {
+    grid-template-columns: var(--sbx-tree-w, 284px) 1fr;
+    .dock { display: none; }
+    &.sidebarCollapsed { grid-template-columns: 0 1fr; }
+  }
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+    .outline { display: none; }
+  }
+}
+
+// Tab to reopen collapsed sidebar
+.reopenTab {
+  position: absolute;
+  left: 0;
+  top: 10px;
+  z-index: 20;
+  width: 20px;
+  height: 36px;
+  border-radius: 0 var(--sbx-r-sm) var(--sbx-r-sm) 0;
+  border: 1px solid var(--sbx-gray-200);
+  border-left: none;
+  background: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--sbx-gray-500);
+  font-size: 16px;
+  font-weight: bold;
+  box-shadow: 2px 0 4px rgba(0,0,0,0.06);
+  transition: color 0.15s;
+  &:hover { color: var(--sbx-primary); }
+}
+
+.outline {
+  border-right: 1px solid var(--sbx-gray-200);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: white;
+  transition: width 0.2s;
+}
+
+.outlineHidden {
+  overflow: hidden;
+  width: 0;
+  min-width: 0;
+  border-right: none;
+}
+
+.editor {
+  overflow-y: auto;
+  background: var(--sbx-gray-50);
+  min-width: 0;
+}
+
+.dock {
+  border-left: 1px solid var(--sbx-gray-200);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: white;
+  transition: width 0.2s;
+}
+
+.dockHidden {
+  overflow: hidden;
+  width: 0;
+  min-width: 0;
+  border-left: none;
+}
+
+// Tab to reopen collapsed library dock
+.dockReopenTab {
+  position: absolute;
+  right: 0;
+  top: 10px;
+  z-index: 20;
+  width: 20px;
+  height: 36px;
+  border-radius: var(--sbx-r-sm) 0 0 var(--sbx-r-sm);
+  border: 1px solid var(--sbx-gray-200);
+  border-right: none;
+  background: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--sbx-gray-500);
+  font-size: 16px;
+  font-weight: bold;
+  box-shadow: -2px 0 4px rgba(0,0,0,0.06);
+  transition: color 0.15s;
+  &:hover { color: var(--sbx-primary); }
+}
+
+.dragChip {
+  background: var(--sbx-primary);
+  color: white;
+  border-radius: var(--sbx-r-xl);
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: var(--sbx-shadow-2);
+  pointer-events: none;
+  white-space: nowrap;
+  max-width: 200px;
+  display: flex;
+  align-items: center;
+}
+
+.dragChipLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+// Placeholder styles for sub-components not yet implemented
+.placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  padding: 24px;
+}
+
+.placeholderLabel {
+  font-family: var(--sbx-font);
+  font-size: 13px;
+  color: var(--sbx-gray-400);
+  background: var(--sbx-gray-100);
+  border: 1.5px dashed var(--sbx-gray-300);
+  border-radius: var(--sbx-r-md);
+  padding: 10px 18px;
+}

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useState } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import type { EditorMode, ToolbarAction } from '../../types/editor';
+import type { IContent } from '../../types/content';
+import { Topbar } from '../Topbar';
+import { OutlineTree } from '../OutlineTree';
+import { ContextualEditor } from '../ContextualEditor';
+import { LibraryDock } from '../LibraryDock';
+import { useTreeStore } from '../../store/tree.store';
+import { useSaveHierarchy } from '../../hooks/useSaveHierarchy';
+import toast from 'react-hot-toast';
+import styles from './SplitBuilderShell.module.scss';
+
+interface SplitBuilderShellProps {
+  editorMode: EditorMode;
+  onToolbarEvent?: (event: { action: ToolbarAction; data?: unknown }) => void;
+  onContentAdded?: (item: unknown, targetNodeId: string) => void;
+  onHierarchySaved?: (hierarchy: unknown) => void;
+}
+
+export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
+  editorMode,
+  onToolbarEvent,
+  onContentAdded,
+  onHierarchySaved,
+}) => {
+  const [activeDragItem, setActiveDragItem] = useState<IContent | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [dockCollapsed, setDockCollapsed] = useState(false);
+
+  const { addResource, treeData } = useTreeStore();
+  const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
+  const { save, isSaving, isDirty, lastSaved } = useSaveHierarchy();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const item = event.active.data.current?.item as IContent | undefined;
+    if (item) setActiveDragItem(item);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveDragItem(null);
+      const item = event.active.data.current?.item as IContent | undefined;
+      if (!item) return;
+      const over = event.over;
+      const targetNodeId = (over?.id as string | undefined) ?? selectedNodeId ?? undefined;
+      if (!targetNodeId) {
+        toast.error('Drop onto a unit to add content');
+        return;
+      }
+      const rootId = treeData[0]?.id;
+      const allowContentUnderRoot = false; // matches tree.store guard
+      if (!allowContentUnderRoot && targetNodeId === rootId) {
+        toast.error('Drop content onto a unit, not directly on the course.');
+        return;
+      }
+      addResource(item, targetNodeId);
+      onContentAdded?.(item, targetNodeId);
+      toast.success(`Added "${item.name}" to unit`);
+    },
+    [selectedNodeId, addResource, onContentAdded],
+  );
+
+  const handleToolbarEvent = useCallback(
+    (event: { action: ToolbarAction; data?: unknown }) => {
+      if (event.action === 'saveCollection') {
+        save().then(() => { onHierarchySaved?.(treeData); });
+      }
+      onToolbarEvent?.(event);
+    },
+    [save, onToolbarEvent, onHierarchySaved, treeData],
+  );
+
+  return (
+    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <div className={styles.shell}>
+        <Topbar
+          editorMode={editorMode}
+          isSaving={isSaving}
+          isDirty={isDirty}
+          lastSaved={lastSaved}
+          onToolbarEvent={handleToolbarEvent}
+        />
+
+        <div className={[
+          styles.workspace,
+          sidebarCollapsed ? styles.sidebarCollapsed : '',
+          dockCollapsed ? styles.dockCollapsed : '',
+        ].filter(Boolean).join(' ')}>
+          <aside
+            className={[styles.outline, sidebarCollapsed ? styles.outlineHidden : ''].join(' ')}
+            aria-label="Course outline"
+            aria-hidden={sidebarCollapsed}
+          >
+            <OutlineTree
+              editorMode={editorMode}
+              collapsed={sidebarCollapsed}
+              onToggleCollapse={() => setSidebarCollapsed(v => !v)}
+            />
+          </aside>
+
+          {/* Reopen tab when sidebar is collapsed */}
+          {sidebarCollapsed && (
+            <button
+              className={styles.reopenTab}
+              onClick={() => setSidebarCollapsed(false)}
+              title="Show outline"
+              type="button"
+            >
+              ›
+            </button>
+          )}
+
+          <main className={styles.editor} role="main" aria-label="Content editor">
+            <ContextualEditor editorMode={editorMode} onToolbarEvent={handleToolbarEvent} />
+          </main>
+
+          <aside
+            className={[styles.dock, dockCollapsed ? styles.dockHidden : ''].filter(Boolean).join(' ')}
+            aria-label="Content library"
+            aria-hidden={dockCollapsed}
+          >
+            <LibraryDock
+              editorMode={editorMode}
+              collapsed={dockCollapsed}
+              onToggleCollapse={() => setDockCollapsed(v => !v)}
+            />
+          </aside>
+
+          {/* Reopen tab when library dock is collapsed */}
+          {dockCollapsed && (
+            <button
+              className={styles.dockReopenTab}
+              onClick={() => setDockCollapsed(false)}
+              title="Show library"
+              type="button"
+            >
+              ‹
+            </button>
+          )}
+        </div>
+      </div>
+
+      <DragOverlay dropAnimation={null}>
+        {activeDragItem ? (
+          <div className={styles.dragChip}>
+            <span className={styles.dragChipLabel}>{activeDragItem.name}</span>
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+};

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -11,6 +11,7 @@ import {
 import type { EditorMode, ToolbarAction } from '../../types/editor';
 import type { IContent } from '../../types/content';
 import { Topbar } from '../Topbar';
+import { UnsavedChangesModal } from '../modals/UnsavedChangesModal';
 import { OutlineTree } from '../OutlineTree';
 import { ContextualEditor } from '../ContextualEditor';
 import { LibraryDock } from '../LibraryDock';
@@ -36,6 +37,7 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
   const [activeDragItem, setActiveDragItem] = useState<IContent | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [dockCollapsed, setDockCollapsed] = useState(false);
+  const [showUnsavedPrompt, setShowUnsavedPrompt] = useState(false);
 
   const { addResource, treeData } = useTreeStore();
   const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
@@ -77,6 +79,11 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
 
   const handleToolbarEvent = useCallback(
     async (event: { action: ToolbarAction; data?: unknown }) => {
+      // Guard Back when there are unsaved changes (auto-save is disabled).
+      if (event.action === 'back' && isDirty) {
+        setShowUnsavedPrompt(true);
+        return;
+      }
       if (event.action === 'saveCollection') {
         await save();
         onHierarchySaved?.(treeData);
@@ -96,8 +103,21 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
       }
       onToolbarEvent?.(event);
     },
-    [save, runAction, onToolbarEvent, onHierarchySaved, treeData],
+    [save, runAction, onToolbarEvent, onHierarchySaved, treeData, isDirty],
   );
+
+  // Resolve the unsaved-changes prompt for Back.
+  const handleUnsavedSave = useCallback(async () => {
+    await save();
+    setShowUnsavedPrompt(false);
+    onHierarchySaved?.(treeData);
+    onToolbarEvent?.({ action: 'back' });
+  }, [save, onHierarchySaved, onToolbarEvent, treeData]);
+
+  const handleUnsavedDiscard = useCallback(() => {
+    setShowUnsavedPrompt(false);
+    onToolbarEvent?.({ action: 'back' });
+  }, [onToolbarEvent]);
 
   return (
     <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
@@ -176,6 +196,15 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
           </div>
         ) : null}
       </DragOverlay>
+
+      {showUnsavedPrompt && (
+        <UnsavedChangesModal
+          onSave={handleUnsavedSave}
+          onDiscard={handleUnsavedDiscard}
+          onCancel={() => setShowUnsavedPrompt(false)}
+          isSaving={isSaving}
+        />
+      )}
     </DndContext>
   );
 };

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -16,6 +16,7 @@ import { OutlineTree } from '../OutlineTree';
 import { ContextualEditor } from '../ContextualEditor';
 import { LibraryDock } from '../LibraryDock';
 import { useTreeStore } from '../../store/tree.store';
+import { useEditorStore } from '../../store/editor.store';
 import { useSaveHierarchy } from '../../hooks/useSaveHierarchy';
 import { useToolbarActions } from '../../hooks/useToolbarActions';
 import toast from 'react-hot-toast';
@@ -38,11 +39,11 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [dockCollapsed, setDockCollapsed] = useState(false);
   const [showUnsavedPrompt, setShowUnsavedPrompt] = useState(false);
-  // Tracks whether the currently selected node's form is valid.
-  // Defaults true so Save is enabled before any form interaction.
-  const [isFormValid, setIsFormValid] = useState(true);
 
   const { addResource, treeData } = useTreeStore();
+  const setFormStatus = useEditorStore((s) => s.setFormStatus);
+  // isFormValid: true while the current node's form hasn't been touched or is valid.
+  const [isFormValid, setIsFormValid] = useState(true);
   const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
   const { save, isSaving, isDirty, lastSaved } = useSaveHierarchy();
   const { runAction } = useToolbarActions(save);
@@ -98,8 +99,10 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
     async (event: { action: ToolbarAction; data?: unknown }) => {
       // Intercept form status updates from ContextualEditor — don't bubble up.
       if (event.action === 'onFormStatusChange') {
-        const { isValid } = (event.data ?? {}) as { isValid?: boolean };
-        setIsFormValid(isValid !== false);
+        const { isValid, nodeId } = (event.data ?? {}) as { isValid?: boolean; nodeId?: string | null };
+        const valid = isValid !== false;
+        setIsFormValid(valid);
+        if (nodeId) setFormStatus(nodeId, valid);
         return;
       }
       // Guard Back when there are unsaved changes (auto-save is disabled).

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -38,6 +38,9 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [dockCollapsed, setDockCollapsed] = useState(false);
   const [showUnsavedPrompt, setShowUnsavedPrompt] = useState(false);
+  // Tracks whether the currently selected node's form is valid.
+  // Defaults true so Save is enabled before any form interaction.
+  const [isFormValid, setIsFormValid] = useState(true);
 
   const { addResource, treeData } = useTreeStore();
   const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
@@ -89,6 +92,12 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
 
   const handleToolbarEvent = useCallback(
     async (event: { action: ToolbarAction; data?: unknown }) => {
+      // Intercept form status updates from ContextualEditor — don't bubble up.
+      if (event.action === 'onFormStatusChange') {
+        const { isValid } = (event.data ?? {}) as { isValid?: boolean };
+        setIsFormValid(isValid !== false);
+        return;
+      }
       // Guard Back when there are unsaved changes (auto-save is disabled).
       if (event.action === 'back' && isDirty) {
         setShowUnsavedPrompt(true);
@@ -137,6 +146,7 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
           isSaving={isSaving}
           isDirty={isDirty}
           lastSaved={lastSaved}
+          isFormValid={isFormValid}
           onToolbarEvent={handleToolbarEvent}
         />
 

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -83,7 +83,11 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
         toast.error('Drop content onto a unit, not directly on the course.');
         return;
       }
-      addResource(item, targetNodeId);
+      const added = addResource(item, targetNodeId);
+      if (!added) {
+        toast.error(`"${item.name}" is already in this collection`);
+        return;
+      }
       onContentAdded?.(item, targetNodeId);
       toast.success(`Added "${item.name}" to unit`);
     },
@@ -104,6 +108,10 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
         return;
       }
       if (event.action === 'saveCollection') {
+        if (!isFormValid) {
+          toast.error('Please fill the required metadata');
+          return;
+        }
         await save();
         onHierarchySaved?.(treeData);
         onToolbarEvent?.(event);
@@ -122,7 +130,7 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
       }
       onToolbarEvent?.(event);
     },
-    [save, runAction, onToolbarEvent, onHierarchySaved, treeData, isDirty],
+    [save, runAction, onToolbarEvent, onHierarchySaved, treeData, isDirty, isFormValid],
   );
 
   // Resolve the unsaved-changes prompt for Back.

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -43,6 +43,16 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
   const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
   const { save, isSaving, isDirty, lastSaved } = useSaveHierarchy();
   const { runAction } = useToolbarActions(save);
+
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -46,7 +46,7 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
   const [isFormValid, setIsFormValid] = useState(true);
   const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
   const { save, isSaving, isDirty, lastSaved } = useSaveHierarchy();
-  const { runAction } = useToolbarActions(save);
+  const { runAction, checkRequiredFields } = useToolbarActions(save);
 
   useEffect(() => {
     if (!isDirty) return;
@@ -106,7 +106,8 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
         return;
       }
       // Guard Back when there are unsaved changes (auto-save is disabled).
-      if (event.action === 'back' && isDirty) {
+      // Only in edit mode — reviewers/viewers exit without a save prompt.
+      if (event.action === 'back' && isDirty && editorMode === 'edit') {
         setShowUnsavedPrompt(true);
         return;
       }
@@ -115,6 +116,9 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
           toast.error('Please fill the required metadata');
           return;
         }
+        // Tree-wide required-field gate — blocks saving until every node's
+        // required metadata is filled (toasts + selects the offender itself).
+        if (!checkRequiredFields()) return;
         await save();
         onHierarchySaved?.(treeData);
         onToolbarEvent?.(event);
@@ -133,16 +137,22 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
       }
       onToolbarEvent?.(event);
     },
-    [save, runAction, onToolbarEvent, onHierarchySaved, treeData, isDirty, isFormValid],
+    [save, runAction, checkRequiredFields, onToolbarEvent, onHierarchySaved, treeData, isDirty, isFormValid, editorMode],
   );
 
   // Resolve the unsaved-changes prompt for Back.
   const handleUnsavedSave = useCallback(async () => {
+    // Same required-field gate as Save — stay in the editor so the user can
+    // fill the flagged fields (the gate toasts and selects the offender).
+    if (!checkRequiredFields()) {
+      setShowUnsavedPrompt(false);
+      return;
+    }
     await save();
     setShowUnsavedPrompt(false);
     onHierarchySaved?.(treeData);
     onToolbarEvent?.({ action: 'back' });
-  }, [save, onHierarchySaved, onToolbarEvent, treeData]);
+  }, [save, checkRequiredFields, onHierarchySaved, onToolbarEvent, treeData]);
 
   const handleUnsavedDiscard = useCallback(() => {
     setShowUnsavedPrompt(false);

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/SplitBuilderShell.tsx
@@ -16,6 +16,7 @@ import { ContextualEditor } from '../ContextualEditor';
 import { LibraryDock } from '../LibraryDock';
 import { useTreeStore } from '../../store/tree.store';
 import { useSaveHierarchy } from '../../hooks/useSaveHierarchy';
+import { useToolbarActions } from '../../hooks/useToolbarActions';
 import toast from 'react-hot-toast';
 import styles from './SplitBuilderShell.module.scss';
 
@@ -39,6 +40,7 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
   const { addResource, treeData } = useTreeStore();
   const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
   const { save, isSaving, isDirty, lastSaved } = useSaveHierarchy();
+  const { runAction } = useToolbarActions(save);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -74,13 +76,27 @@ export const SplitBuilderShell: React.FC<SplitBuilderShellProps> = ({
   );
 
   const handleToolbarEvent = useCallback(
-    (event: { action: ToolbarAction; data?: unknown }) => {
+    async (event: { action: ToolbarAction; data?: unknown }) => {
       if (event.action === 'saveCollection') {
-        save().then(() => { onHierarchySaved?.(treeData); });
+        await save();
+        onHierarchySaved?.(treeData);
+        onToolbarEvent?.(event);
+        return;
+      }
+      // review / publish / reject are handled internally (Angular parity);
+      // still emit afterwards so the host app can navigate/close on success.
+      if (
+        event.action === 'sendForReview' ||
+        event.action === 'reject' ||
+        event.action === 'publish'
+      ) {
+        const ok = await runAction(event.action, event.data);
+        if (ok) onToolbarEvent?.(event);
+        return;
       }
       onToolbarEvent?.(event);
     },
-    [save, onToolbarEvent, onHierarchySaved, treeData],
+    [save, runAction, onToolbarEvent, onHierarchySaved, treeData],
   );
 
   return (

--- a/projects/collection-editor-react/src/components/SplitBuilderShell/index.ts
+++ b/projects/collection-editor-react/src/components/SplitBuilderShell/index.ts
@@ -1,0 +1,1 @@
+export { SplitBuilderShell } from './SplitBuilderShell';

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.module.scss
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.module.scss
@@ -82,7 +82,8 @@
 }
 
 .unsaved {
-  color: var(--sbx-warning);
+  color: var(--sbx-error, #dc2626);
+  font-weight: 600;
 }
 
 // ── Icon-only buttons (Collaborators, Upload CSV) ────────────────────────────

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.module.scss
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.module.scss
@@ -1,0 +1,294 @@
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--sbx-topbar-h, 60px);
+  padding: 0 20px;
+  background: white;
+  border-bottom: 1px solid var(--sbx-gray-200);
+  box-shadow: var(--sbx-shadow-1);
+  flex-shrink: 0;
+  gap: 16px;
+  z-index: 10;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  flex: 1;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.backBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--sbx-r-sm);
+  border: 1.5px solid var(--sbx-gray-200);
+  background: white;
+  cursor: pointer;
+  color: var(--sbx-gray-600);
+  flex-shrink: 0;
+  transition: border-color 0.15s, color 0.15s;
+
+  &:hover {
+    border-color: var(--sbx-primary);
+    color: var(--sbx-primary);
+  }
+}
+
+.title {
+  font-family: var(--sbx-font);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--sbx-gray-900);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 300px;
+}
+
+.statusChip {
+  font-size: 12px;
+  font-family: var(--sbx-font);
+  flex-shrink: 0;
+  padding: 2px 10px;
+  border-radius: var(--sbx-r-xl);
+  border: 1.5px solid var(--sbx-gray-300);
+  color: var(--sbx-gray-600);
+  background: var(--sbx-gray-50);
+  font-weight: 500;
+}
+
+.savedIndicator {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--sbx-font);
+  font-size: 12px;
+  color: var(--sbx-gray-500);
+  white-space: nowrap;
+}
+
+.unsaved {
+  color: var(--sbx-warning);
+}
+
+// ── Icon-only buttons (Collaborators, Upload CSV) ────────────────────────────
+
+.iconBtn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: var(--sbx-r-sm);
+  border: 1.5px solid var(--sbx-gray-200);
+  background: white;
+  cursor: pointer;
+  color: var(--sbx-gray-600);
+  font-family: var(--sbx-font);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+
+  &:hover {
+    border-color: var(--sbx-primary);
+    color: var(--sbx-primary);
+    background: var(--sbx-primary-50, #EFF6FF);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--sbx-primary);
+    outline-offset: 2px;
+  }
+}
+
+.iconBtnLabel {
+  // Hide on very narrow viewports if needed; keep visible by default
+  display: inline;
+}
+
+// ── QR dropdown ──────────────────────────────────────────────────────────────
+
+.qrDropdown {
+  position: relative;
+}
+
+.qrMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: white;
+  border: 1.5px solid var(--sbx-gray-200);
+  border-radius: var(--sbx-r-md, 8px);
+  box-shadow: var(--sbx-shadow-2, 0 4px 16px rgba(0,0,0,0.12));
+  min-width: 190px;
+  z-index: 200;
+  overflow: hidden;
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 14px;
+    border: none;
+    background: none;
+    font-family: var(--sbx-font);
+    font-size: 13px;
+    color: var(--sbx-gray-700);
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.12s;
+
+    &:hover:not(:disabled) { background: var(--sbx-gray-50); }
+    &:disabled { opacity: 0.45; cursor: not-allowed; }
+  }
+}
+
+// ── Review mode button group ─────────────────────────────────────────────────
+
+.reviewBtns {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 8px;
+  border-left: 1px solid var(--sbx-gray-200);
+  margin-left: 4px;
+}
+
+// ── Sourcing-review mode button group ────────────────────────────────────────
+
+.sourcingBtns {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 8px;
+  border-left: 1px solid var(--sbx-gray-200);
+  margin-left: 4px;
+}
+
+// ── Modal overlay backdrop ────────────────────────────────────────────────────
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+// ── Inline SendBack modal ─────────────────────────────────────────────────────
+
+.sbOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.sbModal {
+  background: white;
+  border-radius: var(--sbx-r-md, 8px);
+  box-shadow: var(--sbx-shadow-3, 0 8px 32px rgba(0, 0, 0, 0.18));
+  width: 480px;
+  max-width: calc(100vw - 32px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sbModalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--sbx-gray-200);
+}
+
+.sbModalTitle {
+  font-family: var(--sbx-font);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--sbx-gray-900);
+}
+
+.sbModalClose {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--sbx-gray-500);
+  padding: 0 4px;
+
+  &:hover {
+    color: var(--sbx-gray-900);
+  }
+}
+
+.sbModalBody {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sbLabel {
+  font-family: var(--sbx-font);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--sbx-gray-700);
+}
+
+.sbTextarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--sbx-font);
+  font-size: 13px;
+  color: var(--sbx-gray-900);
+  border: 1.5px solid var(--sbx-gray-300);
+  border-radius: var(--sbx-r-sm, 6px);
+  padding: 10px 12px;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s;
+
+  &:focus {
+    border-color: var(--sbx-primary);
+  }
+}
+
+.sbError {
+  font-family: var(--sbx-font);
+  font-size: 12px;
+  color: var(--sbx-error, #DC2626);
+  margin: 0;
+}
+
+.sbModalFooter {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--sbx-gray-200);
+}

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -187,7 +187,7 @@ interface GenerateQRModalProps {
 const GenerateQRModal: React.FC<GenerateQRModalProps> = ({ onConfirm, onCancel }) => {
   const [count, setCount] = useState('');
   const numCount = parseInt(count, 10);
-  const isValid = !isNaN(numCount) && numCount >= 1 && numCount <= 250;
+  const isValid = !isNaN(numCount) && numCount >= 2 && numCount <= 250;
 
   return (
     <div className={styles.sbOverlay} role="dialog" aria-modal="true" aria-labelledby="genqr-title">
@@ -205,16 +205,16 @@ const GenerateQRModal: React.FC<GenerateQRModalProps> = ({ onConfirm, onCancel }
           <input
             id="qr-count"
             type="number"
-            min={1}
+            min={2}
             max={250}
             className={styles.sbTextarea}
             style={{ resize: 'none', height: '40px' }}
-            placeholder="Enter number (1–250)"
+            placeholder="Enter number (2–250)"
             value={count}
             onChange={(e) => setCount(e.target.value)}
           />
           {count && !isValid && (
-            <p className={styles.sbError}>Enter a number between 1 and 250.</p>
+            <p className={styles.sbError}>Enter a number between 2 and 250.</p>
           )}
         </div>
         <div className={styles.sbModalFooter}>
@@ -281,9 +281,9 @@ export const Topbar: React.FC<TopbarProps> = ({
     setShowGenerateQR(false);
     setIsGeneratingQR(true);
     try {
-      const processId = await reserveDialcodes(contentId, count);
+      const { processId, reservedDialcodes } = await reserveDialcodes(contentId, count);
       if (processId && rootNode) {
-        updateNode(rootNode.id, { qrCodeProcessId: processId });
+        updateNode(rootNode.id, { qrCodeProcessId: processId, reservedDialcodes });
       }
       toast.success('QR Codes generation started. Use "Download QR Codes" once ready.');
     } catch {
@@ -294,31 +294,66 @@ export const Topbar: React.FC<TopbarProps> = ({
   }, [contentId, rootNode, updateNode]);
 
   const handleDownloadQR = useCallback(async () => {
+    // Metadata guard — mirrors Angular requirement
+    const meta = rootNode?.metadata ?? {};
+    if (!meta['medium'] || !meta['gradeLevel'] || !meta['subject']) {
+      toast.error('Please ensure Medium, Class and Subject are set before downloading QR Codes.');
+      return;
+    }
+
     if (!qrCodeProcessId) {
       toast.error('No QR codes generated yet. Generate QR Codes first.');
       return;
     }
+
     setIsDownloadingQR(true);
     try {
       const result = await getDialcodeProcessStatus(qrCodeProcessId);
-      const zipUrl = result.zipFileName;
-      if (zipUrl) {
-        const a = document.createElement('a');
-        a.href = zipUrl;
-        a.download = 'qrcodes.zip';
-        a.target = '_blank';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-      } else {
-        toast.error('QR Codes not ready yet. Please wait and try again.');
+
+      if (result.status === 'in-process') {
+        toast('QR code image generation is in progress. Please try downloading after some time.', { icon: 'ℹ️' });
+        return;
       }
+
+      const cloudUrl = result.url;
+      if (!cloudUrl) {
+        toast.error('QR Codes not ready yet. Please wait and try again.');
+        return;
+      }
+
+      // Blob-convert so the browser always triggers a local file download
+      // regardless of the cloud storage server's Content-Disposition header.
+      const blob = await fetch(cloudUrl).then(r => r.blob());
+      const dataUrl = await new Promise<string>((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.readAsDataURL(blob);
+      });
+
+      // Dynamic filename matching Angular convention
+      const toStr = (v: unknown) =>
+        Array.isArray(v) ? v.join('_') : typeof v === 'string' ? v : '';
+      const medium  = toStr(meta['medium']);
+      const grade   = toStr(meta['gradeLevel']);
+      const subject = toStr(meta['subject']);
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const filename = `${contentId}_${medium}_${grade}_${subject}_${ts}.zip`;
+
+      const a = document.createElement('a');
+      a.href = dataUrl;
+      a.download = filename;
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+
+      toast.success('QR codes downloaded.');
     } catch {
       toast.error('Failed to download QR Codes.');
     } finally {
       setIsDownloadingQR(false);
     }
-  }, [qrCodeProcessId]);
+  }, [qrCodeProcessId, rootNode, contentId]);
 
   const isEditMode = editorMode === 'edit';
   const isReviewMode = editorMode === 'review';

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -431,8 +431,9 @@ export const Topbar: React.FC<TopbarProps> = ({
             <span className={styles.savedIndicator} aria-live="polite">
               Saving&hellip;
             </span>
-          ) : isDirty ? (
+          ) : isDirty && isEditMode ? (
             // Dirty takes precedence over a prior "Saved" — no auto-save anymore.
+            // View modes (review/read) never show "Unsaved".
             <span
               className={`${styles.savedIndicator} ${styles.unsaved}`}
               aria-live="polite"

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -1,0 +1,498 @@
+import React, { useCallback, useState, useRef, useEffect } from 'react';
+import {
+  ArrowLeft,
+  Send,
+  Check,
+  Users,
+  CheckCircle,
+  XCircle,
+  RotateCcw,
+  Shield,
+  QrCode,
+  Download,
+} from 'lucide-react';
+import type { EditorMode, ToolbarAction } from '../../types/editor';
+import { useTreeStore } from '../../store/tree.store';
+import { useEditorStore } from '../../store/editor.store';
+import { useUiStore } from '../../store/ui.store';
+import { Button } from '../shared/Button';
+import { PublishChecklist } from '../modals/PublishChecklist';
+import { QualityParamsModal } from '../modals/QualityParamsModal';
+import { ManageCollaborators } from '../Collaborators/ManageCollaborators';
+import { reserveDialcodes, getDialcodeProcessStatus } from '../../api/dialcode';
+import toast from 'react-hot-toast';
+import styles from './Topbar.module.scss';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+interface TopbarProps {
+  editorMode: EditorMode;
+  isSaving: boolean;
+  isDirty: boolean;
+  lastSaved: string | null;
+  onToolbarEvent: (event: { action: ToolbarAction; data?: unknown }) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function formatLastSaved(ts: string | null): string {
+  if (!ts) return '';
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function deriveStatusLabel(status: unknown): string {
+  if (typeof status === 'string' && status.trim().length > 0) {
+    return status.trim();
+  }
+  return 'Draft';
+}
+
+// ---------------------------------------------------------------------------
+// SendBack confirm modal (inline, lightweight)
+// ---------------------------------------------------------------------------
+interface SendBackModalProps {
+  onConfirm: (comment: string) => void;
+  onCancel: () => void;
+}
+
+const SendBackModal: React.FC<SendBackModalProps> = ({ onConfirm, onCancel }) => {
+  const [comment, setComment] = useState('');
+
+  return (
+    <div className={styles.sbOverlay} role="dialog" aria-modal="true" aria-labelledby="sendback-title">
+      <div className={styles.sbModal}>
+        <div className={styles.sbModalHeader}>
+          <span id="sendback-title" className={styles.sbModalTitle}>Send Back for Corrections</span>
+          <button className={styles.sbModalClose} onClick={onCancel} aria-label="Close" type="button">
+            ×
+          </button>
+        </div>
+        <div className={styles.sbModalBody}>
+          <label className={styles.sbLabel} htmlFor="sendback-comment">
+            Comment <span aria-hidden="true" style={{ color: 'var(--sbx-error, #DC2626)' }}>*</span>
+          </label>
+          <textarea
+            id="sendback-comment"
+            className={styles.sbTextarea}
+            placeholder="Describe what needs to be corrected…"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            rows={4}
+            required
+            aria-required="true"
+          />
+          {comment.trim().length === 0 && (
+            <p className={styles.sbError}>A comment is required.</p>
+          )}
+        </div>
+        <div className={styles.sbModalFooter}>
+          <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+          <Button
+            variant="primary"
+            onClick={() => onConfirm(comment.trim())}
+            disabled={comment.trim().length === 0}
+          >
+            Send Back
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Generate QR Codes modal (inline)
+// ---------------------------------------------------------------------------
+interface GenerateQRModalProps {
+  onConfirm: (count: number) => void;
+  onCancel: () => void;
+}
+
+const GenerateQRModal: React.FC<GenerateQRModalProps> = ({ onConfirm, onCancel }) => {
+  const [count, setCount] = useState('');
+  const numCount = parseInt(count, 10);
+  const isValid = !isNaN(numCount) && numCount >= 1 && numCount <= 250;
+
+  return (
+    <div className={styles.sbOverlay} role="dialog" aria-modal="true" aria-labelledby="genqr-title">
+      <div className={styles.sbModal}>
+        <div className={styles.sbModalHeader}>
+          <span id="genqr-title" className={styles.sbModalTitle}>Generate QR Codes</span>
+          <button className={styles.sbModalClose} onClick={onCancel} aria-label="Close" type="button">
+            ×
+          </button>
+        </div>
+        <div className={styles.sbModalBody}>
+          <label className={styles.sbLabel} htmlFor="qr-count">
+            Number of QR Codes <span aria-hidden="true" style={{ color: 'var(--sbx-error, #DC2626)' }}>*</span>
+          </label>
+          <input
+            id="qr-count"
+            type="number"
+            min={1}
+            max={250}
+            className={styles.sbTextarea}
+            style={{ resize: 'none', height: '40px' }}
+            placeholder="Enter number (1–250)"
+            value={count}
+            onChange={(e) => setCount(e.target.value)}
+          />
+          {count && !isValid && (
+            <p className={styles.sbError}>Enter a number between 1 and 250.</p>
+          )}
+        </div>
+        <div className={styles.sbModalFooter}>
+          <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+          <Button variant="primary" onClick={() => onConfirm(numCount)} disabled={!isValid}>
+            Generate
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+export const Topbar: React.FC<TopbarProps> = ({
+  editorMode,
+  isSaving,
+  isDirty,
+  lastSaved,
+  onToolbarEvent,
+}) => {
+  const treeData = useTreeStore((s) => s.treeData);
+  const rootNode = treeData[0];
+  const title = rootNode?.name ?? 'Untitled';
+  const statusLabel = deriveStatusLabel(rootNode?.metadata?.status ?? rootNode?.status);
+
+  const contentId = useEditorStore(
+    (s) =>
+      s.editorConfig?.context?.contentId ??
+      s.editorConfig?.context?.identifier ??
+      '',
+  );
+
+  const { activeModal, modalData, closeModal, openModal } = useUiStore();
+
+  // Local state for the send-back modal (not stored in ui.store)
+  const [showSendBack, setShowSendBack] = useState(false);
+  const [showQRMenu, setShowQRMenu] = useState(false);
+  const qrMenuRef = useRef<HTMLDivElement>(null);
+  const [showGenerateQR, setShowGenerateQR] = useState(false);
+
+  useEffect(() => {
+    if (!showQRMenu) return;
+    const handler = (e: MouseEvent) => {
+      if (!qrMenuRef.current?.contains(e.target as Node)) setShowQRMenu(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showQRMenu]);
+  const [isGeneratingQR, setIsGeneratingQR] = useState(false);
+  const [isDownloadingQR, setIsDownloadingQR] = useState(false);
+
+  const { updateNode } = useTreeStore();
+  const qrCodeProcessId = rootNode?.metadata?.qrCodeProcessId as string | undefined;
+
+  const handleGenerateQR = useCallback(async (count: number) => {
+    if (!contentId) return;
+    setShowGenerateQR(false);
+    setIsGeneratingQR(true);
+    try {
+      const processId = await reserveDialcodes(contentId, count);
+      if (processId && rootNode) {
+        updateNode(rootNode.id, { qrCodeProcessId: processId });
+      }
+      toast.success('QR Codes generation started. Use "Download QR Codes" once ready.');
+    } catch {
+      toast.error('Failed to generate QR Codes. Please try again.');
+    } finally {
+      setIsGeneratingQR(false);
+    }
+  }, [contentId, rootNode, updateNode]);
+
+  const handleDownloadQR = useCallback(async () => {
+    if (!qrCodeProcessId) {
+      toast.error('No QR codes generated yet. Generate QR Codes first.');
+      return;
+    }
+    setIsDownloadingQR(true);
+    try {
+      const result = await getDialcodeProcessStatus(qrCodeProcessId);
+      const zipUrl = result.zipFileName;
+      if (zipUrl) {
+        const a = document.createElement('a');
+        a.href = zipUrl;
+        a.download = 'qrcodes.zip';
+        a.target = '_blank';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      } else {
+        toast.error('QR Codes not ready yet. Please wait and try again.');
+      }
+    } catch {
+      toast.error('Failed to download QR Codes.');
+    } finally {
+      setIsDownloadingQR(false);
+    }
+  }, [qrCodeProcessId]);
+
+  const isEditMode = editorMode === 'edit';
+  const isReviewMode = editorMode === 'review';
+  const isSourcingReviewMode = editorMode === 'sourcingreview';
+  const isReadOnly = editorMode === 'read';
+
+  const emit = useCallback(
+    (action: ToolbarAction, data?: unknown) => {
+      onToolbarEvent({ action, data });
+    },
+    [onToolbarEvent],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Modal handlers
+  // ---------------------------------------------------------------------------
+  const handlePublishConfirm = useCallback(() => {
+    closeModal();
+    emit('publish');
+  }, [closeModal, emit]);
+
+  const handleQualityConfirm = useCallback(
+    (comment: string, score?: number) => {
+      const action = modalData?.action as 'approve' | 'reject' | undefined;
+      closeModal();
+      if (action === 'approve') {
+        emit('sourcingApprove', { comment, score });
+      } else {
+        emit('reject', { comment });
+      }
+    },
+    [closeModal, emit, modalData],
+  );
+
+  const handleSendBack = useCallback(
+    (comment: string) => {
+      setShowSendBack(false);
+      emit('sendBackForCorrections', { comment });
+    },
+    [emit],
+  );
+
+  return (
+    <>
+      <header className={styles.topbar} role="banner">
+        {/* ── Left: Back + Title + Status ─────────────────────── */}
+        <div className={styles.left}>
+          <button
+            className={styles.backBtn}
+            onClick={() => emit('back')}
+            aria-label="Go back"
+            type="button"
+          >
+            <ArrowLeft size={18} />
+          </button>
+
+          <h1 className={styles.title} title={title}>
+            {title}
+          </h1>
+
+          <span className={`sbx-chip ${styles.statusChip}`} aria-label={`Status: ${statusLabel}`}>
+            {statusLabel}
+          </span>
+        </div>
+
+        {/* ── Right: Save indicator + actions ──────────────────── */}
+        <div className={styles.right}>
+          {/* Autosave / dirty indicator */}
+          {isSaving ? (
+            <span className={styles.savedIndicator} aria-live="polite">
+              Saving&hellip;
+            </span>
+          ) : lastSaved ? (
+            <span className={styles.savedIndicator} aria-live="polite">
+              <Check size={14} aria-hidden="true" />
+              Saved {formatLastSaved(lastSaved)}
+            </span>
+          ) : isDirty ? (
+            <span
+              className={`${styles.savedIndicator} ${styles.unsaved}`}
+              aria-live="polite"
+            >
+              Unsaved changes
+            </span>
+          ) : null}
+
+          {/* Save as Draft button (hidden in read-only) */}
+          {!isReadOnly && (
+            <Button variant="ghost" size="sm" onClick={() => emit('saveCollection')}>
+              Save as Draft
+            </Button>
+          )}
+
+          {/* ── edit mode ─────────────────────────────────────── */}
+          {isEditMode && (
+            <>
+              <Button variant="primary" size="sm" onClick={() => emit('sendForReview')}>
+                <Send size={14} aria-hidden="true" />
+                &nbsp;Send for review
+              </Button>
+
+              {/* Collaborators — icon only with tooltip */}
+              <button
+                className={styles.iconBtn}
+                onClick={() => openModal('manageCollaborators')}
+                aria-label="Collaborators"
+                title="Collaborators"
+                type="button"
+              >
+                <Users size={16} aria-hidden="true" />
+              </button>
+
+              {/* QR Codes dropdown */}
+              <div className={styles.qrDropdown} ref={qrMenuRef}>
+                <button
+                  className={styles.iconBtn}
+                  onClick={() => setShowQRMenu(v => !v)}
+                  aria-label="QR Codes"
+                  title="QR Codes"
+                  type="button"
+                  aria-haspopup="true"
+                  aria-expanded={showQRMenu}
+                >
+                  <QrCode size={16} aria-hidden="true" />
+                  <span className={styles.iconBtnLabel}>QR Codes</span>
+                  <span style={{ fontSize: 10, marginLeft: 2 }}>▾</span>
+                </button>
+                {showQRMenu && (
+                  <div className={styles.qrMenu} role="menu">
+                    <button
+                      role="menuitem"
+                      type="button"
+                      onClick={() => { setShowQRMenu(false); setShowGenerateQR(true); }}
+                      disabled={isGeneratingQR}
+                    >
+                      <QrCode size={14} />
+                      {isGeneratingQR ? 'Generating…' : 'Generate QR Codes'}
+                    </button>
+                    <button
+                      role="menuitem"
+                      type="button"
+                      onClick={() => { setShowQRMenu(false); handleDownloadQR(); }}
+                      disabled={isDownloadingQR || !qrCodeProcessId}
+                    >
+                      <Download size={14} />
+                      {isDownloadingQR ? 'Downloading…' : 'Download QR Codes'}
+                    </button>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* ── review mode ───────────────────────────────────── */}
+          {isReviewMode && (
+            <div className={styles.reviewBtns}>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => openModal('publishChecklist')}
+              >
+                <CheckCircle size={14} aria-hidden="true" />
+                &nbsp;Publish
+              </Button>
+
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => openModal('qualityParams', { action: 'reject' })}
+              >
+                <XCircle size={14} aria-hidden="true" />
+                &nbsp;Reject
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowSendBack(true)}
+              >
+                <RotateCcw size={14} aria-hidden="true" />
+                &nbsp;Send Back
+              </Button>
+            </div>
+          )}
+
+          {/* ── sourcingreview mode ───────────────────────────── */}
+          {isSourcingReviewMode && (
+            <div className={styles.sourcingBtns}>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => openModal('qualityParams', { action: 'approve' })}
+              >
+                <Shield size={14} aria-hidden="true" />
+                &nbsp;Approve
+              </Button>
+
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => openModal('qualityParams', { action: 'reject' })}
+              >
+                <XCircle size={14} aria-hidden="true" />
+                &nbsp;Reject
+              </Button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      {/* ── Modals ──────────────────────────────────────────────── */}
+
+      {activeModal === 'publishChecklist' && (
+        <PublishChecklist
+          contentId={contentId}
+          onConfirm={handlePublishConfirm}
+          onCancel={closeModal}
+        />
+      )}
+
+      {activeModal === 'qualityParams' && (
+        <QualityParamsModal
+          contentId={contentId}
+          action={(modalData?.action as 'approve' | 'reject') ?? 'reject'}
+          onConfirm={handleQualityConfirm}
+          onCancel={closeModal}
+        />
+      )}
+
+      {activeModal === 'manageCollaborators' && (
+        <div className={styles.modalOverlay} role="dialog" aria-modal="true">
+          <ManageCollaborators
+            contentId={contentId}
+            onClose={closeModal}
+          />
+        </div>
+      )}
+
+      {showSendBack && (
+        <SendBackModal
+          onConfirm={handleSendBack}
+          onCancel={() => setShowSendBack(false)}
+        />
+      )}
+
+      {showGenerateQR && (
+        <GenerateQRModal
+          onConfirm={handleGenerateQR}
+          onCancel={() => setShowGenerateQR(false)}
+        />
+      )}
+    </>
+  );
+};

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -119,17 +119,13 @@ const ConfirmReviewModal: React.FC<ConfirmReviewModalProps> = ({ onConfirm, onCa
     <div className={styles.sbOverlay} role="dialog" aria-modal="true" aria-labelledby="review-confirm-title">
       <div className={styles.sbModal}>
         <div className={styles.sbModalHeader}>
-          <span id="review-confirm-title" className={styles.sbModalTitle}>Send for Review</span>
+          <span id="review-confirm-title" className={styles.sbModalTitle}>Accepting Terms &amp; Conditions</span>
           <button className={styles.sbModalClose} onClick={onCancel} aria-label="Close" type="button">
             ×
           </button>
         </div>
         <div className={styles.sbModalBody}>
-          <p style={{ fontSize: 13, color: 'var(--sbx-gray-600, #4B5563)', lineHeight: 1.5, margin: 0 }}>
-            Once sent for review, this content will be locked for editing until the
-            review is complete. Please ensure all units and content are finalised.
-          </p>
-          <label style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginTop: 14, fontSize: 13 }}>
+          <label style={{ display: 'flex', gap: 8, alignItems: 'flex-start', fontSize: 13, lineHeight: 1.55 }}>
             <input
               type="checkbox"
               checked={agreed}
@@ -137,14 +133,27 @@ const ConfirmReviewModal: React.FC<ConfirmReviewModalProps> = ({ onConfirm, onCa
               style={{ marginTop: 2 }}
             />
             <span>
-              I confirm this content adheres to the content policy and is ready for review.
+              I agree that by submitting / publishing this Content, I confirm that this
+              Content complies with prescribed guidelines, including the Terms of Use and
+              Content Policy and that I consent to publish it under the{' '}
+              <a
+                className="sb-color-primary"
+                style={{ fontWeight: 600 }}
+                href="https://creativecommons.org/licenses"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Creative Commons Framework
+              </a>{' '}
+              in accordance with the <strong>Content Policy</strong>. I have made sure that
+              I do not violate others&rsquo; copyright or privacy rights.
             </span>
           </label>
         </div>
         <div className={styles.sbModalFooter}>
           <Button variant="ghost" onClick={onCancel}>Cancel</Button>
           <Button variant="primary" onClick={onConfirm} disabled={!agreed}>
-            Send for review
+            Submit
           </Button>
         </div>
       </div>
@@ -366,17 +375,18 @@ export const Topbar: React.FC<TopbarProps> = ({
             <span className={styles.savedIndicator} aria-live="polite">
               Saving&hellip;
             </span>
-          ) : lastSaved ? (
-            <span className={styles.savedIndicator} aria-live="polite">
-              <Check size={14} aria-hidden="true" />
-              Saved {formatLastSaved(lastSaved)}
-            </span>
           ) : isDirty ? (
+            // Dirty takes precedence over a prior "Saved" — no auto-save anymore.
             <span
               className={`${styles.savedIndicator} ${styles.unsaved}`}
               aria-live="polite"
             >
-              Unsaved changes
+              Unsaved
+            </span>
+          ) : lastSaved ? (
+            <span className={styles.savedIndicator} aria-live="polite">
+              <Check size={14} aria-hidden="true" />
+              Saved {formatLastSaved(lastSaved)}
             </span>
           ) : null}
 

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -51,33 +51,48 @@ function deriveStatusLabel(status: unknown): string {
 }
 
 // ---------------------------------------------------------------------------
-// SendBack confirm modal (inline, lightweight)
+// Generic review-comment modal — used for both Reject and Send Back.
+// Matches the Angular "Add Review Comments" popup text.
 // ---------------------------------------------------------------------------
-interface SendBackModalProps {
+interface ReviewCommentModalProps {
+  titleText: string;
+  labelText: string;
+  placeholderText: string;
+  submitLabel: string;
+  submitVariant?: 'primary' | 'danger';
   onConfirm: (comment: string) => void;
   onCancel: () => void;
 }
 
-const SendBackModal: React.FC<SendBackModalProps> = ({ onConfirm, onCancel }) => {
+const ReviewCommentModal: React.FC<ReviewCommentModalProps> = ({
+  titleText,
+  labelText,
+  placeholderText,
+  submitLabel,
+  submitVariant = 'primary',
+  onConfirm,
+  onCancel,
+}) => {
   const [comment, setComment] = useState('');
+  const modalId = titleText.toLowerCase().replace(/\s+/g, '-');
 
   return (
-    <div className={styles.sbOverlay} role="dialog" aria-modal="true" aria-labelledby="sendback-title">
+    <div className={styles.sbOverlay} role="dialog" aria-modal="true" aria-labelledby={`${modalId}-title`}>
       <div className={styles.sbModal}>
         <div className={styles.sbModalHeader}>
-          <span id="sendback-title" className={styles.sbModalTitle}>Send Back for Corrections</span>
+          <span id={`${modalId}-title`} className={styles.sbModalTitle}>{titleText}</span>
           <button className={styles.sbModalClose} onClick={onCancel} aria-label="Close" type="button">
             ×
           </button>
         </div>
         <div className={styles.sbModalBody}>
-          <label className={styles.sbLabel} htmlFor="sendback-comment">
-            Comment <span aria-hidden="true" style={{ color: 'var(--sbx-error, #DC2626)' }}>*</span>
+          <label className={styles.sbLabel} htmlFor={`${modalId}-comment`}>
+            {labelText} <span aria-hidden="true" style={{ color: 'var(--sbx-error, #DC2626)' }}>*</span>
           </label>
           <textarea
-            id="sendback-comment"
+            id={`${modalId}-comment`}
             className={styles.sbTextarea}
-            placeholder="Describe what needs to be corrected…"
+            placeholder={placeholderText}
             value={comment}
             onChange={(e) => setComment(e.target.value)}
             rows={4}
@@ -85,17 +100,17 @@ const SendBackModal: React.FC<SendBackModalProps> = ({ onConfirm, onCancel }) =>
             aria-required="true"
           />
           {comment.trim().length === 0 && (
-            <p className={styles.sbError}>A comment is required.</p>
+            <p className={styles.sbError}>Fill comments</p>
           )}
         </div>
         <div className={styles.sbModalFooter}>
           <Button variant="ghost" onClick={onCancel}>Cancel</Button>
           <Button
-            variant="primary"
+            variant={submitVariant}
             onClick={() => onConfirm(comment.trim())}
             disabled={comment.trim().length === 0}
           >
-            Send Back
+            {submitLabel}
           </Button>
         </div>
       </div>
@@ -241,6 +256,7 @@ export const Topbar: React.FC<TopbarProps> = ({
 
   // Local state for the send-back modal (not stored in ui.store)
   const [showSendBack, setShowSendBack] = useState(false);
+  const [showRejectModal, setShowRejectModal] = useState(false);
   const [showConfirmReview, setShowConfirmReview] = useState(false);
   const [showQRMenu, setShowQRMenu] = useState(false);
   const qrMenuRef = useRef<HTMLDivElement>(null);
@@ -481,7 +497,7 @@ export const Topbar: React.FC<TopbarProps> = ({
               <Button
                 variant="danger"
                 size="sm"
-                onClick={() => openModal('qualityParams', { action: 'reject' })}
+                onClick={() => setShowRejectModal(true)}
                 disabled={buttonLoaders.rejectCollection}
                 isLoading={buttonLoaders.rejectCollection}
               >
@@ -560,8 +576,24 @@ export const Topbar: React.FC<TopbarProps> = ({
         />
       )}
 
+      {showRejectModal && (
+        <ReviewCommentModal
+          titleText="Add Review Comments"
+          labelText="Enter your comments"
+          placeholderText="Add comment"
+          submitLabel="Submit Review"
+          submitVariant="danger"
+          onConfirm={(comment) => { setShowRejectModal(false); emit('reject', { comment }); }}
+          onCancel={() => setShowRejectModal(false)}
+        />
+      )}
+
       {showSendBack && (
-        <SendBackModal
+        <ReviewCommentModal
+          titleText="Add Review Comments"
+          labelText="Enter your comments"
+          placeholderText="Add comment"
+          submitLabel="Submit Review"
           onConfirm={handleSendBack}
           onCancel={() => setShowSendBack(false)}
         />

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -254,6 +254,12 @@ export const Topbar: React.FC<TopbarProps> = ({
 
   const buttonLoaders = useEditorStore((s) => s.buttonLoaders);
 
+  // Category definition controls optional toolbar features.
+  // generateDIALCodes default "Yes" means QR codes are enabled for this content type.
+  // Default to showing if the API hasn't loaded yet (backward compat).
+  const categoryMeta = useEditorStore((s) => s.categoryMeta);
+  const showDialcode = !categoryMeta || categoryMeta.schemaDefaults.generateDIALCodes !== 'No';
+
   // Local state for the send-back modal (not stored in ui.store)
   const [showSendBack, setShowSendBack] = useState(false);
   const [showRejectModal, setShowRejectModal] = useState(false);
@@ -471,8 +477,8 @@ export const Topbar: React.FC<TopbarProps> = ({
                 <Users size={16} aria-hidden="true" />
               </button>
 
-              {/* QR Codes dropdown */}
-              <div className={styles.qrDropdown} ref={qrMenuRef}>
+              {/* QR Codes dropdown — hidden when generateDIALCodes is "No" for this category */}
+              {showDialcode && <div className={styles.qrDropdown} ref={qrMenuRef}>
                 <button
                   className={styles.iconBtn}
                   onClick={() => setShowQRMenu(v => !v)}
@@ -508,7 +514,7 @@ export const Topbar: React.FC<TopbarProps> = ({
                     </button>
                   </div>
                 )}
-              </div>
+              </div>}
             </>
           )}
 

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -31,6 +31,7 @@ interface TopbarProps {
   isSaving: boolean;
   isDirty: boolean;
   lastSaved: string | null;
+  isFormValid?: boolean;
   onToolbarEvent: (event: { action: ToolbarAction; data?: unknown }) => void;
 }
 
@@ -236,6 +237,7 @@ export const Topbar: React.FC<TopbarProps> = ({
   isSaving,
   isDirty,
   lastSaved,
+  isFormValid = true,
   onToolbarEvent,
 }) => {
   const treeData = useTreeStore((s) => s.treeData);
@@ -447,9 +449,16 @@ export const Topbar: React.FC<TopbarProps> = ({
           {/* Save as Draft — author action only. Hidden in read-only and for
               content under review (review / sourcing modes or Review status). */}
           {!isReadOnly && !isReviewMode && !isSourcingReviewMode && statusLabel !== 'Review' && (
-            <Button variant="ghost" size="sm" onClick={() => emit('saveCollection')}>
-              Save as Draft
-            </Button>
+            <span title={!isFormValid ? 'Fill all required fields before saving' : undefined}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => emit('saveCollection')}
+                disabled={!isFormValid}
+              >
+                Save as Draft
+              </Button>
+            </span>
           )}
 
           {/* ── edit mode ─────────────────────────────────────── */}
@@ -616,10 +625,10 @@ export const Topbar: React.FC<TopbarProps> = ({
 
       {showRejectModal && (
         <ReviewCommentModal
-          titleText="Add Review Comments"
-          labelText="Enter your comments"
-          placeholderText="Add comment"
-          submitLabel="Submit Review"
+          titleText="Reject Content"
+          labelText="Reason for rejection"
+          placeholderText="Explain why this content is being rejected"
+          submitLabel="Reject"
           submitVariant="danger"
           onConfirm={(comment) => { setShowRejectModal(false); emit('reject', { comment }); }}
           onCancel={() => setShowRejectModal(false)}
@@ -628,10 +637,11 @@ export const Topbar: React.FC<TopbarProps> = ({
 
       {showSendBack && (
         <ReviewCommentModal
-          titleText="Add Review Comments"
-          labelText="Enter your comments"
-          placeholderText="Add comment"
-          submitLabel="Submit Review"
+          titleText="Send Back for Corrections"
+          labelText="Corrections needed"
+          placeholderText="Describe the corrections the author needs to make"
+          submitLabel="Send Back"
+          submitVariant="primary"
           onConfirm={handleSendBack}
           onCancel={() => setShowSendBack(false)}
         />

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -294,13 +294,6 @@ export const Topbar: React.FC<TopbarProps> = ({
   }, [contentId, rootNode, updateNode]);
 
   const handleDownloadQR = useCallback(async () => {
-    // Metadata guard — mirrors Angular requirement
-    const meta = rootNode?.metadata ?? {};
-    if (!meta['medium'] || !meta['gradeLevel'] || !meta['subject']) {
-      toast.error('Please ensure Medium, Class and Subject are set before downloading QR Codes.');
-      return;
-    }
-
     if (!qrCodeProcessId) {
       toast.error('No QR codes generated yet. Generate QR Codes first.');
       return;
@@ -330,14 +323,18 @@ export const Topbar: React.FC<TopbarProps> = ({
         reader.readAsDataURL(blob);
       });
 
-      // Dynamic filename matching Angular convention
+      // Build filename — metadata fields are optional, omit empty segments
+      const meta = rootNode?.metadata ?? {};
       const toStr = (v: unknown) =>
         Array.isArray(v) ? v.join('_') : typeof v === 'string' ? v : '';
-      const medium  = toStr(meta['medium']);
-      const grade   = toStr(meta['gradeLevel']);
-      const subject = toStr(meta['subject']);
+      const parts = [
+        contentId,
+        toStr(meta['medium']),
+        toStr(meta['gradeLevel']),
+        toStr(meta['subject']),
+      ].filter(Boolean);
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
-      const filename = `${contentId}_${medium}_${grade}_${subject}_${ts}.zip`;
+      const filename = `${parts.join('_')}_${ts}.zip`;
 
       const a = document.createElement('a');
       a.href = dataUrl;

--- a/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/collection-editor-react/src/components/Topbar/Topbar.tsx
@@ -104,6 +104,55 @@ const SendBackModal: React.FC<SendBackModalProps> = ({ onConfirm, onCancel }) =>
 };
 
 // ---------------------------------------------------------------------------
+// Send-for-Review confirmation modal (inline)
+// Mirrors Angular's "Accept Terms & Conditions" confirm before submitting.
+// ---------------------------------------------------------------------------
+interface ConfirmReviewModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmReviewModal: React.FC<ConfirmReviewModalProps> = ({ onConfirm, onCancel }) => {
+  const [agreed, setAgreed] = useState(false);
+
+  return (
+    <div className={styles.sbOverlay} role="dialog" aria-modal="true" aria-labelledby="review-confirm-title">
+      <div className={styles.sbModal}>
+        <div className={styles.sbModalHeader}>
+          <span id="review-confirm-title" className={styles.sbModalTitle}>Send for Review</span>
+          <button className={styles.sbModalClose} onClick={onCancel} aria-label="Close" type="button">
+            ×
+          </button>
+        </div>
+        <div className={styles.sbModalBody}>
+          <p style={{ fontSize: 13, color: 'var(--sbx-gray-600, #4B5563)', lineHeight: 1.5, margin: 0 }}>
+            Once sent for review, this content will be locked for editing until the
+            review is complete. Please ensure all units and content are finalised.
+          </p>
+          <label style={{ display: 'flex', gap: 8, alignItems: 'flex-start', marginTop: 14, fontSize: 13 }}>
+            <input
+              type="checkbox"
+              checked={agreed}
+              onChange={(e) => setAgreed(e.target.checked)}
+              style={{ marginTop: 2 }}
+            />
+            <span>
+              I confirm this content adheres to the content policy and is ready for review.
+            </span>
+          </label>
+        </div>
+        <div className={styles.sbModalFooter}>
+          <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+          <Button variant="primary" onClick={onConfirm} disabled={!agreed}>
+            Send for review
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Generate QR Codes modal (inline)
 // ---------------------------------------------------------------------------
 interface GenerateQRModalProps {
@@ -179,8 +228,11 @@ export const Topbar: React.FC<TopbarProps> = ({
 
   const { activeModal, modalData, closeModal, openModal } = useUiStore();
 
+  const buttonLoaders = useEditorStore((s) => s.buttonLoaders);
+
   // Local state for the send-back modal (not stored in ui.store)
   const [showSendBack, setShowSendBack] = useState(false);
+  const [showConfirmReview, setShowConfirmReview] = useState(false);
   const [showQRMenu, setShowQRMenu] = useState(false);
   const qrMenuRef = useRef<HTMLDivElement>(null);
   const [showGenerateQR, setShowGenerateQR] = useState(false);
@@ -328,8 +380,9 @@ export const Topbar: React.FC<TopbarProps> = ({
             </span>
           ) : null}
 
-          {/* Save as Draft button (hidden in read-only) */}
-          {!isReadOnly && (
+          {/* Save as Draft — author action only. Hidden in read-only and for
+              content under review (review / sourcing modes or Review status). */}
+          {!isReadOnly && !isReviewMode && !isSourcingReviewMode && statusLabel !== 'Review' && (
             <Button variant="ghost" size="sm" onClick={() => emit('saveCollection')}>
               Save as Draft
             </Button>
@@ -338,7 +391,13 @@ export const Topbar: React.FC<TopbarProps> = ({
           {/* ── edit mode ─────────────────────────────────────── */}
           {isEditMode && (
             <>
-              <Button variant="primary" size="sm" onClick={() => emit('sendForReview')}>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => setShowConfirmReview(true)}
+                disabled={buttonLoaders.saveCollection}
+                isLoading={buttonLoaders.saveCollection}
+              >
                 <Send size={14} aria-hidden="true" />
                 &nbsp;Send for review
               </Button>
@@ -402,6 +461,8 @@ export const Topbar: React.FC<TopbarProps> = ({
                 variant="primary"
                 size="sm"
                 onClick={() => openModal('publishChecklist')}
+                disabled={buttonLoaders.publishCollection}
+                isLoading={buttonLoaders.publishCollection}
               >
                 <CheckCircle size={14} aria-hidden="true" />
                 &nbsp;Publish
@@ -411,6 +472,8 @@ export const Topbar: React.FC<TopbarProps> = ({
                 variant="danger"
                 size="sm"
                 onClick={() => openModal('qualityParams', { action: 'reject' })}
+                disabled={buttonLoaders.rejectCollection}
+                isLoading={buttonLoaders.rejectCollection}
               >
                 <XCircle size={14} aria-hidden="true" />
                 &nbsp;Reject
@@ -478,6 +541,13 @@ export const Topbar: React.FC<TopbarProps> = ({
             onClose={closeModal}
           />
         </div>
+      )}
+
+      {showConfirmReview && (
+        <ConfirmReviewModal
+          onConfirm={() => { setShowConfirmReview(false); emit('sendForReview'); }}
+          onCancel={() => setShowConfirmReview(false)}
+        />
       )}
 
       {showSendBack && (

--- a/projects/collection-editor-react/src/components/Topbar/index.ts
+++ b/projects/collection-editor-react/src/components/Topbar/index.ts
@@ -1,0 +1,1 @@
+export { Topbar } from './Topbar';

--- a/projects/collection-editor-react/src/components/UnitContentList/ContentRow.module.scss
+++ b/projects/collection-editor-react/src/components/UnitContentList/ContentRow.module.scss
@@ -1,0 +1,83 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: var(--sbx-r-md);
+  border: 1px solid var(--sbx-gray-200);
+  background: white;
+  transition: box-shadow 0.15s;
+
+  &:hover {
+    box-shadow: var(--sbx-shadow-1);
+
+    .removeBtn {
+      opacity: 1;
+    }
+
+    .grip {
+      opacity: 1;
+    }
+  }
+}
+
+.grip {
+  color: var(--sbx-gray-300);
+  cursor: grab;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.1s;
+  flex-shrink: 0;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.ctIcon {
+  flex-shrink: 0;
+}
+
+.info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--sbx-gray-800);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  font-size: 11px;
+  color: var(--sbx-gray-500);
+}
+
+.removeBtn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  color: var(--sbx-gray-400);
+  cursor: pointer;
+  border-radius: var(--sbx-r-xs);
+  opacity: 0;
+  transition: opacity 0.1s, color 0.1s;
+
+  &:hover {
+    color: var(--sbx-error);
+    background: rgba(220, 38, 38, 0.08);
+  }
+}

--- a/projects/collection-editor-react/src/components/UnitContentList/ContentRow.tsx
+++ b/projects/collection-editor-react/src/components/UnitContentList/ContentRow.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, X, Video, FileText, Layers, Package, Music, HelpCircle, File } from 'lucide-react';
+import type { INode } from '../../types/editor';
+import { getCtStyle } from '../../hooks/useContentType';
+import styles from './ContentRow.module.scss';
+
+const CT_ICONS: Record<string, React.ElementType> = {
+  video: Video, pdf: FileText, h5p: Layers, scorm: Package,
+  audio: Music, quiz: HelpCircle, default: File,
+};
+
+interface ContentRowProps {
+  item: INode;
+  onRemove: (id: string) => void;
+  isEditable: boolean;
+}
+
+export const ContentRow: React.FC<ContentRowProps> = ({ item, onRemove, isEditable }) => {
+  const ctStyle = getCtStyle(item);
+  const CtIcon = CT_ICONS[ctStyle.key] ?? File;
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+    disabled: !isEditable,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className={styles.row} role="listitem">
+      {/* Drag grip */}
+      {isEditable && (
+        <span className={styles.grip} {...attributes} {...listeners} aria-label="Drag to reorder">
+          <GripVertical size={15} />
+        </span>
+      )}
+
+      {/* CT icon */}
+      <span className={[`sbx-ct-sq--${ctStyle.key}`, styles.ctIcon].join(' ')} aria-hidden="true">
+        <CtIcon size={14} />
+      </span>
+
+      {/* Info */}
+      <div className={styles.info}>
+        <span className={styles.name} title={item.name}>{item.name}</span>
+        <span className={styles.meta}>{ctStyle.label}</span>
+      </div>
+
+      {/* CT badge */}
+      <span className={`sbx-ct-badge--${ctStyle.key}`}>{ctStyle.label}</span>
+
+      {/* Remove */}
+      {isEditable && (
+        <button
+          type="button"
+          className={styles.removeBtn}
+          onClick={() => onRemove(item.id)}
+          aria-label={`Remove ${item.name}`}
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/UnitContentList/UnitContentList.module.scss
+++ b/projects/collection-editor-react/src/components/UnitContentList/UnitContentList.module.scss
@@ -1,0 +1,73 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.heading {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sbx-gray-700);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.count {
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--sbx-gray-100);
+  color: var(--sbx-gray-600);
+  padding: 1px 8px;
+  border-radius: var(--sbx-r-xl);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.emptyState {
+  padding: 16px;
+  text-align: center;
+  color: var(--sbx-gray-400);
+  border: 1.5px dashed var(--sbx-gray-200);
+  border-radius: var(--sbx-r-md);
+
+  p {
+    margin: 0 0 4px;
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  span {
+    font-size: 12px;
+  }
+}
+
+.addRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 16px;
+  border: 1.5px dashed var(--sbx-gray-300);
+  border-radius: var(--sbx-r-md);
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--sbx-gray-500);
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: var(--sbx-primary);
+    color: var(--sbx-primary);
+    background: var(--sbx-primary-light);
+  }
+}

--- a/projects/collection-editor-react/src/components/UnitContentList/UnitContentList.tsx
+++ b/projects/collection-editor-react/src/components/UnitContentList/UnitContentList.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback } from 'react';
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { Plus } from 'lucide-react';
+import type { EditorMode } from '../../types/editor';
+import { useTreeStore } from '../../store/tree.store';
+import { ContentRow } from './ContentRow';
+import styles from './UnitContentList.module.scss';
+
+interface UnitContentListProps {
+  editorMode: EditorMode;
+}
+
+export const UnitContentList: React.FC<UnitContentListProps> = ({ editorMode }) => {
+  const { selectedNodeId, getChildrenOf, reorderChildren, deleteNode } = useTreeStore();
+  const children = selectedNodeId ? getChildrenOf(selectedNodeId) : [];
+  const isEditable = editorMode === 'edit';
+
+  const sensors = useSensors(
+    // distance:5 prevents conflict with outer DnD context (distance:8) while still feeling responsive
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id || !selectedNodeId) return;
+    // Read fresh children at event time to avoid stale closure
+    const fresh = useTreeStore.getState().getChildrenOf(selectedNodeId);
+    const fromIndex = fresh.findIndex(c => c.id === active.id);
+    const toIndex = fresh.findIndex(c => c.id === over.id);
+    if (fromIndex < 0 || toIndex < 0) return;
+    reorderChildren(selectedNodeId, fromIndex, toIndex);
+  }, [selectedNodeId, reorderChildren]);
+
+  const handleRemove = useCallback((id: string) => {
+    if (window.confirm('Remove this content from the unit?')) {
+      deleteNode(id);
+    }
+  }, [deleteNode]);
+
+  if (!selectedNodeId) return null;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.heading}>Content in this unit</span>
+        <span className={styles.count}>{children.length}</span>
+      </div>
+
+      {children.length > 0 ? (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={children.map(c => c.id)} strategy={verticalListSortingStrategy}>
+            <div className={styles.list} role="list">
+              {children.map(child => (
+                <ContentRow
+                  key={child.id}
+                  item={child}
+                  onRemove={handleRemove}
+                  isEditable={isEditable}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      ) : (
+        <div className={styles.emptyState}>
+          <p>No content yet</p>
+          <span>Drag from the library or click Add content</span>
+        </div>
+      )}
+
+      {isEditable && (
+        <button className={styles.addRow} type="button" aria-label="Add content to unit">
+          <Plus size={14} /> Add content
+        </button>
+      )}
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/UnitContentList/index.ts
+++ b/projects/collection-editor-react/src/components/UnitContentList/index.ts
@@ -1,0 +1,1 @@
+export { UnitContentList } from './UnitContentList';

--- a/projects/collection-editor-react/src/components/modals/ConfirmDialog.tsx
+++ b/projects/collection-editor-react/src/components/modals/ConfirmDialog.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button } from '../shared/Button';
+import styles from './modals.module.scss';
+
+interface ConfirmDialogProps {
+  title: string;
+  message: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'primary' | 'danger';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'primary',
+  onConfirm,
+  onCancel,
+}) => (
+  <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+    <div className={styles.modal}>
+      <div className={styles.modalHeader}>
+        <span id="confirm-dialog-title">{title}</span>
+        <button
+          className={styles.modalHeaderClose}
+          onClick={onCancel}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className={styles.modalBody}>{message}</div>
+
+      <div className={styles.modalFooter}>
+        <Button variant="ghost" onClick={onCancel}>
+          {cancelLabel}
+        </Button>
+        <Button variant={variant} onClick={onConfirm}>
+          {confirmLabel}
+        </Button>
+      </div>
+    </div>
+  </div>
+);

--- a/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
+++ b/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
@@ -1,0 +1,180 @@
+import React, { useMemo, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { publishContent } from '../../api/hierarchy';
+import { useTreeStore } from '../../store/tree.store';
+import { Button } from '../shared/Button';
+import styles from './modals.module.scss';
+
+interface PublishChecklistProps {
+  contentId: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+interface CheckItem {
+  label: string;
+  passed: boolean;
+  critical: boolean;
+}
+
+function PassIcon(): React.ReactElement {
+  return (
+    <span className={`${styles.checkIcon} ${styles.pass}`} aria-label="passed">
+      ✓
+    </span>
+  );
+}
+
+function FailIcon(): React.ReactElement {
+  return (
+    <span className={`${styles.checkIcon} ${styles.fail}`} aria-label="failed">
+      ✗
+    </span>
+  );
+}
+
+export const PublishChecklist: React.FC<PublishChecklistProps> = ({
+  contentId,
+  onConfirm,
+  onCancel,
+}) => {
+  const [isPublishing, setIsPublishing] = useState(false);
+
+  const treeData = useTreeStore((s) => s.treeData);
+
+  const checks = useMemo<CheckItem[]>(() => {
+    const root = treeData[0];
+
+    // 1. Root node has title and description
+    const hasTitle = Boolean(root?.name && root.name.trim().length > 0);
+    const hasDescription = Boolean(
+      root?.description?.trim() ||
+      (root?.metadata?.description as string | undefined)?.trim()
+    );
+
+    // 2. Root node has an appIcon
+    const hasAppIcon = Boolean(
+      root?.appIcon ||
+      (root?.metadata?.appIcon as string | undefined)
+    );
+
+    // 3. At least one unit exists (folder child of root)
+    const rootChildren = root?.children ?? [];
+    const hasUnit = rootChildren.some((child) => child.isFolder);
+
+    // 4. At least one content item added (non-folder leaf anywhere in tree)
+    function hasLeaf(nodes: typeof treeData): boolean {
+      for (const node of nodes) {
+        if (!node.isFolder) return true;
+        if (node.children && hasLeaf(node.children)) return true;
+      }
+      return false;
+    }
+    const hasContent = hasLeaf(rootChildren);
+
+    // 5. License field is set
+    const hasLicense = Boolean(
+      (root?.metadata?.license as string | undefined)?.trim()
+    );
+
+    return [
+      {
+        label: 'Root node has a title and description',
+        passed: hasTitle && hasDescription,
+        critical: true,
+      },
+      {
+        label: 'Root node has an app icon',
+        passed: hasAppIcon,
+        critical: true,
+      },
+      {
+        label: 'At least one unit exists',
+        passed: hasUnit,
+        critical: true,
+      },
+      {
+        label: 'At least one content item added',
+        passed: hasContent,
+        critical: true,
+      },
+      {
+        label: 'License field is set',
+        passed: hasLicense,
+        critical: true,
+      },
+    ];
+  }, [treeData]);
+
+  const canPublish = checks.every((c) => !c.critical || c.passed);
+  const failCount = checks.filter((c) => !c.passed).length;
+
+  const handlePublish = async () => {
+    setIsPublishing(true);
+    try {
+      await publishContent(contentId);
+      toast.success('Content published successfully');
+      onConfirm();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to publish content';
+      toast.error(message);
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="publish-modal-title">
+      <div className={styles.modal}>
+        <div className={styles.modalHeader}>
+          <span id="publish-modal-title">Publish Checklist</span>
+          <button
+            className={styles.modalHeaderClose}
+            onClick={onCancel}
+            aria-label="Close"
+            disabled={isPublishing}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className={styles.modalBody}>
+          <p className={styles.sectionTitle}>Pre-publish validation</p>
+
+          {checks.map((item) => (
+            <div key={item.label} className={styles.checkRow}>
+              {item.passed ? <PassIcon /> : <FailIcon />}
+              <span>{item.label}</span>
+            </div>
+          ))}
+
+          {failCount > 0 && (
+            <>
+              <hr className={styles.divider} />
+              <div className={styles.errorBanner}>
+                {failCount === 1
+                  ? '1 check failed. Please resolve it before publishing.'
+                  : `${failCount} checks failed. Please resolve them before publishing.`}
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className={styles.modalFooter}>
+          <Button variant="ghost" onClick={onCancel} disabled={isPublishing}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handlePublish}
+            disabled={!canPublish || isPublishing}
+            isLoading={isPublishing}
+          >
+            {isPublishing ? 'Publishing…' : 'Publish'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
+++ b/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { publishContent } from '../../api/hierarchy';
 import { useTreeStore } from '../../store/tree.store';
+import { useEditorStore } from '../../store/editor.store';
 import { Button } from '../shared/Button';
 import styles from './modals.module.scss';
 
@@ -41,6 +42,12 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
   const [isPublishing, setIsPublishing] = useState(false);
 
   const treeData = useTreeStore((s) => s.treeData);
+
+  // Manual confirmation items defined by the category definition (forms.publishchecklist).
+  // The reviewer must tick each before publishing is enabled.
+  const checklistItems = useEditorStore((s) => s.publishChecklist) ?? [];
+  const [confirmed, setConfirmed] = useState<Record<string, boolean>>({});
+  const allConfirmed = checklistItems.every((c) => confirmed[c.code]);
 
   const checks = useMemo<CheckItem[]>(() => {
     const root = treeData[0];
@@ -106,7 +113,7 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
     ];
   }, [treeData]);
 
-  const canPublish = checks.every((c) => !c.critical || c.passed);
+  const canPublish = checks.every((c) => !c.critical || c.passed) && allConfirmed;
   const failCount = checks.filter((c) => !c.passed).length;
 
   const handlePublish = async () => {
@@ -148,6 +155,26 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
               <span>{item.label}</span>
             </div>
           ))}
+
+          {checklistItems.length > 0 && (
+            <>
+              <hr className={styles.divider} />
+              <p className={styles.sectionTitle}>Reviewer confirmation</p>
+              {checklistItems.map((item) => (
+                <label key={item.code} className={styles.checkRow}>
+                  <input
+                    type="checkbox"
+                    checked={!!confirmed[item.code]}
+                    disabled={isPublishing}
+                    onChange={(e) =>
+                      setConfirmed((prev) => ({ ...prev, [item.code]: e.target.checked }))
+                    }
+                  />
+                  <span>{item.label}</span>
+                </label>
+              ))}
+            </>
+          )}
 
           {failCount > 0 && (
             <>

--- a/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
+++ b/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
@@ -1,6 +1,4 @@
 import React, { useMemo, useState } from 'react';
-import { toast } from 'react-hot-toast';
-import { publishContent } from '../../api/hierarchy';
 import { useTreeStore } from '../../store/tree.store';
 import { useEditorStore } from '../../store/editor.store';
 import { Button } from '../shared/Button';
@@ -35,12 +33,10 @@ function FailIcon(): React.ReactElement {
 }
 
 export const PublishChecklist: React.FC<PublishChecklistProps> = ({
-  contentId,
+  contentId: _contentId,
   onConfirm,
   onCancel,
 }) => {
-  const [isPublishing, setIsPublishing] = useState(false);
-
   const treeData = useTreeStore((s) => s.treeData);
 
   // Manual confirmation items defined by the category definition (forms.publishchecklist).
@@ -116,19 +112,10 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
   const canPublish = checks.every((c) => !c.critical || c.passed) && allConfirmed;
   const failCount = checks.filter((c) => !c.passed).length;
 
-  const handlePublish = async () => {
-    setIsPublishing(true);
-    try {
-      await publishContent(contentId);
-      toast.success('Content published successfully');
-      onConfirm();
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : 'Failed to publish content';
-      toast.error(message);
-    } finally {
-      setIsPublishing(false);
-    }
+  // Publishing is performed centrally (useToolbarActions) after the modal
+  // confirms — this just signals confirmation.
+  const handlePublish = () => {
+    onConfirm();
   };
 
   return (
@@ -140,7 +127,6 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
             className={styles.modalHeaderClose}
             onClick={onCancel}
             aria-label="Close"
-            disabled={isPublishing}
           >
             ×
           </button>
@@ -165,7 +151,6 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
                   <input
                     type="checkbox"
                     checked={!!confirmed[item.code]}
-                    disabled={isPublishing}
                     onChange={(e) =>
                       setConfirmed((prev) => ({ ...prev, [item.code]: e.target.checked }))
                     }
@@ -189,16 +174,15 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
         </div>
 
         <div className={styles.modalFooter}>
-          <Button variant="ghost" onClick={onCancel} disabled={isPublishing}>
+          <Button variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
           <Button
             variant="primary"
             onClick={handlePublish}
-            disabled={!canPublish || isPublishing}
-            isLoading={isPublishing}
+            disabled={!canPublish}
           >
-            {isPublishing ? 'Publishing…' : 'Publish'}
+            Publish
           </Button>
         </div>
       </div>

--- a/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
+++ b/projects/collection-editor-react/src/components/modals/PublishChecklist.tsx
@@ -1,5 +1,4 @@
-import React, { useMemo, useState } from 'react';
-import { useTreeStore } from '../../store/tree.store';
+import React, { useState } from 'react';
 import { useEditorStore } from '../../store/editor.store';
 import { Button } from '../shared/Button';
 import styles from './modals.module.scss';
@@ -10,110 +9,26 @@ interface PublishChecklistProps {
   onCancel: () => void;
 }
 
-interface CheckItem {
-  label: string;
-  passed: boolean;
-  critical: boolean;
-}
-
-function PassIcon(): React.ReactElement {
-  return (
-    <span className={`${styles.checkIcon} ${styles.pass}`} aria-label="passed">
-      ✓
-    </span>
-  );
-}
-
-function FailIcon(): React.ReactElement {
-  return (
-    <span className={`${styles.checkIcon} ${styles.fail}`} aria-label="failed">
-      ✗
-    </span>
-  );
-}
-
+/**
+ * Publish confirmation — mirrors the Angular publish-checklist popup.
+ * - With no checklist items: a simple "Are you sure you want to publish this {objectType}?"
+ * - With checklist items: the reviewer must tick every item before "Yes" is enabled.
+ */
 export const PublishChecklist: React.FC<PublishChecklistProps> = ({
   contentId: _contentId,
   onConfirm,
   onCancel,
 }) => {
-  const treeData = useTreeStore((s) => s.treeData);
+  const objectType =
+    useEditorStore((s) => s.editorConfig?.config?.objectType) || 'Content';
 
   // Manual confirmation items defined by the category definition (forms.publishchecklist).
-  // The reviewer must tick each before publishing is enabled.
   const checklistItems = useEditorStore((s) => s.publishChecklist) ?? [];
   const [confirmed, setConfirmed] = useState<Record<string, boolean>>({});
   const allConfirmed = checklistItems.every((c) => confirmed[c.code]);
+  const canPublish = checklistItems.length === 0 || allConfirmed;
 
-  const checks = useMemo<CheckItem[]>(() => {
-    const root = treeData[0];
-
-    // 1. Root node has title and description
-    const hasTitle = Boolean(root?.name && root.name.trim().length > 0);
-    const hasDescription = Boolean(
-      root?.description?.trim() ||
-      (root?.metadata?.description as string | undefined)?.trim()
-    );
-
-    // 2. Root node has an appIcon
-    const hasAppIcon = Boolean(
-      root?.appIcon ||
-      (root?.metadata?.appIcon as string | undefined)
-    );
-
-    // 3. At least one unit exists (folder child of root)
-    const rootChildren = root?.children ?? [];
-    const hasUnit = rootChildren.some((child) => child.isFolder);
-
-    // 4. At least one content item added (non-folder leaf anywhere in tree)
-    function hasLeaf(nodes: typeof treeData): boolean {
-      for (const node of nodes) {
-        if (!node.isFolder) return true;
-        if (node.children && hasLeaf(node.children)) return true;
-      }
-      return false;
-    }
-    const hasContent = hasLeaf(rootChildren);
-
-    // 5. License field is set
-    const hasLicense = Boolean(
-      (root?.metadata?.license as string | undefined)?.trim()
-    );
-
-    return [
-      {
-        label: 'Root node has a title and description',
-        passed: hasTitle && hasDescription,
-        critical: true,
-      },
-      {
-        label: 'Root node has an app icon',
-        passed: hasAppIcon,
-        critical: true,
-      },
-      {
-        label: 'At least one unit exists',
-        passed: hasUnit,
-        critical: true,
-      },
-      {
-        label: 'At least one content item added',
-        passed: hasContent,
-        critical: true,
-      },
-      {
-        label: 'License field is set',
-        passed: hasLicense,
-        critical: true,
-      },
-    ];
-  }, [treeData]);
-
-  const canPublish = checks.every((c) => !c.critical || c.passed) && allConfirmed;
-  const failCount = checks.filter((c) => !c.passed).length;
-
-  // Publishing is performed centrally (useToolbarActions) after the modal
-  // confirms — this just signals confirmation.
+  // Publishing is performed centrally (useToolbarActions) after confirmation.
   const handlePublish = () => {
     onConfirm();
   };
@@ -122,7 +37,7 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
     <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="publish-modal-title">
       <div className={styles.modal}>
         <div className={styles.modalHeader}>
-          <span id="publish-modal-title">Publish Checklist</span>
+          <span id="publish-modal-title">Publish {objectType}</span>
           <button
             className={styles.modalHeaderClose}
             onClick={onCancel}
@@ -133,19 +48,16 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
         </div>
 
         <div className={styles.modalBody}>
-          <p className={styles.sectionTitle}>Pre-publish validation</p>
-
-          {checks.map((item) => (
-            <div key={item.label} className={styles.checkRow}>
-              {item.passed ? <PassIcon /> : <FailIcon />}
-              <span>{item.label}</span>
-            </div>
-          ))}
-
-          {checklistItems.length > 0 && (
+          {checklistItems.length === 0 ? (
+            <p style={{ margin: 0, fontSize: 14, lineHeight: 1.5 }}>
+              Are you sure you want to publish this {objectType}?
+            </p>
+          ) : (
             <>
-              <hr className={styles.divider} />
-              <p className={styles.sectionTitle}>Reviewer confirmation</p>
+              <p className={styles.sectionTitle}>
+                Please confirm that ALL the following items are verified (by ticking the
+                check-boxes) before you can publish:
+              </p>
               {checklistItems.map((item) => (
                 <label key={item.code} className={styles.checkRow}>
                   <input
@@ -160,29 +72,14 @@ export const PublishChecklist: React.FC<PublishChecklistProps> = ({
               ))}
             </>
           )}
-
-          {failCount > 0 && (
-            <>
-              <hr className={styles.divider} />
-              <div className={styles.errorBanner}>
-                {failCount === 1
-                  ? '1 check failed. Please resolve it before publishing.'
-                  : `${failCount} checks failed. Please resolve them before publishing.`}
-              </div>
-            </>
-          )}
         </div>
 
         <div className={styles.modalFooter}>
           <Button variant="ghost" onClick={onCancel}>
-            Cancel
+            No
           </Button>
-          <Button
-            variant="primary"
-            onClick={handlePublish}
-            disabled={!canPublish}
-          >
-            Publish
+          <Button variant="primary" onClick={handlePublish} disabled={!canPublish}>
+            Yes
           </Button>
         </div>
       </div>

--- a/projects/collection-editor-react/src/components/modals/QualityParamsModal.tsx
+++ b/projects/collection-editor-react/src/components/modals/QualityParamsModal.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Button } from '../shared/Button';
+import styles from './modals.module.scss';
+
+interface QualityParamsModalProps {
+  contentId: string;
+  action: 'approve' | 'reject';
+  onConfirm: (comment: string, score?: number) => void;
+  onCancel: () => void;
+}
+
+export const QualityParamsModal: React.FC<QualityParamsModalProps> = ({
+  contentId: _contentId,
+  action,
+  onConfirm,
+  onCancel,
+}) => {
+  const [comment, setComment] = useState('');
+  const [score, setScore] = useState<number>(7);
+
+  const isApprove = action === 'approve';
+  const title = isApprove ? 'Review Quality' : 'Reject Content';
+
+  // For reject the comment is required; for approve it is optional
+  const isSubmitDisabled = !isApprove && comment.trim().length === 0;
+
+  const handleSubmit = () => {
+    if (isApprove) {
+      onConfirm(comment.trim(), score);
+    } else {
+      onConfirm(comment.trim());
+    }
+  };
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="quality-modal-title">
+      <div className={styles.modal}>
+        <div className={styles.modalHeader}>
+          <span id="quality-modal-title">{title}</span>
+          <button
+            className={styles.modalHeaderClose}
+            onClick={onCancel}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className={styles.modalBody}>
+          {isApprove ? (
+            <>
+              <div className={styles.formGroup}>
+                <label htmlFor="quality-score">Quality Score</label>
+                <div className={styles.sliderGroup}>
+                  <input
+                    id="quality-score"
+                    type="range"
+                    min={0}
+                    max={10}
+                    step={1}
+                    value={score}
+                    onChange={(e) => setScore(Number(e.target.value))}
+                    aria-valuemin={0}
+                    aria-valuemax={10}
+                    aria-valuenow={score}
+                  />
+                  <span className={styles.sliderValue}>{score}</span>
+                </div>
+                <div className={styles.sliderLabels}>
+                  <span>0 — Poor</span>
+                  <span>10 — Excellent</span>
+                </div>
+              </div>
+
+              <div className={styles.formGroup}>
+                <label htmlFor="quality-comment">
+                  Comment{' '}
+                  <span style={{ fontWeight: 400, color: 'var(--sbx-gray-400, #9CA3AF)' }}>
+                    (optional)
+                  </span>
+                </label>
+                <textarea
+                  id="quality-comment"
+                  className={styles.textarea}
+                  placeholder="Add any notes for the content creator…"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  rows={4}
+                />
+              </div>
+            </>
+          ) : (
+            <div className={styles.formGroup}>
+              <label htmlFor="reject-reason">
+                Rejection Reason{' '}
+                <span style={{ color: 'var(--sbx-error, #DC2626)' }}>*</span>
+              </label>
+              <textarea
+                id="reject-reason"
+                className={styles.textarea}
+                placeholder="Describe why this content is being rejected…"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                rows={5}
+                required
+                aria-required="true"
+              />
+              {comment.trim().length === 0 && (
+                <p
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--sbx-error, #DC2626)',
+                    marginTop: 4,
+                  }}
+                >
+                  A rejection reason is required.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.modalFooter}>
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            variant={isApprove ? 'primary' : 'danger'}
+            onClick={handleSubmit}
+            disabled={isSubmitDisabled}
+          >
+            {isApprove ? 'Approve' : 'Reject'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/projects/collection-editor-react/src/components/modals/UnsavedChangesModal.tsx
+++ b/projects/collection-editor-react/src/components/modals/UnsavedChangesModal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '../shared/Button';
+import styles from './modals.module.scss';
+
+interface UnsavedChangesModalProps {
+  onSave: () => void;
+  onDiscard: () => void;
+  onCancel: () => void;
+  isSaving?: boolean;
+}
+
+/**
+ * Shown when the user clicks Back with unsaved changes. Lets them save and
+ * leave, discard and leave, or stay on the page.
+ */
+export const UnsavedChangesModal: React.FC<UnsavedChangesModalProps> = ({
+  onSave,
+  onDiscard,
+  onCancel,
+  isSaving,
+}) => {
+  return createPortal(
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="unsaved-title">
+      <div className={styles.modal}>
+        <div className={styles.modalHeader}>
+          <span id="unsaved-title">Unsaved changes</span>
+          <button className={styles.modalHeaderClose} onClick={onCancel} aria-label="Close" disabled={isSaving}>
+            ×
+          </button>
+        </div>
+        <div className={styles.modalBody}>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.5 }}>
+            You have unsaved changes. Would you like to save them before leaving?
+          </p>
+        </div>
+        <div className={styles.modalFooter}>
+          <Button variant="ghost" onClick={onCancel} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onDiscard} disabled={isSaving}>
+            Discard
+          </Button>
+          <Button variant="primary" onClick={onSave} isLoading={isSaving} disabled={isSaving}>
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/projects/collection-editor-react/src/components/modals/index.ts
+++ b/projects/collection-editor-react/src/components/modals/index.ts
@@ -1,0 +1,3 @@
+export { PublishChecklist } from './PublishChecklist';
+export { QualityParamsModal } from './QualityParamsModal';
+export { ConfirmDialog } from './ConfirmDialog';

--- a/projects/collection-editor-react/src/components/modals/modals.module.scss
+++ b/projects/collection-editor-react/src/components/modals/modals.module.scss
@@ -97,8 +97,8 @@
 }
 
 .errorBanner {
-  background: #FEF2F2;
-  border: 1px solid #FECACA;
+  background: var(--sbx-status-err-bg);
+  border: 1px solid var(--sbx-status-err-border);
   border-radius: 6px;
   padding: 10px 14px;
   font-size: 13px;

--- a/projects/collection-editor-react/src/components/modals/modals.module.scss
+++ b/projects/collection-editor-react/src/components/modals/modals.module.scss
@@ -1,0 +1,180 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: white;
+  border-radius: 8px;
+  padding: 24px;
+  min-width: 400px;
+  max-width: 600px;
+  width: 100%;
+  box-shadow: 0 20px 25px rgba(0, 0, 0, 0.15), 0 8px 10px rgba(0, 0, 0, 0.10);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--sbx-gray-900, #111827);
+  margin-bottom: 16px;
+}
+
+.modalHeaderClose {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: var(--sbx-gray-500, #6B7280);
+  font-size: 20px;
+  line-height: 1;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    color: var(--sbx-gray-800, #1F2937);
+    background: var(--sbx-gray-100, #F3F4F6);
+  }
+}
+
+.modalBody {
+  margin-bottom: 24px;
+  color: var(--sbx-gray-700, #374151);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  align-items: center;
+}
+
+.checkRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  color: var(--sbx-gray-700, #374151);
+}
+
+.checkIcon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.pass {
+  color: var(--sbx-success, #16A34A);
+}
+
+.fail {
+  color: var(--sbx-error, #DC2626);
+}
+
+.divider {
+  border: none;
+  border-top: 1px solid var(--sbx-gray-200, #E5E7EB);
+  margin: 16px 0;
+}
+
+.errorBanner {
+  background: #FEF2F2;
+  border: 1px solid #FECACA;
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--sbx-error, #DC2626);
+  margin-bottom: 16px;
+}
+
+.formGroup {
+  margin-bottom: 16px;
+
+  label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--sbx-gray-700, #374151);
+    margin-bottom: 6px;
+  }
+}
+
+.textarea {
+  width: 100%;
+  border: 1.5px solid var(--sbx-gray-300, #D1D5DB);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: var(--sbx-gray-900, #111827);
+  font-family: inherit;
+  resize: vertical;
+  min-height: 90px;
+  transition: border-color 0.15s;
+
+  &:focus {
+    outline: none;
+    border-color: var(--sbx-primary, #2D6AE3);
+    box-shadow: 0 0 0 3px rgba(45, 106, 227, 0.12);
+  }
+
+  &::placeholder {
+    color: var(--sbx-gray-400, #9CA3AF);
+  }
+}
+
+.sliderGroup {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  input[type='range'] {
+    flex: 1;
+    accent-color: var(--sbx-primary, #2D6AE3);
+    height: 4px;
+    cursor: pointer;
+  }
+}
+
+.sliderValue {
+  min-width: 28px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--sbx-primary, #2D6AE3);
+}
+
+.sliderLabels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--sbx-gray-400, #9CA3AF);
+  margin-top: 4px;
+}
+
+.sectionTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--sbx-gray-500, #6B7280);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}

--- a/projects/collection-editor-react/src/components/shared/Button.tsx
+++ b/projects/collection-editor-react/src/components/shared/Button.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Spinner } from './Spinner';
+
+interface ButtonProps {
+  variant?: 'primary' | 'ghost' | 'danger';
+  size?: 'sm' | 'md';
+  isLoading?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+  type?: 'button' | 'submit' | 'reset';
+}
+
+export const Button: React.FC<ButtonProps> = ({
+  variant = 'ghost',
+  size = 'md',
+  isLoading,
+  disabled,
+  onClick,
+  children,
+  className,
+  type = 'button',
+}) => (
+  <button
+    type={type}
+    className={`sbx-btn-${variant} ${size === 'sm' ? 'sbx-btn-sm' : ''} ${className ?? ''}`}
+    onClick={onClick}
+    disabled={isLoading || disabled}
+    aria-busy={isLoading ? true : undefined}
+  >
+    {isLoading ? <Spinner size={14} /> : null}
+    {children}
+  </button>
+);

--- a/projects/collection-editor-react/src/components/shared/Card.tsx
+++ b/projects/collection-editor-react/src/components/shared/Card.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface CardProps {
+  className?: string;
+  children: React.ReactNode;
+  onClick?: () => void;
+}
+
+export const Card: React.FC<CardProps> = ({ className, children, onClick }) => (
+  <div
+    className={`sbx-card ${className ?? ''}`}
+    onClick={onClick}
+    role={onClick ? 'button' : undefined}
+    tabIndex={onClick ? 0 : undefined}
+    onKeyDown={
+      onClick
+        ? (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onClick();
+            }
+          }
+        : undefined
+    }
+  >
+    {children}
+  </div>
+);

--- a/projects/collection-editor-react/src/components/shared/Chip.tsx
+++ b/projects/collection-editor-react/src/components/shared/Chip.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface ChipProps {
+  variant?: 'filled' | 'outline';
+  active?: boolean;
+  onRemove?: () => void;
+  onClick?: () => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const Chip: React.FC<ChipProps> = ({
+  variant = 'outline',
+  active,
+  onRemove,
+  onClick,
+  className,
+  children,
+}) => (
+  <span
+    className={`sbx-chip ${variant} ${active ? 'active' : ''} ${className ?? ''}`}
+    onClick={onClick}
+    role={onClick ? 'button' : undefined}
+    tabIndex={onClick ? 0 : undefined}
+    onKeyDown={
+      onClick
+        ? (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onClick();
+            }
+          }
+        : undefined
+    }
+  >
+    {children}
+    {onRemove && (
+      <button
+        type="button"
+        className="sbx-chip-remove"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        aria-label="Remove"
+      >
+        ×
+      </button>
+    )}
+  </span>
+);

--- a/projects/collection-editor-react/src/components/shared/DropZone.module.scss
+++ b/projects/collection-editor-react/src/components/shared/DropZone.module.scss
@@ -1,0 +1,19 @@
+.dropZone {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed var(--sbx-gray-300);
+  border-radius: var(--sbx-r-md);
+  padding: 24px;
+  color: var(--sbx-gray-500);
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.active {
+  display: flex;
+  border-color: var(--sbx-primary);
+  color: var(--sbx-primary);
+  background: var(--sbx-primary-light);
+}

--- a/projects/collection-editor-react/src/components/shared/DropZone.tsx
+++ b/projects/collection-editor-react/src/components/shared/DropZone.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styles from './DropZone.module.scss';
+
+interface DropZoneProps {
+  isActive: boolean;
+  label?: string;
+  nodeId?: string;
+  className?: string;
+}
+
+export const DropZone: React.FC<DropZoneProps> = ({
+  isActive,
+  label = 'Drop here',
+  nodeId,
+  className,
+}) => (
+  <div
+    className={`${styles.dropZone} ${isActive ? styles.active : ''} ${className ?? ''}`}
+    data-droppable={isActive ? 'true' : undefined}
+    data-node-id={nodeId}
+    aria-label={label}
+    role="region"
+  >
+    <span>{label}</span>
+  </div>
+);

--- a/projects/collection-editor-react/src/components/shared/Spinner.module.scss
+++ b/projects/collection-editor-react/src/components/shared/Spinner.module.scss
@@ -1,0 +1,14 @@
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spin {
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+}

--- a/projects/collection-editor-react/src/components/shared/Spinner.tsx
+++ b/projects/collection-editor-react/src/components/shared/Spinner.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styles from './Spinner.module.scss';
+
+interface SpinnerProps {
+  size?: number;
+  color?: string;
+}
+
+export const Spinner: React.FC<SpinnerProps> = ({
+  size = 16,
+  color = 'currentColor',
+}) => (
+  <svg
+    className={styles.spin}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-label="Loading"
+    role="status"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="10"
+      stroke={color}
+      strokeWidth="3"
+      strokeDasharray="31.4"
+      strokeDashoffset="10"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/projects/collection-editor-react/src/components/shared/index.ts
+++ b/projects/collection-editor-react/src/components/shared/index.ts
@@ -1,0 +1,5 @@
+export { Chip } from './Chip';
+export { Spinner } from './Spinner';
+export { Button } from './Button';
+export { Card } from './Card';
+export { DropZone } from './DropZone';

--- a/projects/collection-editor-react/src/dev-main.tsx
+++ b/projects/collection-editor-react/src/dev-main.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'react-hot-toast';
+import { CollectionEditor } from './components/CollectionEditor';
+import type { IEditorConfig } from './types/editor';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+const MOCK_CONFIG: IEditorConfig = {
+  context: {
+    authToken: '',
+    userId: 'cdee2eb6-d1d6-43bd-b18d-959213006510',
+    uid: 'cdee2eb6-d1d6-43bd-b18d-959213006510',
+    sid: 'iYO2K6dOSdA0rwq7NeT1TDzS-dbqduvV',
+    did: '7e85b4967aebd6704ba1f604f20056b6',
+    channel: '0145017576228454407',
+    pdata: { id: 'test.sunbird.portal', ver: '2.8.0', pid: 'creation-portal' },
+    env: 'collection_editor',
+    identifier: 'do_2145942355538657281390',
+    contentId: 'do_2145942355538657281390',
+    framework: 'NCF',
+    targetFWIds: ['NCF'],
+  },
+  config: {
+    mode: 'edit',
+    maxDepth: 4,
+    objectType: 'Collection',
+    primaryCategory: 'Course',
+    framework: ['NCF'],
+    targetFWIds: ['NCF'],
+  },
+  enableSplitBuilder: true,
+};
+
+const rootEl = document.getElementById('root');
+if (!rootEl) {
+  throw new Error('Root element #root not found');
+}
+
+createRoot(rootEl).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <CollectionEditor
+        {...MOCK_CONFIG}
+        onToolbarEvent={console.log}
+      />
+      <Toaster position="top-right" />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/projects/collection-editor-react/src/hooks/index.ts
+++ b/projects/collection-editor-react/src/hooks/index.ts
@@ -1,0 +1,9 @@
+export { useEditorInit } from './useEditorInit';
+export { useTree } from './useTree';
+export type { UseTreeReturn } from './useTree';
+export { useFramework } from './useFramework';
+export { useLibrary } from './useLibrary';
+export { useSaveHierarchy } from './useSaveHierarchy';
+export { useContentType, getCtStyle } from './useContentType';
+export type { CtStyle } from './useContentType';
+export { useTelemetry } from './useTelemetry';

--- a/projects/collection-editor-react/src/hooks/useChannelData.ts
+++ b/projects/collection-editor-react/src/hooks/useChannelData.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { getChannelData } from '../api/channel';
+import type { IChannelData } from '../api/channel';
+
+export function useChannelData(channelId?: string): IChannelData & { isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ['channel', channelId],
+    queryFn: () => getChannelData(channelId!),
+    enabled: !!channelId,
+    staleTime: 10 * 60 * 1000, // channel data rarely changes
+  });
+
+  return {
+    identifier: query.data?.identifier ?? channelId ?? '',
+    name: query.data?.name,
+    frameworks: query.data?.frameworks,
+    collectionAdditionalCategories: query.data?.collectionAdditionalCategories,
+    contentAdditionalCategories: query.data?.contentAdditionalCategories,
+    defaultLicense: query.data?.defaultLicense,
+    isLoading: query.isLoading,
+  };
+}

--- a/projects/collection-editor-react/src/hooks/useContentStatus.ts
+++ b/projects/collection-editor-react/src/hooks/useContentStatus.ts
@@ -1,0 +1,15 @@
+import { useTreeStore } from '../store/tree.store';
+
+/**
+ * Reads the root collection's status from the tree and reports whether it is
+ * still in "Draft". Adding units / content is only allowed for Draft content —
+ * once it moves to Review / Live, the add affordances are disabled.
+ */
+export function useIsDraftStatus(): boolean {
+  return useTreeStore((s) => {
+    const root = s.treeData[0];
+    const status =
+      ((root?.metadata?.status as string | undefined) ?? root?.status ?? 'Draft');
+    return status.toLowerCase() === 'draft';
+  });
+}

--- a/projects/collection-editor-react/src/hooks/useContentStatus.ts
+++ b/projects/collection-editor-react/src/hooks/useContentStatus.ts
@@ -1,4 +1,5 @@
 import { useTreeStore } from '../store/tree.store';
+import type { INode } from '../types/editor';
 
 /**
  * Reads the root collection's status from the tree and reports whether it is
@@ -11,5 +12,30 @@ export function useIsDraftStatus(): boolean {
     const status =
       ((root?.metadata?.status as string | undefined) ?? root?.status ?? 'Draft');
     return status.toLowerCase() === 'draft';
+  });
+}
+
+/**
+ * Returns true only when the currently selected tree node is a Unit or
+ * Sub-Unit (isFolder, but NOT the root). Used to gate the Library + button —
+ * content should only be addable to units, not directly to the course root or
+ * to individual leaf content nodes.
+ */
+export function useSelectedNodeIsUnit(): boolean {
+  return useTreeStore((s) => {
+    if (!s.selectedNodeId) return false;
+    const rootId = s.treeData[0]?.id;
+    const findNode = (nodes: INode[]): INode | undefined => {
+      for (const n of nodes) {
+        if (n.id === s.selectedNodeId) return n;
+        if (n.children?.length) {
+          const found = findNode(n.children);
+          if (found) return found;
+        }
+      }
+      return undefined;
+    };
+    const node = findNode(s.treeData);
+    return !!node?.isFolder && node.id !== rootId;
   });
 }

--- a/projects/collection-editor-react/src/hooks/useContentType.ts
+++ b/projects/collection-editor-react/src/hooks/useContentType.ts
@@ -1,0 +1,55 @@
+import { CT_COLOR_MAP, CT_ICON_MAP } from '../types/content';
+import type { INode } from '../types/editor';
+import type { IContent } from '../types/content';
+
+type ContentLike = Partial<INode> | Partial<IContent>;
+
+function resolveKey(item: ContentLike): string {
+  const str = [
+    (item as IContent).mimeType ?? '',
+    (item as IContent).primaryCategory ?? '',
+    (item as INode).contentType ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  if (str.includes('video')) return 'video';
+  if (str.includes('pdf') || str.includes('epub')) return 'pdf';
+  if (str.includes('h5p')) return 'h5p';
+  if (str.includes('scorm')) return 'scorm';
+  if (str.includes('audio') || str.includes('mp3')) return 'audio';
+  if (
+    str.includes('quiz') ||
+    str.includes('question') ||
+    str.includes('ecml')
+  )
+    return 'quiz';
+  return 'default';
+}
+
+export interface CtStyle {
+  key: string;
+  color: string;
+  bgClass: string;
+  badgeClass: string;
+  tintClass: string;
+  iconName: string;
+  label: string;
+}
+
+export function getCtStyle(item: ContentLike): CtStyle {
+  const key = resolveKey(item);
+  return {
+    key,
+    color: CT_COLOR_MAP[key as keyof typeof CT_COLOR_MAP] ?? CT_COLOR_MAP.default,
+    bgClass: `sbx-ct-sq--${key}`,
+    badgeClass: `sbx-ct-badge--${key}`,
+    tintClass: `sbx-ct-tint--${key}`,
+    iconName: CT_ICON_MAP[key as keyof typeof CT_ICON_MAP] ?? CT_ICON_MAP.default,
+    label: key.charAt(0).toUpperCase() + key.slice(1),
+  };
+}
+
+export function useContentType() {
+  return { getCtStyle };
+}

--- a/projects/collection-editor-react/src/hooks/useEditorInit.ts
+++ b/projects/collection-editor-react/src/hooks/useEditorInit.ts
@@ -15,7 +15,7 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
   const [error, setError] = useState<Error | null>(null);
   const [isReady, setIsReady] = useState(false);
 
-  const { setEditorConfig, setEditorMode, setFormConfigs } = useEditorStore();
+  const { setEditorConfig, setEditorMode, setCategoryDefinition } = useEditorStore();
   const { setTreeData, selectNode } = useTreeStore();
 
   useEffect(() => {
@@ -47,11 +47,21 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
             ?? 'Course';
           const channel = config.context.channel ?? '';
           try {
-            const { rootFormFields, unitFormFields } = await getCategoryDefinition(
-              primaryCategory, channel,
+            const parsed = await getCategoryDefinition(
+              primaryCategory, channel, config.config.objectType ?? 'Collection',
             );
-            if (!cancelled && (rootFormFields.length > 0 || unitFormFields.length > 0)) {
-              setFormConfigs(rootFormFields, unitFormFields);
+            if (!cancelled) {
+              setCategoryDefinition(parsed);
+              // Honor the maxDepth declared by sourcingSettings when present.
+              const sourcingMaxDepth = (
+                parsed.sourcingSettings?.collection as Record<string, unknown> | undefined
+              )?.maxDepth as number | undefined;
+              if (sourcingMaxDepth && !config.config.maxDepth) {
+                setEditorConfig({
+                  ...config,
+                  config: { ...config.config, maxDepth: sourcingMaxDepth },
+                });
+              }
             }
           } catch {
             // silently fall back to hardcoded defaults

--- a/projects/collection-editor-react/src/hooks/useEditorInit.ts
+++ b/projects/collection-editor-react/src/hooks/useEditorInit.ts
@@ -50,20 +50,41 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
           // Fetch category definition for dynamic form fields (best-effort, non-blocking)
           const primaryCategory = config.config.primaryCategory ?? 'Course';
           const channel = config.context.channel ?? '';
+          const apiVersion = config.config.categoryDefinitionApiVersion ?? 'v4';
           try {
             const parsed = await getCategoryDefinition(
-              primaryCategory, channel, config.config.objectType ?? 'Collection',
+              primaryCategory, channel, config.config.objectType ?? 'Collection', apiVersion,
             );
             if (!cancelled) {
               setCategoryDefinition(parsed);
-              // Honor the maxDepth declared by sourcingSettings when present.
-              const sourcingMaxDepth = (
+
+              // Apply sourcing settings from the category definition into editorConfig.
+              // Angular does this via sethierarchyConfig() — merges the full
+              // sourcingSettings.collection into editorConfig.config.
+              const sourcing = (
                 parsed.sourcingSettings?.collection as Record<string, unknown> | undefined
-              )?.maxDepth as number | undefined;
-              if (sourcingMaxDepth && !config.config.maxDepth) {
+              ) ?? {};
+
+              const configPatch: Record<string, unknown> = {};
+              if (sourcing.maxDepth && !config.config.maxDepth) {
+                configPatch.maxDepth = sourcing.maxDepth as number;
+              }
+              // Propagate allowed children types and hierarchy level definitions
+              // (used by the tree to control what can be added at each depth).
+              if (sourcing.children && !config.config.children) {
+                configPatch.children = sourcing.children;
+              }
+              if (sourcing.hierarchy && !(config.config.hierarchy as Record<string, unknown> | undefined)?.level1) {
+                configPatch.hierarchy = {
+                  ...(config.config.hierarchy as Record<string, unknown> | undefined ?? {}),
+                  ...sourcing.hierarchy as Record<string, unknown>,
+                };
+              }
+
+              if (Object.keys(configPatch).length > 0) {
                 setEditorConfig({
                   ...config,
-                  config: { ...config.config, maxDepth: sourcingMaxDepth },
+                  config: { ...config.config, ...configPatch },
                 });
               }
             }

--- a/projects/collection-editor-react/src/hooks/useEditorInit.ts
+++ b/projects/collection-editor-react/src/hooks/useEditorInit.ts
@@ -16,7 +16,7 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
   const [error, setError] = useState<Error | null>(null);
   const [isReady, setIsReady] = useState(false);
 
-  const { setEditorConfig, setEditorMode, setCategoryDefinition } = useEditorStore();
+  const { setEditorConfig, setEditorMode, setCategoryDefinition, setContentFramework } = useEditorStore();
   const { setTreeData, selectNode } = useTreeStore();
 
   useEffect(() => {
@@ -44,6 +44,15 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
             setTreeData(nodes);
             if (rootNode) {
               selectNode(rootNode.id);
+              // Mirror Angular's `collection.framework || context.framework`:
+              // the loaded content's own framework takes precedence over the
+              // editor context, so editing existing content drives the cascade
+              // off the right framework.
+              const meta = rootNode.metadata ?? {};
+              const fw = (meta['framework'] as string | undefined) ?? config.context.framework ?? null;
+              const tfw = (meta['targetFWIds'] as string[] | undefined)
+                ?? config.context.targetFWIds ?? null;
+              setContentFramework(fw, tfw);
             }
           }
 

--- a/projects/collection-editor-react/src/hooks/useEditorInit.ts
+++ b/projects/collection-editor-react/src/hooks/useEditorInit.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { IEditorConfig } from '../types/editor';
 import { useEditorStore } from '../store/editor.store';
 import { useTreeStore } from '../store/tree.store';
-import { readHierarchy } from '../api/hierarchy';
+import { readHierarchy, readQuestionSetHierarchyTree } from '../api/hierarchy';
 import { getCategoryDefinition } from '../api/categoryDefinition';
 import { setApiBaseUrl } from '../api/client';
 
@@ -38,7 +38,13 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
           config.context.contentId ?? config.context.identifier ?? '';
 
         if (contentId) {
-          const { rootNode } = await readHierarchy(contentId);
+          // QuestionSet-rooted editors must read from the questionset endpoint
+          // (payload under result.questionset); everything else is a
+          // content-collection hierarchy.
+          const isQuestionSetRoot = config.config.objectType === 'QuestionSet';
+          const { rootNode } = isQuestionSetRoot
+            ? await readQuestionSetHierarchyTree(contentId)
+            : await readHierarchy(contentId);
           if (!cancelled) {
             const nodes = rootNode ? [rootNode] : [];
             setTreeData(nodes);

--- a/projects/collection-editor-react/src/hooks/useEditorInit.ts
+++ b/projects/collection-editor-react/src/hooks/useEditorInit.ts
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react';
+import type { IEditorConfig } from '../types/editor';
+import { useEditorStore } from '../store/editor.store';
+import { useTreeStore } from '../store/tree.store';
+import { readHierarchy } from '../api/hierarchy';
+import { getCategoryDefinition } from '../api/categoryDefinition';
+
+interface UseEditorInitOptions {
+  config: IEditorConfig;
+  onError?: (e: Error) => void;
+}
+
+export function useEditorInit({ config, onError }: UseEditorInitOptions) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const { setEditorConfig, setEditorMode, setFormConfigs } = useEditorStore();
+  const { setTreeData, selectNode } = useTreeStore();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        setEditorConfig(config);
+        setEditorMode(config.config.mode);
+
+        const contentId =
+          config.context.contentId ?? config.context.identifier ?? '';
+
+        if (contentId) {
+          const { rootNode } = await readHierarchy(contentId);
+          if (!cancelled) {
+            const nodes = rootNode ? [rootNode] : [];
+            setTreeData(nodes);
+            if (rootNode) {
+              selectNode(rootNode.id);
+            }
+          }
+
+          // Fetch category definition for dynamic form fields (best-effort, non-blocking)
+          const primaryCategory = (config.context as unknown as Record<string, unknown>).primaryCategory as string
+            ?? 'Course';
+          const channel = config.context.channel ?? '';
+          try {
+            const { rootFormFields, unitFormFields } = await getCategoryDefinition(
+              primaryCategory, channel,
+            );
+            if (!cancelled && (rootFormFields.length > 0 || unitFormFields.length > 0)) {
+              setFormConfigs(rootFormFields, unitFormFields);
+            }
+          } catch {
+            // silently fall back to hardcoded defaults
+          }
+        }
+
+        if (!cancelled) {
+          setIsReady(true);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          setError(e);
+          onError?.(e);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    init();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config.context.contentId, config.context.identifier]);
+
+  return { isLoading, error, isReady };
+}

--- a/projects/collection-editor-react/src/hooks/useEditorInit.ts
+++ b/projects/collection-editor-react/src/hooks/useEditorInit.ts
@@ -50,7 +50,7 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
           // Fetch category definition for dynamic form fields (best-effort, non-blocking)
           const primaryCategory = config.config.primaryCategory ?? 'Course';
           const channel = config.context.channel ?? '';
-          const apiVersion = config.config.categoryDefinitionApiVersion ?? 'v4';
+          const apiVersion = config.config.categoryDefinitionApiVersion ?? 'v1';
           try {
             const parsed = await getCategoryDefinition(
               primaryCategory, channel, config.config.objectType ?? 'Collection', apiVersion,

--- a/projects/collection-editor-react/src/hooks/useEditorInit.ts
+++ b/projects/collection-editor-react/src/hooks/useEditorInit.ts
@@ -4,6 +4,7 @@ import { useEditorStore } from '../store/editor.store';
 import { useTreeStore } from '../store/tree.store';
 import { readHierarchy } from '../api/hierarchy';
 import { getCategoryDefinition } from '../api/categoryDefinition';
+import { setApiBaseUrl } from '../api/client';
 
 interface UseEditorInitOptions {
   config: IEditorConfig;
@@ -26,6 +27,10 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
         setIsLoading(true);
         setError(null);
 
+        if (config.apiBaseUrl) {
+          setApiBaseUrl(config.apiBaseUrl);
+        }
+
         setEditorConfig(config);
         setEditorMode(config.config.mode);
 
@@ -43,8 +48,7 @@ export function useEditorInit({ config, onError }: UseEditorInitOptions) {
           }
 
           // Fetch category definition for dynamic form fields (best-effort, non-blocking)
-          const primaryCategory = (config.context as unknown as Record<string, unknown>).primaryCategory as string
-            ?? 'Course';
+          const primaryCategory = config.config.primaryCategory ?? 'Course';
           const channel = config.context.channel ?? '';
           try {
             const parsed = await getCategoryDefinition(

--- a/projects/collection-editor-react/src/hooks/useFramework.ts
+++ b/projects/collection-editor-react/src/hooks/useFramework.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { getFramework } from '../api/framework';
+import type { IFrameworkDetails } from '../types/framework';
+
+export function useFramework(
+  frameworkId?: string,
+  targetFWIds?: string[],
+): IFrameworkDetails & { isLoading: boolean } {
+  const orgQuery = useQuery({
+    queryKey: ['framework', frameworkId],
+    queryFn: () => getFramework(frameworkId!),
+    enabled: !!frameworkId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Query for first target framework (simplified — extend with useQueries if needed)
+  const firstTargetId = targetFWIds?.[0];
+  const targetQuery = useQuery({
+    queryKey: ['framework', firstTargetId],
+    queryFn: () => getFramework(firstTargetId!),
+    enabled: !!firstTargetId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const targetFrameworks = targetQuery.data ? [targetQuery.data] : [];
+
+  return {
+    organisationFramework: orgQuery.data,
+    targetFrameworks,
+    isLoading: orgQuery.isLoading || targetQuery.isLoading,
+  };
+}

--- a/projects/collection-editor-react/src/hooks/useFrameworkOptions.ts
+++ b/projects/collection-editor-react/src/hooks/useFrameworkOptions.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import { searchFrameworks } from '../api/framework';
+
+interface ChannelFramework { identifier: string; name: string; type?: string }
+
+/**
+ * Build the option list for the `framework` (Course Type) field.
+ *
+ * Mirrors Angular's getFrameworkDetails (editor.component.ts:277-318):
+ *  - Start from the channel's frameworks.
+ *  - If the category definition declares `orgFWType`, restrict to frameworks of
+ *    those types; for any declared type the channel does NOT cover, fetch the
+ *    system-default frameworks of that type via composite search and merge them.
+ *  - With no `orgFWType`, fall back to all channel frameworks.
+ */
+export function useFrameworkOptions(
+  channelFrameworks: ChannelFramework[] | undefined,
+  orgFWType: string[] | undefined,
+  channel: string | undefined,
+): Array<{ label: string; value: string }> {
+  const list = channelFrameworks ?? [];
+  const channelTypes = new Set(list.map(f => f.type).filter(Boolean) as string[]);
+  const missingTypes = (orgFWType ?? []).filter(t => !channelTypes.has(t));
+
+  const { data: fetched } = useQuery({
+    queryKey: ['framework-search', missingTypes.sort().join(','), channel],
+    queryFn: () => searchFrameworks({ type: missingTypes, systemDefault: 'Yes' }),
+    enabled: missingTypes.length > 0,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const base = orgFWType && orgFWType.length
+    ? list.filter(f => f.type && orgFWType.includes(f.type))
+    : list;
+
+  const merged = [
+    ...(fetched ?? []).map(f => ({ label: f.name, value: f.identifier })),
+    ...base.map(f => ({ label: f.name, value: f.identifier })),
+  ];
+
+  // De-dupe by value, preserving first occurrence.
+  const seen = new Set<string>();
+  return merged.filter(o => (seen.has(o.value) ? false : (seen.add(o.value), true)));
+}

--- a/projects/collection-editor-react/src/hooks/useLibrary.ts
+++ b/projects/collection-editor-react/src/hooks/useLibrary.ts
@@ -65,7 +65,6 @@ export function useLibrary() {
       try {
         const filters: Record<string, unknown> = {
           status: ['Live'],
-          contentType: ['Resource'],
           primaryCategory: filter && filter !== 'all'
             ? [filter]
             : allowedCategories,

--- a/projects/collection-editor-react/src/hooks/useLibrary.ts
+++ b/projects/collection-editor-react/src/hooks/useLibrary.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useLibraryStore } from '../store/library.store';
+import { useEditorStore } from '../store/editor.store';
+import { useTreeStore } from '../store/tree.store';
+import { compositeSearch } from '../api/content';
+import { LIBRARY_PRIMARY_CATEGORIES } from '../types/content';
+import type { LibraryFilters } from '../components/LibraryDock/LibraryFilterPanel';
+
+const PAGE_SIZE = 20;
+
+/**
+ * Returns allowed primaryCategory values for the currently selected unit,
+ * driven by editorConfig.config.hierarchy.levelN.children.Content.
+ * Falls back to the full LIBRARY_PRIMARY_CATEGORIES constant.
+ */
+export function useAllowedCategories(): string[] {
+  const config = useEditorStore((s) => s.editorConfig);
+  const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
+  const treeData = useTreeStore((s) => s.treeData);
+
+  // Compute selected node depth (root = 0)
+  const depth = useCallback(() => {
+    if (!selectedNodeId || !treeData.length) return 0;
+    function getDepth(nodes: typeof treeData, id: string, d = 0): number {
+      for (const n of nodes) {
+        if (n.id === id) return d;
+        if (n.children?.length) {
+          const found = getDepth(n.children, id, d + 1);
+          if (found >= 0) return found;
+        }
+      }
+      return -1;
+    }
+    return Math.max(0, getDepth(treeData, selectedNodeId));
+  }, [selectedNodeId, treeData])();
+
+  const hierarchy = config?.config?.hierarchy as Record<string, unknown> | undefined;
+  if (!hierarchy) return [...LIBRARY_PRIMARY_CATEGORIES];
+
+  // level1 = depth 1, level2 = depth 2, etc.
+  const levelKey = `level${depth}`;
+  const levelConfig = hierarchy[levelKey] as Record<string, unknown> | undefined;
+  const children = levelConfig?.children as Record<string, unknown> | undefined;
+  const contentCategories = children?.['Content'] as string[] | undefined;
+
+  if (contentCategories?.length) return contentCategories;
+  return [...LIBRARY_PRIMARY_CATEGORIES];
+}
+
+export function useLibrary() {
+  const store = useLibraryStore();
+  const channel = useEditorStore((s) => s.editorConfig?.context?.channel ?? '');
+  const allowedCategories = useAllowedCategories();
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const load = useCallback(
+    async (
+      query = '',
+      filter = 'all',
+      advancedFilters: LibraryFilters = {},
+      reset = true,
+      sortAZ = false,
+    ) => {
+      store.setLoading(true);
+      try {
+        const filters: Record<string, unknown> = {
+          status: ['Live'],
+          contentType: ['Resource'],
+          primaryCategory: filter && filter !== 'all'
+            ? [filter]
+            : allowedCategories,
+        };
+        if (advancedFilters?.board?.length) filters['board'] = advancedFilters.board;
+        if (advancedFilters?.medium?.length) filters['medium'] = advancedFilters.medium;
+        if (advancedFilters?.gradeLevel?.length) filters['gradeLevel'] = advancedFilters.gradeLevel;
+        if (advancedFilters?.subject?.length) filters['subject'] = advancedFilters.subject;
+        if (advancedFilters?.primaryCategory?.length) filters['primaryCategory'] = advancedFilters.primaryCategory;
+
+        const currentOffset = reset ? 0 : store.offset;
+
+        const { content, count } = await compositeSearch({
+          filters,
+          query,
+          limit: query ? 50 : PAGE_SIZE,
+          offset: currentOffset,
+          channel: channel || undefined,
+          sortBy: sortAZ ? { name: 'asc' } : { lastUpdatedOn: 'desc' },
+        });
+
+        if (reset) {
+          store.setContent(content, count);
+        } else {
+          store.appendContent(content, count);
+        }
+      } catch (e) {
+        console.error('[useLibrary] load error:', e);
+      } finally {
+        store.setLoading(false);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [allowedCategories, channel],
+  );
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channel]);
+
+  const search = useCallback(
+    (query: string) => {
+      store.setSearch(query);
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = setTimeout(
+        () => load(query, store.activeFilter, store.advancedFilters, true, store.sortAZ),
+        300,
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [store.activeFilter, store.advancedFilters, store.sortAZ, load],
+  );
+
+  const setFilter = useCallback(
+    (filter: string) => {
+      store.setFilter(filter);
+      load(store.searchQuery, filter, store.advancedFilters, true, store.sortAZ);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [store.searchQuery, store.advancedFilters, store.sortAZ, load],
+  );
+
+  const applyAdvancedFilters = useCallback(
+    (advancedFilters: LibraryFilters) => {
+      store.setAdvancedFilters(advancedFilters);
+      load(store.searchQuery, store.activeFilter, advancedFilters, true, store.sortAZ);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [store.searchQuery, store.activeFilter, store.sortAZ, load],
+  );
+
+  const toggleSort = useCallback(() => {
+    const nextSortAZ = !store.sortAZ;
+    store.setSortAZ(nextSortAZ);
+    load(store.searchQuery, store.activeFilter, store.advancedFilters, true, nextSortAZ);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store.sortAZ, store.searchQuery, store.activeFilter, store.advancedFilters, load]);
+
+  const loadMore = useCallback(() => {
+    if (store.isLoading) return;
+    load(store.searchQuery, store.activeFilter, store.advancedFilters, false, store.sortAZ);
+  }, [store.isLoading, store.searchQuery, store.activeFilter, store.advancedFilters, store.sortAZ, load]);
+
+  const hasMore = store.allContent.length < store.totalCount;
+
+  return {
+    content: store.filteredContent,
+    isLoading: store.isLoading,
+    totalCount: store.totalCount,
+    activeFilter: store.activeFilter,
+    advancedFilters: store.advancedFilters,
+    searchQuery: store.searchQuery,
+    sortAZ: store.sortAZ,
+    hasMore,
+    search,
+    setFilter,
+    applyAdvancedFilters,
+    toggleSort,
+    loadMore,
+    refetch: () => load(store.searchQuery, store.activeFilter, store.advancedFilters, true, store.sortAZ),
+  };
+}

--- a/projects/collection-editor-react/src/hooks/useQumlContent.ts
+++ b/projects/collection-editor-react/src/hooks/useQumlContent.ts
@@ -1,0 +1,100 @@
+import { useQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { readQuestionSetHierarchy, getQuestionList } from '../api/question';
+
+const QUESTION_MIME = 'application/vnd.sunbird.question';
+
+interface UseQumlContentOptions {
+  enabled?: boolean;
+}
+
+type Node = Record<string, unknown> & { children?: Node[] };
+
+function maxScoreDecl(source: Node): Record<string, unknown> {
+  return {
+    cardinality: 'single',
+    type: 'integer',
+    defaultValue: (source['maxScore'] as number) ?? 1,
+  };
+}
+
+/**
+ * Fetches and assembles the QuestionSet metadata a QuML player needs.
+ *  - reads the questionset hierarchy
+ *  - collects all question identifiers from the tree
+ *  - fetches full question bodies via /question/v2/list
+ *  - replaces question stubs in the hierarchy with the full data
+ *  - backfills outcomeDeclaration.maxScore where missing
+ * The result is passed straight to <sunbird-quml-player> as `metadata`.
+ */
+export function useQumlContent(
+  questionSetId: string,
+  options?: UseQumlContentOptions,
+): UseQueryResult<Record<string, unknown>, Error> {
+  const enabled = (options?.enabled ?? true) && Boolean(questionSetId);
+
+  return useQuery<Record<string, unknown>, Error>({
+    queryKey: ['quml', 'questionset', questionSetId],
+    enabled,
+    queryFn: async () => {
+      const metadata = (await readQuestionSetHierarchy(questionSetId)) as Node;
+
+      // Collect all question IDs from the hierarchy
+      const collectQuestionIds = (node: Node | undefined): string[] => {
+        if (!node) return [];
+        const currentId =
+          node['mimeType'] === QUESTION_MIME && node['identifier']
+            ? [node['identifier'] as string]
+            : [];
+        const childIds = (node.children ?? []).flatMap(collectQuestionIds);
+        return [...currentId, ...childIds];
+      };
+
+      const questionIds = collectQuestionIds(metadata);
+
+      // Fetch full question data and index it by identifier
+      const questionMap = new Map<string, Node>();
+      if (questionIds.length) {
+        const questions = await getQuestionList(questionIds);
+        questions.forEach((q) => {
+          const id = q['identifier'] as string | undefined;
+          if (id) questionMap.set(id, q as Node);
+        });
+      }
+
+      // Replace question stubs in the hierarchy with full question data
+      const replaceQuestions = (node: Node | undefined): Node | undefined => {
+        if (!node) return node;
+        if (node['mimeType'] === QUESTION_MIME && node['identifier']) {
+          const q = questionMap.get(node['identifier'] as string) ?? node;
+          const outcome = q['outcomeDeclaration'] as
+            | Record<string, unknown>
+            | undefined;
+          if (!outcome?.['maxScore']) {
+            q['outcomeDeclaration'] = { ...(outcome ?? {}), maxScore: maxScoreDecl(q) };
+          }
+          return q;
+        }
+        if (Array.isArray(node.children)) {
+          node.children = node.children.map((c) => replaceQuestions(c) as Node);
+        }
+        return node;
+      };
+
+      const enriched = replaceQuestions(metadata) as Node;
+
+      // Ensure the questionset itself carries an outcomeDeclaration.maxScore
+      const outcome = enriched['outcomeDeclaration'] as
+        | Record<string, unknown>
+        | undefined;
+      if (!outcome?.['maxScore']) {
+        enriched['outcomeDeclaration'] = {
+          ...(outcome ?? {}),
+          maxScore: maxScoreDecl(enriched),
+        };
+      }
+
+      return enriched;
+    },
+  });
+}

--- a/projects/collection-editor-react/src/hooks/useQumlContent.ts
+++ b/projects/collection-editor-react/src/hooks/useQumlContent.ts
@@ -19,6 +19,59 @@ function maxScoreDecl(source: Node): Record<string, unknown> {
 }
 
 /**
+ * Finds a question node and its immediate parent within an enriched hierarchy.
+ */
+function findQuestionWithParent(
+  node: Node | undefined,
+  questionId: string,
+  parent?: Node,
+): { question: Node; parent?: Node } | null {
+  if (!node) return null;
+  if (node['identifier'] === questionId) return { question: node, parent };
+  for (const child of node.children ?? []) {
+    const found = findQuestionWithParent(child, questionId, node);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * Builds a single-question questionset hierarchy from an enriched base set,
+ * mirroring Angular's qumlplayer-page.component.initQumlPlayer(): keep the
+ * questionset shell but expose only the selected question, so the player
+ * renders exactly one question.
+ */
+export function buildSingleQuestionHierarchy(
+  base: Record<string, unknown>,
+  questionId: string,
+): Record<string, unknown> | null {
+  const match = findQuestionWithParent(base as Node, questionId);
+  if (!match) return null;
+  const { question, parent } = match;
+
+  const hierarchy: Record<string, unknown> = {
+    ...base,
+    children: [question],
+    childNodes: [questionId],
+    shuffle: parent?.['shuffle'],
+    showSolutions: (parent?.['showSolutions'] as string) ?? 'No',
+    showFeedback: (parent?.['showFeedback'] as string) ?? 'No',
+  };
+
+  // maxScore rules from Angular: shuffle → 1; short-answer (SA) → omit;
+  // otherwise carry the question's own maxScore.
+  if (parent?.['shuffle'] === true) {
+    hierarchy['maxScore'] = 1;
+  } else if (question['qType'] === 'SA') {
+    delete hierarchy['maxScore'];
+  } else if (question['maxScore'] != null) {
+    hierarchy['maxScore'] = question['maxScore'];
+  }
+
+  return hierarchy;
+}
+
+/**
  * Fetches and assembles the QuestionSet metadata a QuML player needs.
  *  - reads the questionset hierarchy
  *  - collects all question identifiers from the tree

--- a/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
+++ b/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import { useTreeStore } from '../store/tree.store';
 import { useEditorStore } from '../store/editor.store';
 import { updateHierarchy } from '../api/hierarchy';
@@ -171,7 +171,6 @@ function buildSavePayload(
 // ---------------------------------------------------------------------------
 export function useSaveHierarchy() {
   const [isSaving, setIsSaving] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
   const treeCache = useTreeStore((s) => s.treeCache);
   const treeData = useTreeStore((s) => s.treeData);
@@ -202,14 +201,6 @@ export function useSaveHierarchy() {
       setIsSaving(false);
     }
   }, [config, isSaving, treeData, treeCache, setIsDirty, setLastSaved]);
-
-  // Auto-save debounce on dirty changes
-  useEffect(() => {
-    if (!isDirty) return;
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(save, 1500);
-    return () => clearTimeout(timerRef.current);
-  }, [isDirty, treeCache, save]);
 
   return {
     save,

--- a/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
+++ b/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
@@ -7,6 +7,14 @@ import toast from 'react-hot-toast';
 
 // ---------------------------------------------------------------------------
 // Build the nodesModified + hierarchy payload expected by Sunbird v3 API
+//
+// Key rules (derived from the working curl reference request):
+//  1. nodesModified  → root node always; new nodes; folders WITH cached edits only
+//                      Leaf content is NEVER in nodesModified (API ignores it)
+//  2. hierarchy      → ALL nodes (root, folders, leaf content)
+//                      Folder entries include relationalMetadata for any leaf
+//                      children that have cached edits (name/keywords/optional)
+//  3. lastUpdatedBy  → top-level field on `data`, NOT inside nodesModified entries
 // ---------------------------------------------------------------------------
 function buildSavePayload(
   nodes: INode[],
@@ -22,11 +30,12 @@ function buildSavePayload(
   // React-internal fields that must never be sent to the API
   const BASE_STRIP = new Set([
     'id', 'isFolder', 'children', 'parent', 'isNew', 'breadcrumb', 'title',
+    // relationalMetadata is leaf-content-specific; it does not belong in nodesModified metadata
+    'relationalMetadata', 'optional',
   ]);
 
   // Framework fields that require validated term identifiers.
-  // Strip these from the ORIGINAL loaded metadata (may contain stale label-based values)
-  // but ALLOW them when the user explicitly sets them via the form (stored in treeCache).
+  // Strip from ORIGINAL loaded metadata but ALLOW when user explicitly sets via form.
   const FRAMEWORK_STRIP = new Set([
     'targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds',
     'targetSubjectIds', 'targetFWIds', 'targetTopicIds',
@@ -65,21 +74,46 @@ function buildSavePayload(
     return out;
   }
 
+  // Build relationalMetadata for direct leaf-content children of a folder.
+  // The API stores collection-specific resource attributes (name, keywords, optional)
+  // on the PARENT unit's hierarchy entry, not on the resource's nodesModified entry.
+  function buildRelationalMeta(node: INode): Record<string, Record<string, unknown>> {
+    const relMeta: Record<string, Record<string, unknown>> = {};
+    for (const child of node.children ?? []) {
+      if (child.isFolder) continue; // only for leaf content
+      const childCached = treeCache[child.identifier];
+      if (!childCached) continue;
+      const { isNew: _, ...childEdits } = childCached;
+      if (Object.keys(childEdits).length === 0) continue;
+
+      // Merge existing relationalMetadata (from the loaded hierarchy) with user edits.
+      const existingRelMeta = (child.metadata?.relationalMetadata ?? {}) as Record<string, unknown>;
+      relMeta[child.identifier] = {
+        name: child.name,
+        ...existingRelMeta,
+        ...childEdits, // user edits always win
+      };
+    }
+    return relMeta;
+  }
+
   function walk(node: INode, isRoot: boolean) {
     const identifier = node.identifier;
     const cached = treeCache[identifier];
     const isNew = identifier.startsWith('temp-') || !!(cached?.isNew);
 
     // ── nodesModified entry ──────────────────────────────────────────────────
-    // Include if: root, new node, or has cached edits, or is a folder (unit)
-    if (isRoot || isNew || cached || node.isFolder) {
+    // Root: always. New nodes: always. Folders with cached edits: yes.
+    // Leaf content: NEVER (goes into parent's relationalMetadata instead).
+    const isLeaf = !node.isFolder && !isRoot;
+
+    if (isRoot || isNew || (cached && !isLeaf)) {
       let metadata: Record<string, unknown>;
 
       if (isNew) {
-        // New unit: send all required creation fields
         metadata = {
           mimeType: 'application/vnd.ekstep.content-collection',
-          code: identifier, // server replaces temp IDs
+          code: identifier,
           contentType: (node.metadata?.contentType as string) ?? 'CourseUnit',
           primaryCategory: (node.metadata?.primaryCategory as string) ?? 'Course Unit',
           name: node.name,
@@ -88,39 +122,40 @@ function buildSavePayload(
           ...cleanMetadata(node.metadata ?? {}),
         };
       } else if (isRoot) {
-        // Root: strip framework fields from original loaded metadata (may have stale label
-        // values), but let user-edited cache values pass through with their correct identifiers.
         const { isNew: _n, ...cacheEdits } = cached ?? {};
         metadata = {
-          ...cleanMetadata(node.metadata ?? {}, true),   // base: strip framework fields
-          ...cleanMetadata(cacheEdits, false),            // user edits: allow framework fields
+          ...cleanMetadata(node.metadata ?? {}, true),
+          ...cleanMetadata(cacheEdits, false),
           name: node.name,
         };
       } else {
-        // Existing folder: send only cached changes + name, stripped of framework fields
+        // Existing folder (unit) with cached edits
         const { isNew: _n, ...cacheEdits } = cached ?? {};
         metadata = {
           name: node.name,
+          visibility: 'Parent',
           ...cleanMetadata(cacheEdits, true),
         };
       }
 
       nodesModified[identifier] = {
         metadata,
-        objectType: 'Content',
+        objectType: node.objectType || (node.isFolder ? 'Collection' : 'Content'),
         root: isRoot,
         isNew,
       };
     }
 
-    // ── hierarchy entry (folder/collection nodes only) ───────────────────────
-    if (node.isFolder) {
-      hierarchy[identifier] = {
-        name: node.name,
-        children: (node.children ?? []).map((c) => c.identifier),
-        root: isRoot,
-      };
-    }
+    // ── hierarchy entry — ALL nodes ──────────────────────────────────────────
+    // Leaf content appears in hierarchy with empty children[].
+    // Folders also carry relationalMetadata for any edited leaf children.
+    const relMeta = node.isFolder ? buildRelationalMeta(node) : {};
+    hierarchy[identifier] = {
+      name: node.name,
+      children: (node.children ?? []).map((c) => c.identifier),
+      ...(Object.keys(relMeta).length > 0 ? { relationalMetadata: relMeta } : {}),
+      root: isRoot,
+    };
 
     // Recurse
     (node.children ?? []).forEach((child) => walk(child, false));
@@ -151,11 +186,12 @@ export function useSaveHierarchy() {
     if (!contentId) return;
 
     const channel = config.context.channel ?? '';
+    const lastUpdatedBy = config.context.userId ?? config.context.uid ?? '';
 
     setIsSaving(true);
     try {
       const { nodesModified, hierarchy } = buildSavePayload(treeData, treeCache, channel);
-      await updateHierarchy(contentId, nodesModified, hierarchy);
+      await updateHierarchy(contentId, nodesModified, hierarchy, lastUpdatedBy);
       const ts = new Date().toISOString();
       setLastSaved(ts);
       setIsDirty(false);

--- a/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
+++ b/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
@@ -175,6 +175,7 @@ export function useSaveHierarchy() {
   const treeCache = useTreeStore((s) => s.treeCache);
   const treeData = useTreeStore((s) => s.treeData);
   const isDirty = useEditorStore((s) => s.isDirty);
+  const lastSaved = useEditorStore((s) => s.lastSaved);
   const { setIsDirty, setLastSaved } = useEditorStore();
   const config = useEditorStore((s) => s.editorConfig);
 
@@ -190,7 +191,12 @@ export function useSaveHierarchy() {
     setIsSaving(true);
     try {
       const { nodesModified, hierarchy } = buildSavePayload(treeData, treeCache, channel);
-      await updateHierarchy(contentId, nodesModified, hierarchy, lastUpdatedBy);
+      const { identifiers } = await updateHierarchy(contentId, nodesModified, hierarchy, lastUpdatedBy);
+      // Replace temp- ids with server-assigned do_ ids so subsequent saves
+      // don't re-create the same nodes as new duplicates.
+      if (identifiers && Object.keys(identifiers).length > 0) {
+        useTreeStore.getState().replaceNodeIds(identifiers);
+      }
       const ts = new Date().toISOString();
       setLastSaved(ts);
       setIsDirty(false);
@@ -206,6 +212,6 @@ export function useSaveHierarchy() {
     save,
     isSaving,
     isDirty,
-    lastSaved: useEditorStore.getState().lastSaved,
+    lastSaved,
   };
 }

--- a/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
+++ b/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
@@ -47,9 +47,9 @@ function buildSavePayload(
   // because different category definitions use different field codes.
   const ARRAY_FIELDS = new Set([
     'audience', 'attributions', 'keywords', 'language', 'additionalCategories',
-    // Org-framework fields — legacy codes
-    'board', 'medium', 'gradeLevel', 'subject',
-    // Org-framework fields — *Ids codes used by newer category definitions
+    // Org-framework fields — legacy codes (board is scalar; medium/gradeLevel/subject are arrays)
+    'medium', 'gradeLevel', 'subject',
+    // Org-framework fields — *Ids codes used by newer category definitions (all arrays)
     'boardIds', 'mediumIds', 'gradeLevelIds', 'subjectIds',
     // Target-framework fields
     'targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds', 'targetSubjectIds',

--- a/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
+++ b/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
@@ -42,11 +42,19 @@ function buildSavePayload(
     'topic', 'topicsIds',
   ]);
 
-  // Fields the API requires as arrays
+  // Fields the API requires as arrays.
+  // Both legacy names (board/medium/gradeLevel/subject) and *Ids variants are listed
+  // because different category definitions use different field codes.
   const ARRAY_FIELDS = new Set([
-    'audience', 'attributions', 'targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds',
-    'targetSubjectIds', 'medium', 'gradeLevel', 'subject', 'additionalCategories',
-    'keywords', 'language',
+    'audience', 'attributions', 'keywords', 'language', 'additionalCategories',
+    // Org-framework fields — legacy codes
+    'board', 'medium', 'gradeLevel', 'subject',
+    // Org-framework fields — *Ids codes used by newer category definitions
+    'boardIds', 'mediumIds', 'gradeLevelIds', 'subjectIds',
+    // Target-framework fields
+    'targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds', 'targetSubjectIds',
+    // Dial codes
+    'dialcodes',
   ]);
 
   // Fields the API requires as numbers

--- a/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
+++ b/projects/collection-editor-react/src/hooks/useSaveHierarchy.ts
@@ -1,0 +1,184 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useTreeStore } from '../store/tree.store';
+import { useEditorStore } from '../store/editor.store';
+import { updateHierarchy } from '../api/hierarchy';
+import type { INode } from '../types/editor';
+import toast from 'react-hot-toast';
+
+// ---------------------------------------------------------------------------
+// Build the nodesModified + hierarchy payload expected by Sunbird v3 API
+// ---------------------------------------------------------------------------
+function buildSavePayload(
+  nodes: INode[],
+  treeCache: Record<string, Record<string, unknown>>,
+  channel: string,
+): {
+  nodesModified: Record<string, unknown>;
+  hierarchy: Record<string, unknown>;
+} {
+  const nodesModified: Record<string, unknown> = {};
+  const hierarchy: Record<string, unknown> = {};
+
+  // React-internal fields that must never be sent to the API
+  const BASE_STRIP = new Set([
+    'id', 'isFolder', 'children', 'parent', 'isNew', 'breadcrumb', 'title',
+  ]);
+
+  // Framework fields that require validated term identifiers.
+  // Strip these from the ORIGINAL loaded metadata (may contain stale label-based values)
+  // but ALLOW them when the user explicitly sets them via the form (stored in treeCache).
+  const FRAMEWORK_STRIP = new Set([
+    'targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds',
+    'targetSubjectIds', 'targetFWIds', 'targetTopicIds',
+    'topic', 'topicsIds',
+  ]);
+
+  // Fields the API requires as arrays
+  const ARRAY_FIELDS = new Set([
+    'audience', 'attributions', 'targetBoardIds', 'targetMediumIds', 'targetGradeLevelIds',
+    'targetSubjectIds', 'medium', 'gradeLevel', 'subject', 'additionalCategories',
+    'keywords', 'language',
+  ]);
+
+  // Fields the API requires as numbers
+  const NUMBER_FIELDS = new Set(['copyrightYear', 'compatibilityLevel', 'version']);
+
+  function cleanMetadata(
+    raw: Record<string, unknown>,
+    stripFramework = false,
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(raw)) {
+      if (BASE_STRIP.has(k)) continue;
+      if (stripFramework && FRAMEWORK_STRIP.has(k)) continue;
+      if (ARRAY_FIELDS.has(k)) {
+        if (Array.isArray(v)) out[k] = v;
+        else if (v !== null && v !== undefined && v !== '') out[k] = [v];
+        else out[k] = [];
+      } else if (NUMBER_FIELDS.has(k)) {
+        const n = Number(v);
+        if (!isNaN(n)) out[k] = n;
+      } else {
+        out[k] = v;
+      }
+    }
+    return out;
+  }
+
+  function walk(node: INode, isRoot: boolean) {
+    const identifier = node.identifier;
+    const cached = treeCache[identifier];
+    const isNew = identifier.startsWith('temp-') || !!(cached?.isNew);
+
+    // ── nodesModified entry ──────────────────────────────────────────────────
+    // Include if: root, new node, or has cached edits, or is a folder (unit)
+    if (isRoot || isNew || cached || node.isFolder) {
+      let metadata: Record<string, unknown>;
+
+      if (isNew) {
+        // New unit: send all required creation fields
+        metadata = {
+          mimeType: 'application/vnd.ekstep.content-collection',
+          code: identifier, // server replaces temp IDs
+          contentType: (node.metadata?.contentType as string) ?? 'CourseUnit',
+          primaryCategory: (node.metadata?.primaryCategory as string) ?? 'Course Unit',
+          name: node.name,
+          visibility: 'Parent',
+          channel,
+          ...cleanMetadata(node.metadata ?? {}),
+        };
+      } else if (isRoot) {
+        // Root: strip framework fields from original loaded metadata (may have stale label
+        // values), but let user-edited cache values pass through with their correct identifiers.
+        const { isNew: _n, ...cacheEdits } = cached ?? {};
+        metadata = {
+          ...cleanMetadata(node.metadata ?? {}, true),   // base: strip framework fields
+          ...cleanMetadata(cacheEdits, false),            // user edits: allow framework fields
+          name: node.name,
+        };
+      } else {
+        // Existing folder: send only cached changes + name, stripped of framework fields
+        const { isNew: _n, ...cacheEdits } = cached ?? {};
+        metadata = {
+          name: node.name,
+          ...cleanMetadata(cacheEdits, true),
+        };
+      }
+
+      nodesModified[identifier] = {
+        metadata,
+        objectType: 'Content',
+        root: isRoot,
+        isNew,
+      };
+    }
+
+    // ── hierarchy entry (folder/collection nodes only) ───────────────────────
+    if (node.isFolder) {
+      hierarchy[identifier] = {
+        name: node.name,
+        children: (node.children ?? []).map((c) => c.identifier),
+        root: isRoot,
+      };
+    }
+
+    // Recurse
+    (node.children ?? []).forEach((child) => walk(child, false));
+  }
+
+  nodes.forEach((node, i) => walk(node, i === 0));
+
+  return { nodesModified, hierarchy };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+export function useSaveHierarchy() {
+  const [isSaving, setIsSaving] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const treeCache = useTreeStore((s) => s.treeCache);
+  const treeData = useTreeStore((s) => s.treeData);
+  const isDirty = useEditorStore((s) => s.isDirty);
+  const { setIsDirty, setLastSaved } = useEditorStore();
+  const config = useEditorStore((s) => s.editorConfig);
+
+  const save = useCallback(async () => {
+    if (!config || isSaving) return;
+    const contentId =
+      config.context.contentId ?? config.context.identifier ?? '';
+    if (!contentId) return;
+
+    const channel = config.context.channel ?? '';
+
+    setIsSaving(true);
+    try {
+      const { nodesModified, hierarchy } = buildSavePayload(treeData, treeCache, channel);
+      await updateHierarchy(contentId, nodesModified, hierarchy);
+      const ts = new Date().toISOString();
+      setLastSaved(ts);
+      setIsDirty(false);
+    } catch (e) {
+      console.error('[useSaveHierarchy] save failed:', e);
+      toast.error('Failed to save. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [config, isSaving, treeData, treeCache, setIsDirty, setLastSaved]);
+
+  // Auto-save debounce on dirty changes
+  useEffect(() => {
+    if (!isDirty) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(save, 1500);
+    return () => clearTimeout(timerRef.current);
+  }, [isDirty, treeCache, save]);
+
+  return {
+    save,
+    isSaving,
+    isDirty,
+    lastSaved: useEditorStore.getState().lastSaved,
+  };
+}

--- a/projects/collection-editor-react/src/hooks/useTelemetry.ts
+++ b/projects/collection-editor-react/src/hooks/useTelemetry.ts
@@ -1,0 +1,46 @@
+import { useEditorStore } from '../store/editor.store';
+
+interface EData {
+  type: string;
+  subtype?: string;
+  id?: string;
+  pageid?: string;
+  [k: string]: unknown;
+}
+
+type TelemetryWindow = {
+  Telemetry?: {
+    interact: (d: unknown) => void;
+    impression: (d: unknown) => void;
+    error: (d: unknown) => void;
+  };
+};
+
+export function useTelemetry() {
+  const config = useEditorStore((s) => s.editorConfig);
+  const ctx = config?.context;
+
+  function interact(edata: EData) {
+    const win = (typeof window !== 'undefined' ? window : {}) as TelemetryWindow;
+    if (win.Telemetry?.interact) {
+      win.Telemetry.interact({ context: ctx, edata });
+    } else {
+      console.debug('[Telemetry] interact', edata);
+    }
+  }
+
+  function impression(edata: EData) {
+    const win = (typeof window !== 'undefined' ? window : {}) as TelemetryWindow;
+    if (win.Telemetry?.impression) {
+      win.Telemetry.impression({ context: ctx, edata });
+    } else {
+      console.debug('[Telemetry] impression', edata);
+    }
+  }
+
+  function error(edata: EData) {
+    console.error('[Telemetry] error', edata);
+  }
+
+  return { interact, impression, error };
+}

--- a/projects/collection-editor-react/src/hooks/useToolbarActions.ts
+++ b/projects/collection-editor-react/src/hooks/useToolbarActions.ts
@@ -8,6 +8,7 @@ import {
   rejectContent,
   publishContent,
 } from '../api/hierarchy';
+import { findMissingRequiredFields } from '../utils/validateRequiredFields';
 
 /**
  * Centralises the review / publish / reject toolbar flows — mirroring how the
@@ -23,7 +24,44 @@ export function useToolbarActions(save: () => Promise<void>) {
   const config = useEditorStore((s) => s.editorConfig);
   const setButtonLoader = useEditorStore((s) => s.setButtonLoader);
   const validateAllForms = useEditorStore((s) => s.validateAllForms);
+  const rootFormConfig = useEditorStore((s) => s.rootFormConfig);
+  const unitFormConfig = useEditorStore((s) => s.unitFormConfig);
   const treeData = useTreeStore((s) => s.treeData);
+  const treeCache = useTreeStore((s) => s.treeCache);
+  const selectNode = useTreeStore((s) => s.selectNode);
+
+  /**
+   * Tree-wide required-field gate for Save / Send-for-review / Publish.
+   * Unlike validateAllForms (touched-forms only), this validates every
+   * root/unit node's metadata against its form config. On failure: toast the
+   * first offending node + fields, flag the nodes, and select the first one
+   * so its form opens with the errors visible.
+   */
+  const checkRequiredFields = useCallback((): boolean => {
+    const ctx = {
+      editorMode: 'edit' as const,
+      objectType: config?.config?.objectType,
+      userFullName: (config?.context as unknown as { user?: { fullName?: string } })
+        ?.user?.fullName,
+    };
+    const gaps = findMissingRequiredFields(
+      treeData,
+      treeCache,
+      rootFormConfig as Array<Record<string, unknown>> | null,
+      unitFormConfig as Array<Record<string, unknown>> | null,
+      ctx,
+    );
+    if (gaps.length === 0) return true;
+
+    const first = gaps[0];
+    toast.error(
+      `"${first.nodeName}": please fill required field${first.missing.length > 1 ? 's' : ''} — ${first.missing.join(', ')}`,
+    );
+    const { setFormStatus } = useEditorStore.getState();
+    gaps.forEach((g) => setFormStatus(g.nodeId, false));
+    selectNode(first.nodeId);
+    return false;
+  }, [treeData, treeCache, rootFormConfig, unitFormConfig, config, selectNode]);
 
   const runAction = useCallback(
     async (action: ToolbarAction, data?: unknown): Promise<boolean> => {
@@ -39,6 +77,9 @@ export function useToolbarActions(save: () => Promise<void>) {
       try {
         switch (action) {
           case 'sendForReview':
+            // Metadata-level gate (toasts specifics internally), then the
+            // touched-form mapper for format-level errors.
+            if (!checkRequiredFields()) return false;
             if (!validateAllForms(treeData)) {
               toast.error('Some units have missing required fields. Please fill them before sending for review.');
               return false;
@@ -59,6 +100,7 @@ export function useToolbarActions(save: () => Promise<void>) {
           }
 
           case 'publish':
+            if (!checkRequiredFields()) return false;
             if (!validateAllForms(treeData)) {
               toast.error('Some units have missing required fields. Please fill them before publishing.');
               return false;
@@ -88,8 +130,8 @@ export function useToolbarActions(save: () => Promise<void>) {
         setButtonLoader('publishCollection', false);
       }
     },
-    [config, save, setButtonLoader],
+    [config, save, setButtonLoader, checkRequiredFields, validateAllForms, treeData],
   );
 
-  return { runAction };
+  return { runAction, checkRequiredFields };
 }

--- a/projects/collection-editor-react/src/hooks/useToolbarActions.ts
+++ b/projects/collection-editor-react/src/hooks/useToolbarActions.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import toast from 'react-hot-toast';
 import type { ToolbarAction } from '../types/editor';
 import { useEditorStore } from '../store/editor.store';
+import { useTreeStore } from '../store/tree.store';
 import {
   sendForReview as sendForReviewApi,
   rejectContent,
@@ -21,6 +22,8 @@ import {
 export function useToolbarActions(save: () => Promise<void>) {
   const config = useEditorStore((s) => s.editorConfig);
   const setButtonLoader = useEditorStore((s) => s.setButtonLoader);
+  const validateAllForms = useEditorStore((s) => s.validateAllForms);
+  const treeData = useTreeStore((s) => s.treeData);
 
   const runAction = useCallback(
     async (action: ToolbarAction, data?: unknown): Promise<boolean> => {
@@ -36,6 +39,10 @@ export function useToolbarActions(save: () => Promise<void>) {
       try {
         switch (action) {
           case 'sendForReview':
+            if (!validateAllForms(treeData)) {
+              toast.error('Some units have missing required fields. Please fill them before sending for review.');
+              return false;
+            }
             setButtonLoader('saveCollection', true);
             // Persist the hierarchy first (Angular: saveContent() -> reviewContent()).
             await save();
@@ -52,6 +59,10 @@ export function useToolbarActions(save: () => Promise<void>) {
           }
 
           case 'publish':
+            if (!validateAllForms(treeData)) {
+              toast.error('Some units have missing required fields. Please fill them before publishing.');
+              return false;
+            }
             setButtonLoader('publishCollection', true);
             await save();
             await publishContent(contentId, lastUpdatedBy);

--- a/projects/collection-editor-react/src/hooks/useToolbarActions.ts
+++ b/projects/collection-editor-react/src/hooks/useToolbarActions.ts
@@ -1,0 +1,84 @@
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+import type { ToolbarAction } from '../types/editor';
+import { useEditorStore } from '../store/editor.store';
+import {
+  sendForReview as sendForReviewApi,
+  rejectContent,
+  publishContent,
+} from '../api/hierarchy';
+
+/**
+ * Centralises the review / publish / reject toolbar flows — mirroring how the
+ * Angular editor.component handles them internally (save → API → toast).
+ *
+ * The modals (publish checklist, reject comment, send-for-review confirm) only
+ * collect input and emit the action; this hook performs the actual API work so
+ * the buttons function out-of-the-box without the host app implementing them.
+ *
+ * Returns runAction(action, data) -> Promise<boolean> (true on success).
+ */
+export function useToolbarActions(save: () => Promise<void>) {
+  const config = useEditorStore((s) => s.editorConfig);
+  const setButtonLoader = useEditorStore((s) => s.setButtonLoader);
+
+  const runAction = useCallback(
+    async (action: ToolbarAction, data?: unknown): Promise<boolean> => {
+      const contentId =
+        config?.context?.contentId ?? config?.context?.identifier ?? '';
+      if (!contentId) {
+        toast.error('No content identifier found.');
+        return false;
+      }
+      const lastUpdatedBy =
+        config?.context?.userId ?? config?.context?.uid ?? '';
+
+      try {
+        switch (action) {
+          case 'sendForReview':
+            setButtonLoader('saveCollection', true);
+            // Persist the hierarchy first (Angular: saveContent() -> reviewContent()).
+            await save();
+            await sendForReviewApi(contentId);
+            toast.success('Content sent for review');
+            return true;
+
+          case 'reject': {
+            setButtonLoader('rejectCollection', true);
+            const comment = (data as { comment?: string } | undefined)?.comment ?? '';
+            await rejectContent(contentId, comment);
+            toast.success('Content rejected and sent back to the author');
+            return true;
+          }
+
+          case 'publish':
+            setButtonLoader('publishCollection', true);
+            await save();
+            await publishContent(contentId, lastUpdatedBy);
+            toast.success('Content published successfully');
+            return true;
+
+          default:
+            return false;
+        }
+      } catch (err) {
+        console.error(`[useToolbarActions] ${action} failed`, err);
+        const verb =
+          action === 'sendForReview'
+            ? 'send for review'
+            : action === 'reject'
+              ? 'reject'
+              : 'publish';
+        toast.error(`Failed to ${verb}. Please try again.`);
+        return false;
+      } finally {
+        setButtonLoader('saveCollection', false);
+        setButtonLoader('rejectCollection', false);
+        setButtonLoader('publishCollection', false);
+      }
+    },
+    [config, save, setButtonLoader],
+  );
+
+  return { runAction };
+}

--- a/projects/collection-editor-react/src/hooks/useTree.ts
+++ b/projects/collection-editor-react/src/hooks/useTree.ts
@@ -1,0 +1,56 @@
+import { useTreeStore } from '../store/tree.store';
+import type { INode } from '../types/editor';
+import type { IContent } from '../types/content';
+
+export interface UseTreeReturn {
+  treeData: INode[];
+  selectedNode: INode | undefined;
+  selectedNodeId: string | null;
+  breadcrumb: Array<{ id: string; name: string }>;
+  isFolder: boolean;
+  isRoot: boolean;
+  children: INode[];
+  addNode: (parentId: string, type: 'unit' | 'subunit') => string;
+  deleteNode: (id: string) => void;
+  addResource: (content: IContent, nodeId: string) => void;
+  reorderChildren: (parentId: string, fromIndex: number, toIndex: number) => void;
+  updateNode: (id: string, patch: Record<string, unknown>) => void;
+  getNodeById: (id: string) => INode | undefined;
+  selectNode: (id: string) => void;
+}
+
+export function useTree(): UseTreeReturn {
+  const treeData = useTreeStore((s) => s.treeData);
+  const selectedNodeId = useTreeStore((s) => s.selectedNodeId);
+  const breadcrumb = useTreeStore((s) => s.breadcrumb);
+  const addNode = useTreeStore((s) => s.addNode);
+  const deleteNode = useTreeStore((s) => s.deleteNode);
+  const addResource = useTreeStore((s) => s.addResource);
+  const reorderChildren = useTreeStore((s) => s.reorderChildren);
+  const updateNode = useTreeStore((s) => s.updateNode);
+  const getNodeById = useTreeStore((s) => s.getNodeById);
+  const getChildrenOf = useTreeStore((s) => s.getChildrenOf);
+  const selectNode = useTreeStore((s) => s.selectNode);
+
+  const selectedNode = selectedNodeId ? getNodeById(selectedNodeId) : undefined;
+  const isFolder = selectedNode?.isFolder ?? false;
+  const isRoot = !selectedNode?.parent;
+  const children = selectedNodeId ? getChildrenOf(selectedNodeId) : [];
+
+  return {
+    treeData,
+    selectedNode,
+    selectedNodeId,
+    breadcrumb,
+    isFolder,
+    isRoot,
+    children,
+    addNode,
+    deleteNode,
+    addResource,
+    reorderChildren,
+    updateNode,
+    getNodeById,
+    selectNode,
+  };
+}

--- a/projects/collection-editor-react/src/hooks/useUserFullName.ts
+++ b/projects/collection-editor-react/src/hooks/useUserFullName.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { readUser } from '../api/user';
+
+/**
+ * Display name of a user, for auto-filling the author field.
+ * firstName + lastName (trimmed), falling back to userName.
+ * Cached indefinitely — a user's name doesn't change within a session.
+ */
+export function useUserFullName(userId?: string): string | undefined {
+  const { data } = useQuery({
+    queryKey: ['user', 'read', userId],
+    enabled: !!userId,
+    staleTime: Infinity,
+    queryFn: () => readUser(userId!),
+  });
+  if (!data) return undefined;
+  const name = [data.firstName, data.lastName].filter(Boolean).join(' ').trim();
+  return name || data.userName || undefined;
+}

--- a/projects/collection-editor-react/src/index.ts
+++ b/projects/collection-editor-react/src/index.ts
@@ -5,3 +5,4 @@ export type { IContent, ILibraryItem } from './types/content';
 export type { IFramework, ICategory, ITerm, IFrameworkDetails } from './types/framework';
 export { registerCollectionEditor } from './web-component/register';
 export { useEditorStore, useTreeStore, useLibraryStore } from './store';
+export { setApiBaseUrl } from './api/client';

--- a/projects/collection-editor-react/src/index.ts
+++ b/projects/collection-editor-react/src/index.ts
@@ -1,0 +1,7 @@
+export { CollectionEditor } from './components/CollectionEditor';
+export type { CollectionEditorProps } from './components/CollectionEditor';
+export type { IEditorConfig, IEditorEvents, INode, EditorMode, ToolbarAction, IButtonLoaders, IUser, IContext, IConfig } from './types/editor';
+export type { IContent, ILibraryItem } from './types/content';
+export type { IFramework, ICategory, ITerm, IFrameworkDetails } from './types/framework';
+export { registerCollectionEditor } from './web-component/register';
+export { useEditorStore, useTreeStore, useLibraryStore } from './store';

--- a/projects/collection-editor-react/src/scss.d.ts
+++ b/projects/collection-editor-react/src/scss.d.ts
@@ -1,0 +1,9 @@
+declare module '*.module.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.scss' {
+  const content: string;
+  export default content;
+}

--- a/projects/collection-editor-react/src/services/quml/QumlPlayerService.ts
+++ b/projects/collection-editor-react/src/services/quml/QumlPlayerService.ts
@@ -10,6 +10,8 @@ export interface QumlContextProps {
   cdata?: unknown[];
   contextRollup?: Record<string, string>;
   objectRollup?: Record<string, string>;
+  /** When true, configures the player to render exactly one question. */
+  singleQuestion?: boolean;
 }
 
 export interface QumlPlayerConfig {
@@ -95,6 +97,16 @@ export class QumlPlayerService {
   ): Promise<QumlPlayerConfig> {
     await this.loadScript();
 
+    // Single-question preview: constrain the set to one question and strip the
+    // start/timer/legend chrome, mirroring Angular's isSingleQuestionPreview.
+    const playerMetadata: Record<string, unknown> = { ...metadata };
+    if (props?.singleQuestion) {
+      playerMetadata['maxQuestions'] = 1;
+      playerMetadata['showStartPage'] = 'No';
+      playerMetadata['showTimer'] = 'No';
+      playerMetadata['requiresSubmit'] = 'No';
+    }
+
     const context: Record<string, unknown> = {
       mode: props?.mode ?? 'play',
       pdata: {
@@ -111,6 +123,7 @@ export class QumlPlayerService {
       contextRollup: props?.contextRollup ?? ctx?.rollup ?? {},
       objectRollup: props?.objectRollup ?? {},
       ...(props?.cdata ? { cdata: props.cdata } : {}),
+      ...(props?.singleQuestion ? { threshold: 1 } : {}),
     };
 
     return {
@@ -123,8 +136,9 @@ export class QumlPlayerService {
           showReplay: true,
           showExit: false,
         },
+        ...(props?.singleQuestion ? { showLegend: false } : {}),
       },
-      metadata,
+      metadata: playerMetadata,
     };
   }
 

--- a/projects/collection-editor-react/src/services/quml/QumlPlayerService.ts
+++ b/projects/collection-editor-react/src/services/quml/QumlPlayerService.ts
@@ -1,0 +1,162 @@
+import type { IContext } from '../../types/editor';
+
+const SCRIPT_SRC = '/assets/quml-player/sunbird-quml-player.js';
+const STYLES_HREF = '/assets/quml-player/styles.css';
+const QUESTION_LIST_URL = '/action/question/v2/list';
+const TAG = 'sunbird-quml-player';
+
+export interface QumlContextProps {
+  mode?: string;
+  cdata?: unknown[];
+  contextRollup?: Record<string, string>;
+  objectRollup?: Record<string, string>;
+}
+
+export interface QumlPlayerConfig {
+  context: Record<string, unknown>;
+  config: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Owns the lifecycle of the <sunbird-quml-player> web component:
+ * script/style loading, element creation, and event wiring.
+ * Ported from spark-portal's QumlPlayerService, with the telemetry context
+ * built from the editor's IContext instead of portal identity singletons.
+ */
+export class QumlPlayerService {
+  private eventHandlers = new WeakMap<
+    HTMLElement,
+    { player: (e: Event) => void; telemetry: (e: Event) => void }
+  >();
+  private static scriptLoaded = false;
+  private static scriptLoading?: Promise<void>;
+  private static stylesLoaded = false;
+
+  private loadScript(): Promise<void> {
+    if (QumlPlayerService.scriptLoaded || customElements.get(TAG)) {
+      QumlPlayerService.scriptLoaded = true;
+      return Promise.resolve();
+    }
+    if (QumlPlayerService.scriptLoading) return QumlPlayerService.scriptLoading;
+
+    QumlPlayerService.scriptLoading = new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = SCRIPT_SRC;
+      script.setAttribute('data-quml-player-script', 'true');
+      script.onload = () => {
+        QumlPlayerService.scriptLoaded = true;
+        QumlPlayerService.scriptLoading = undefined;
+        resolve();
+      };
+      script.onerror = () => {
+        QumlPlayerService.scriptLoading = undefined;
+        reject(new Error(`Failed to load QuML player script: ${SCRIPT_SRC}`));
+      };
+      document.body.appendChild(script);
+    });
+    return QumlPlayerService.scriptLoading;
+  }
+
+  private loadStyles(): void {
+    // The web component fetches individual questions from this URL.
+    (window as unknown as Record<string, unknown>)['questionListUrl'] =
+      QUESTION_LIST_URL;
+
+    if (
+      QumlPlayerService.stylesLoaded ||
+      document.querySelector('[data-quml-player-styles="true"]')
+    ) {
+      QumlPlayerService.stylesLoaded = true;
+      return;
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = STYLES_HREF;
+    link.setAttribute('data-quml-player-styles', 'true');
+    document.head.appendChild(link);
+    QumlPlayerService.stylesLoaded = true;
+  }
+
+  /** Removes the QuML stylesheet on unmount to prevent style bleed. */
+  static unloadStyles(): void {
+    document.querySelector('[data-quml-player-styles="true"]')?.remove();
+    QumlPlayerService.stylesLoaded = false;
+  }
+
+  /**
+   * Waits for the web component script to load, then assembles the player
+   * config from the editor context + enriched questionset metadata.
+   */
+  async createConfig(
+    metadata: Record<string, unknown>,
+    ctx: IContext | undefined,
+    props?: QumlContextProps,
+  ): Promise<QumlPlayerConfig> {
+    await this.loadScript();
+
+    const context: Record<string, unknown> = {
+      mode: props?.mode ?? 'play',
+      pdata: {
+        id: ctx?.pdata?.id ?? 'sunbird.portal',
+        ver: ctx?.pdata?.ver ?? '1.0',
+        pid: ctx?.pdata?.pid ?? 'sunbird-portal',
+      },
+      contentId: (metadata['identifier'] as string) ?? '',
+      sid: ctx?.sid ?? '',
+      uid: ctx?.uid ?? ctx?.userId ?? '',
+      channel: ctx?.channel ?? '',
+      did: ctx?.did ?? '',
+      tags: ctx?.tags ?? [],
+      contextRollup: props?.contextRollup ?? ctx?.rollup ?? {},
+      objectRollup: props?.objectRollup ?? {},
+      ...(props?.cdata ? { cdata: props.cdata } : {}),
+    };
+
+    return {
+      context,
+      config: {
+        sideMenu: {
+          enable: false,
+          showShare: false,
+          showDownload: false,
+          showReplay: true,
+          showExit: false,
+        },
+      },
+      metadata,
+    };
+  }
+
+  createElement(config: QumlPlayerConfig): HTMLElement {
+    this.loadStyles();
+    const el = document.createElement(TAG);
+    el.setAttribute('player-config', JSON.stringify(config));
+    el.setAttribute('data-player-id', (config.metadata['identifier'] as string) ?? 'quml');
+    return el;
+  }
+
+  attachEventListeners(
+    el: HTMLElement,
+    onPlayerEvent?: (e: CustomEvent) => void,
+    onTelemetryEvent?: (e: unknown) => void,
+  ): void {
+    this.removeEventListeners(el);
+    const player = (e: Event) => onPlayerEvent?.(e as CustomEvent);
+    const telemetry = (e: Event) => onTelemetryEvent?.((e as CustomEvent).detail);
+    el.addEventListener('playerEvent', player);
+    el.addEventListener('telemetryEvent', telemetry);
+    this.eventHandlers.set(el, { player, telemetry });
+  }
+
+  removeEventListeners(el: HTMLElement): void {
+    const handlers = this.eventHandlers.get(el);
+    if (handlers) {
+      el.removeEventListener('playerEvent', handlers.player);
+      el.removeEventListener('telemetryEvent', handlers.telemetry);
+      this.eventHandlers.delete(el);
+    }
+  }
+}
+
+export const qumlPlayerService = new QumlPlayerService();

--- a/projects/collection-editor-react/src/services/quml/QumlPlayerService.ts
+++ b/projects/collection-editor-react/src/services/quml/QumlPlayerService.ts
@@ -2,7 +2,6 @@ import type { IContext } from '../../types/editor';
 
 const SCRIPT_SRC = '/assets/quml-player/sunbird-quml-player.js';
 const STYLES_HREF = '/assets/quml-player/styles.css';
-const QUESTION_LIST_URL = '/action/question/v2/list';
 const TAG = 'sunbird-quml-player';
 
 export interface QumlContextProps {
@@ -10,14 +9,30 @@ export interface QumlContextProps {
   cdata?: unknown[];
   contextRollup?: Record<string, string>;
   objectRollup?: Record<string, string>;
-  /** When true, configures the player to render exactly one question. */
-  singleQuestion?: boolean;
 }
 
 export interface QumlPlayerConfig {
   context: Record<string, unknown>;
   config: Record<string, unknown>;
+  /** React-player load source: inline sections (preferred) or identifier self-fetch. */
+  data: Record<string, unknown>;
   metadata: Record<string, unknown>;
+}
+
+/**
+ * Derives the react player's inline `sections` from a questionset hierarchy
+ * whose questions are already inlined (useQumlContent output). Mirrors the
+ * player's own section derivation: a set whose children are all Questions is
+ * a single section; otherwise each child unit is a section.
+ */
+function toSections(
+  hierarchy: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const children =
+    (hierarchy['children'] as Array<Record<string, unknown>> | undefined) ?? [];
+  if (!children.length) return [];
+  const allQuestions = children.every((c) => c['objectType'] === 'Question');
+  return allQuestions ? [hierarchy] : children;
 }
 
 /**
@@ -61,10 +76,6 @@ export class QumlPlayerService {
   }
 
   private loadStyles(): void {
-    // The web component fetches individual questions from this URL.
-    (window as unknown as Record<string, unknown>)['questionListUrl'] =
-      QUESTION_LIST_URL;
-
     if (
       QumlPlayerService.stylesLoaded ||
       document.querySelector('[data-quml-player-styles="true"]')
@@ -97,18 +108,11 @@ export class QumlPlayerService {
   ): Promise<QumlPlayerConfig> {
     await this.loadScript();
 
-    // Single-question preview: constrain the set to one question and strip the
-    // start/timer/legend chrome, mirroring Angular's isSingleQuestionPreview.
-    const playerMetadata: Record<string, unknown> = { ...metadata };
-    if (props?.singleQuestion) {
-      playerMetadata['maxQuestions'] = 1;
-      playerMetadata['showStartPage'] = 'No';
-      playerMetadata['showTimer'] = 'No';
-      playerMetadata['requiresSubmit'] = 'No';
-    }
-
     const context: Record<string, unknown> = {
       mode: props?.mode ?? 'play',
+      // Same-origin base for the player's identifier self-fetch fallback
+      // (/learner/questionset/v2/hierarchy + /api/question/v2/list).
+      host: '',
       pdata: {
         id: ctx?.pdata?.id ?? 'sunbird.portal',
         ver: ctx?.pdata?.ver ?? '1.0',
@@ -123,22 +127,21 @@ export class QumlPlayerService {
       contextRollup: props?.contextRollup ?? ctx?.rollup ?? {},
       objectRollup: props?.objectRollup ?? {},
       ...(props?.cdata ? { cdata: props.cdata } : {}),
-      ...(props?.singleQuestion ? { threshold: 1 } : {}),
     };
 
     return {
       context,
-      config: {
-        sideMenu: {
-          enable: false,
-          showShare: false,
-          showDownload: false,
-          showReplay: true,
-          showExit: false,
-        },
-        ...(props?.singleQuestion ? { showLegend: false } : {}),
+      config: { language: 'en' },
+      // Inline sections render with no network call — required for draft
+      // preview, since the player's identifier self-fetch hits the published
+      // /learner endpoint. identifier is kept as a graceful fallback should
+      // the inline payload fail to normalize.
+      data: {
+        sections: toSections(metadata),
+        identifier: (metadata['identifier'] as string) ?? '',
       },
-      metadata: playerMetadata,
+      // Used by the player for media basePath resolution.
+      metadata,
     };
   }
 

--- a/projects/collection-editor-react/src/store/editor.store.ts
+++ b/projects/collection-editor-react/src/store/editor.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import type { IEditorConfig, EditorMode, IButtonLoaders } from '../types/editor';
-import type { ICategoryDefinitionField } from '../api/categoryDefinition';
+import type { ICategoryField, IParsedCategoryDefinition } from '../api/categoryDefinition';
 
 interface EditorState {
   editorConfig: IEditorConfig | null;
@@ -13,8 +13,19 @@ interface EditorState {
   isQumlPlayer: boolean;
   isDirty: boolean;
   lastSaved: string | null;
-  rootFormConfig: ICategoryDefinitionField[] | null;
-  unitFormConfig: ICategoryDefinitionField[] | null;
+  rootFormConfig: ICategoryField[] | null;
+  unitFormConfig: ICategoryField[] | null;
+  childFormConfig: ICategoryField[] | null;
+  searchFormConfig: ICategoryField[] | null;
+  relationalFormConfig: ICategoryField[] | null;
+  publishChecklist: ICategoryField[] | null;
+  reviewChecklist: ICategoryField[] | null;
+  rfcChecklist: ICategoryField[] | null;
+  categoryMeta: {
+    schemaDefaults: Record<string, unknown>;
+    frameworkMetadata: { orgFWType?: string[]; targetFWType?: string[] };
+    sourcingSettings: Record<string, unknown>;
+  } | null;
   // actions
   setEditorConfig: (config: IEditorConfig) => void;
   setEditorMode: (mode: EditorMode) => void;
@@ -24,7 +35,7 @@ interface EditorState {
   setNodeFlags: (flags: { isFolder?: boolean; isRoot?: boolean; isQuml?: boolean }) => void;
   setLastSaved: (ts: string) => void;
   setIsDirty: (dirty: boolean) => void;
-  setFormConfigs: (rootFields: ICategoryDefinitionField[], unitFields: ICategoryDefinitionField[]) => void;
+  setCategoryDefinition: (parsed: IParsedCategoryDefinition) => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -48,6 +59,13 @@ export const useEditorStore = create<EditorState>((set) => ({
   lastSaved: null,
   rootFormConfig: null,
   unitFormConfig: null,
+  childFormConfig: null,
+  searchFormConfig: null,
+  relationalFormConfig: null,
+  publishChecklist: null,
+  reviewChecklist: null,
+  rfcChecklist: null,
+  categoryMeta: null,
 
   setEditorConfig: (config) => set({ editorConfig: config }),
   setEditorMode: (mode) => set({ editorMode: mode }),
@@ -65,7 +83,22 @@ export const useEditorStore = create<EditorState>((set) => ({
     }),
   setLastSaved: (ts) => set({ lastSaved: ts }),
   setIsDirty: (dirty) => set({ isDirty: dirty }),
-  setFormConfigs: (rootFields, unitFields) => set({ rootFormConfig: rootFields, unitFormConfig: unitFields }),
+  setCategoryDefinition: (parsed) =>
+    set({
+      rootFormConfig: parsed.rootForm,
+      unitFormConfig: parsed.unitForm,
+      childFormConfig: parsed.childForm,
+      searchFormConfig: parsed.searchForm,
+      relationalFormConfig: parsed.relationalForm,
+      publishChecklist: parsed.publishChecklist,
+      reviewChecklist: parsed.reviewChecklist,
+      rfcChecklist: parsed.rfcChecklist,
+      categoryMeta: {
+        schemaDefaults: parsed.schemaDefaults,
+        frameworkMetadata: parsed.frameworkMetadata,
+        sourcingSettings: parsed.sourcingSettings,
+      },
+    }),
 }));
 
 export const getEditorStore = () => useEditorStore.getState;

--- a/projects/collection-editor-react/src/store/editor.store.ts
+++ b/projects/collection-editor-react/src/store/editor.store.ts
@@ -26,6 +26,9 @@ interface EditorState {
     frameworkMetadata: { orgFWType?: string[]; targetFWType?: string[] };
     sourcingSettings: Record<string, unknown>;
   } | null;
+  // Per-node form validity map — mirrors Angular's formStatusMapper.
+  // Keys are node ids; value is false only when the form has been touched and is invalid.
+  formStatusMapper: Record<string, boolean>;
   // actions
   setEditorConfig: (config: IEditorConfig) => void;
   setEditorMode: (mode: EditorMode) => void;
@@ -36,6 +39,8 @@ interface EditorState {
   setLastSaved: (ts: string) => void;
   setIsDirty: (dirty: boolean) => void;
   setCategoryDefinition: (parsed: IParsedCategoryDefinition) => void;
+  setFormStatus: (nodeId: string, isValid: boolean) => void;
+  validateAllForms: (treeNodes: import('../types/editor').INode[]) => boolean;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -57,6 +62,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   isQumlPlayer: false,
   isDirty: false,
   lastSaved: null,
+  formStatusMapper: {},
   rootFormConfig: null,
   unitFormConfig: null,
   childFormConfig: null,
@@ -83,6 +89,20 @@ export const useEditorStore = create<EditorState>((set) => ({
     }),
   setLastSaved: (ts) => set({ lastSaved: ts }),
   setIsDirty: (dirty) => set({ isDirty: dirty }),
+  setFormStatus: (nodeId, isValid) =>
+    set((state) => ({
+      formStatusMapper: { ...state.formStatusMapper, [nodeId]: isValid },
+    })),
+  validateAllForms: (treeNodes) => {
+    const mapper = useEditorStore.getState().formStatusMapper;
+    const queue = [...treeNodes];
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+      if (mapper[node.id] === false) return false;
+      if (node.children) queue.push(...node.children);
+    }
+    return true;
+  },
   setCategoryDefinition: (parsed) =>
     set({
       rootFormConfig: parsed.rootForm,

--- a/projects/collection-editor-react/src/store/editor.store.ts
+++ b/projects/collection-editor-react/src/store/editor.store.ts
@@ -29,6 +29,11 @@ interface EditorState {
   // Per-node form validity map — mirrors Angular's formStatusMapper.
   // Keys are node ids; value is false only when the form has been touched and is invalid.
   formStatusMapper: Record<string, boolean>;
+  // Framework resolved from the loaded collection (rootNode.framework /
+  // targetFWIds). Mirrors Angular's `collection.framework || context.framework`
+  // precedence — the content's own framework wins over the editor context.
+  contentFramework: string | null;
+  contentTargetFWIds: string[] | null;
   // actions
   setEditorConfig: (config: IEditorConfig) => void;
   setEditorMode: (mode: EditorMode) => void;
@@ -39,6 +44,7 @@ interface EditorState {
   setLastSaved: (ts: string) => void;
   setIsDirty: (dirty: boolean) => void;
   setCategoryDefinition: (parsed: IParsedCategoryDefinition) => void;
+  setContentFramework: (framework: string | null, targetFWIds: string[] | null) => void;
   setFormStatus: (nodeId: string, isValid: boolean) => void;
   validateAllForms: (treeNodes: import('../types/editor').INode[]) => boolean;
 }
@@ -63,6 +69,8 @@ export const useEditorStore = create<EditorState>((set) => ({
   isDirty: false,
   lastSaved: null,
   formStatusMapper: {},
+  contentFramework: null,
+  contentTargetFWIds: null,
   rootFormConfig: null,
   unitFormConfig: null,
   childFormConfig: null,
@@ -89,6 +97,8 @@ export const useEditorStore = create<EditorState>((set) => ({
     }),
   setLastSaved: (ts) => set({ lastSaved: ts }),
   setIsDirty: (dirty) => set({ isDirty: dirty }),
+  setContentFramework: (framework, targetFWIds) =>
+    set({ contentFramework: framework, contentTargetFWIds: targetFWIds }),
   setFormStatus: (nodeId, isValid) =>
     set((state) => ({
       formStatusMapper: { ...state.formStatusMapper, [nodeId]: isValid },

--- a/projects/collection-editor-react/src/store/editor.store.ts
+++ b/projects/collection-editor-react/src/store/editor.store.ts
@@ -1,0 +1,71 @@
+import { create } from 'zustand';
+import type { IEditorConfig, EditorMode, IButtonLoaders } from '../types/editor';
+import type { ICategoryDefinitionField } from '../api/categoryDefinition';
+
+interface EditorState {
+  editorConfig: IEditorConfig | null;
+  editorMode: EditorMode;
+  buttonLoaders: IButtonLoaders;
+  showPreview: boolean;
+  pageId: string;
+  isCurrentNodeFolder: boolean;
+  isCurrentNodeRoot: boolean;
+  isQumlPlayer: boolean;
+  isDirty: boolean;
+  lastSaved: string | null;
+  rootFormConfig: ICategoryDefinitionField[] | null;
+  unitFormConfig: ICategoryDefinitionField[] | null;
+  // actions
+  setEditorConfig: (config: IEditorConfig) => void;
+  setEditorMode: (mode: EditorMode) => void;
+  setButtonLoader: (key: keyof IButtonLoaders, value: boolean) => void;
+  setShowPreview: (show: boolean) => void;
+  setPageId: (pageId: string) => void;
+  setNodeFlags: (flags: { isFolder?: boolean; isRoot?: boolean; isQuml?: boolean }) => void;
+  setLastSaved: (ts: string) => void;
+  setIsDirty: (dirty: boolean) => void;
+  setFormConfigs: (rootFields: ICategoryDefinitionField[], unitFields: ICategoryDefinitionField[]) => void;
+}
+
+export const useEditorStore = create<EditorState>((set) => ({
+  editorConfig: null,
+  editorMode: 'edit',
+  buttonLoaders: {
+    saveCollection: false,
+    publishCollection: false,
+    addFromLibrary: false,
+    rejectCollection: false,
+    sendBackCollection: false,
+    sourcingApproveCollection: false,
+    sourcingRejectCollection: false,
+  },
+  showPreview: false,
+  pageId: 'collection_editor',
+  isCurrentNodeFolder: false,
+  isCurrentNodeRoot: false,
+  isQumlPlayer: false,
+  isDirty: false,
+  lastSaved: null,
+  rootFormConfig: null,
+  unitFormConfig: null,
+
+  setEditorConfig: (config) => set({ editorConfig: config }),
+  setEditorMode: (mode) => set({ editorMode: mode }),
+  setButtonLoader: (key, value) =>
+    set((state) => ({
+      buttonLoaders: { ...state.buttonLoaders, [key]: value },
+    })),
+  setShowPreview: (show) => set({ showPreview: show }),
+  setPageId: (pageId) => set({ pageId }),
+  setNodeFlags: (flags) =>
+    set({
+      ...(flags.isFolder !== undefined && { isCurrentNodeFolder: flags.isFolder }),
+      ...(flags.isRoot !== undefined && { isCurrentNodeRoot: flags.isRoot }),
+      ...(flags.isQuml !== undefined && { isQumlPlayer: flags.isQuml }),
+    }),
+  setLastSaved: (ts) => set({ lastSaved: ts }),
+  setIsDirty: (dirty) => set({ isDirty: dirty }),
+  setFormConfigs: (rootFields, unitFields) => set({ rootFormConfig: rootFields, unitFormConfig: unitFields }),
+}));
+
+export const getEditorStore = () => useEditorStore.getState;

--- a/projects/collection-editor-react/src/store/index.ts
+++ b/projects/collection-editor-react/src/store/index.ts
@@ -1,0 +1,3 @@
+export * from './editor.store';
+export * from './tree.store';
+export * from './library.store';

--- a/projects/collection-editor-react/src/store/library.store.ts
+++ b/projects/collection-editor-react/src/store/library.store.ts
@@ -1,0 +1,95 @@
+import { create } from 'zustand';
+import type { IContent } from '../types/content';
+import type { LibraryFilters } from '../components/LibraryDock/LibraryFilterPanel';
+
+interface LibraryState {
+  allContent: IContent[];
+  filteredContent: IContent[];
+  searchQuery: string;
+  activeFilter: string;
+  advancedFilters: LibraryFilters;
+  isLoading: boolean;
+  totalCount: number;
+  offset: number;
+  sortAZ: boolean;
+  // actions
+  setContent: (content: IContent[], total: number) => void;
+  appendContent: (content: IContent[], total: number) => void;
+  setFilter: (filter: string) => void;
+  setSearch: (query: string) => void;
+  setLoading: (loading: boolean) => void;
+  setAdvancedFilters: (filters: LibraryFilters) => void;
+  setOffset: (offset: number) => void;
+  setSortAZ: (sortAZ: boolean) => void;
+  applyFilter: () => void;
+}
+
+export const useLibraryStore = create<LibraryState>((set, get) => ({
+  allContent: [],
+  filteredContent: [],
+  searchQuery: '',
+  activeFilter: 'all',
+  advancedFilters: {},
+  isLoading: false,
+  totalCount: 0,
+  offset: 0,
+  sortAZ: false,
+
+  setContent: (content, total) => {
+    set({ allContent: content, totalCount: total, offset: content.length });
+    get().applyFilter();
+  },
+
+  appendContent: (content, total) => {
+    const current = get().allContent;
+    const merged = [...current, ...content];
+    set({ allContent: merged, totalCount: total, offset: merged.length });
+    get().applyFilter();
+  },
+
+  setFilter: (filter) => {
+    set({ activeFilter: filter });
+    get().applyFilter();
+  },
+
+  setSearch: (query) => {
+    set({ searchQuery: query });
+    get().applyFilter();
+  },
+
+  setLoading: (loading) => set({ isLoading: loading }),
+
+  setAdvancedFilters: (filters) => set({ advancedFilters: filters }),
+
+  setOffset: (offset) => set({ offset }),
+
+  setSortAZ: (sortAZ) => set({ sortAZ }),
+
+  applyFilter: () => {
+    const { allContent, activeFilter, searchQuery } = get();
+    let filtered = allContent;
+
+    if (activeFilter && activeFilter !== 'all') {
+      const filterLower = activeFilter.toLowerCase();
+      filtered = filtered.filter((item) => {
+        const combined = [
+          item.mimeType ?? '',
+          item.primaryCategory ?? '',
+          item.contentType ?? '',
+        ]
+          .join(' ')
+          .toLowerCase();
+        return combined.includes(filterLower);
+      });
+    }
+
+    if (searchQuery && searchQuery.trim() !== '') {
+      const queryLower = searchQuery.toLowerCase().trim();
+      filtered = filtered.filter((item) =>
+        (item.name ?? '').toLowerCase().includes(queryLower),
+      );
+    }
+
+    set({ filteredContent: filtered });
+  },
+}));

--- a/projects/collection-editor-react/src/store/tree.store.ts
+++ b/projects/collection-editor-react/src/store/tree.store.ts
@@ -172,6 +172,9 @@ export const useTreeStore = create<TreeState>((set, get) => ({
         [id]: { ...(state.treeCache[id] ?? {}), ...patch },
       },
     }));
+    // Any node edit (root/unit/leaf form, inline title) must mark the tree
+    // dirty so the debounced autosave in useSaveHierarchy actually runs.
+    useEditorStore.getState().setIsDirty(true);
   },
 
   addNode: (parentId, _type) => {

--- a/projects/collection-editor-react/src/store/tree.store.ts
+++ b/projects/collection-editor-react/src/store/tree.store.ts
@@ -205,7 +205,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     }));
     // Any node edit (root/unit/leaf form, inline title) must mark the tree
     // dirty so the debounced autosave in useSaveHierarchy actually runs.
-    useEditorStore.getState().setIsDirty(true);
+    get().markDirty();
   },
 
   addNode: (parentId, _type) => {
@@ -270,7 +270,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
       newTree = insertIntoParent(newTree, toParentId, { ...node, parent: toParentId });
       return { treeData: newTree };
     });
-    useEditorStore.getState().setIsDirty(true);
+    get().markDirty();
   },
 
   addResource: (content, nodeId) => {
@@ -318,7 +318,11 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   },
 
   markDirty: () => {
-    useEditorStore.getState().setIsDirty(true);
+    // View modes (review/read/sourcingreview) never dirty the tree — form
+    // mount-time normalization fires updateNode even when just viewing, which
+    // would otherwise show "Unsaved" and trigger the back-guard.
+    const { editorMode, setIsDirty } = useEditorStore.getState();
+    if (editorMode === 'edit') setIsDirty(true);
   },
 
   replaceNodeIds: (identifiers) => {

--- a/projects/collection-editor-react/src/store/tree.store.ts
+++ b/projects/collection-editor-react/src/store/tree.store.ts
@@ -153,13 +153,12 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     // are included in activeNodeMeta and available to SparkMetaForm on remount.
     const activeNodeMeta = { ...(node?.metadata ?? {}), ...(treeCache[id] ?? {}) };
 
-    // Update editor store node flags (lazy to avoid circular)
-    import('../store/editor.store').then(({ useEditorStore: editorStore }) => {
-      editorStore.getState().setNodeFlags({
-        isFolder: node?.isFolder ?? false,
-        isRoot: !node?.parent,
-        isQuml: false,
-      });
+    // Update editor store node flags synchronously so consumers don't read a
+    // stale isRoot/isFolder for a render after the node changes.
+    useEditorStore.getState().setNodeFlags({
+      isFolder: node?.isFolder ?? false,
+      isRoot: !node?.parent,
+      isQuml: false,
     });
 
     set({ selectedNodeId: id, breadcrumb, activeNodeMeta });

--- a/projects/collection-editor-react/src/store/tree.store.ts
+++ b/projects/collection-editor-react/src/store/tree.store.ts
@@ -22,6 +22,7 @@ interface TreeState {
   getChildrenOf: (id: string) => INode[];
   getBreadcrumb: (id: string) => Array<{ id: string; name: string }>;
   moveNode: (nodeId: string, fromParentId: string, toParentId: string) => void;
+  replaceNodeIds: (identifiers: Record<string, string>) => void;
 }
 
 // BFS through treeData to find a node by id
@@ -49,7 +50,10 @@ function getNodeDepth(nodes: INode[], targetId: string, depth = 0): number {
 
 // Deep merge a patch into a node's properties within a tree
 // Fields that live both on INode top-level AND inside node.metadata
-const METADATA_MIRROR_FIELDS = new Set(['name', 'appIcon', 'description', 'keywords', 'trackable']);
+const METADATA_MIRROR_FIELDS = new Set([
+  'name', 'appIcon', 'description', 'keywords', 'trackable',
+  'qrCodeProcessId', 'reservedDialcodes',
+]);
 
 function deepMergeNode(nodes: INode[], id: string, patch: Record<string, unknown>): INode[] {
   return nodes.map((node) => {
@@ -110,6 +114,33 @@ function reorderInParent(nodes: INode[], parentId: string, from: number, to: num
     }
     return node;
   });
+}
+
+// Recursively rename node ids (temp-xxx → do_xxx) after a save that returns identifiers
+function renameNodeIds(nodes: INode[], idMap: Record<string, string>): INode[] {
+  return nodes.map((node) => {
+    const newId = idMap[node.id] ?? node.id;
+    const newParent = node.parent ? (idMap[node.parent] ?? node.parent) : node.parent;
+    return {
+      ...node,
+      id: newId,
+      identifier: newId,
+      parent: newParent,
+      children: node.children ? renameNodeIds(node.children, idMap) : [],
+    };
+  });
+}
+
+// Count all non-folder (leaf content) nodes in the tree via BFS
+function countLeafNodes(nodes: INode[]): number {
+  let count = 0;
+  const queue: INode[] = [...nodes];
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    if (!node.isFolder) count++;
+    if (node.children) queue.push(...node.children);
+  }
+  return count;
 }
 
 // Build breadcrumb by walking parent references via BFS lookup
@@ -182,10 +213,9 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     const maxDepth = useEditorStore.getState().editorConfig?.config?.maxDepth ?? 4;
     const parentDepth = getNodeDepth(state.treeData, parentId);
 
-    // parentDepth is the depth of the parent; the new child would be at parentDepth + 1.
-    // We allow depths 0 .. maxDepth-1, so the child must satisfy: parentDepth + 1 <= maxDepth - 1
-    // i.e. parentDepth >= maxDepth - 1 means the child would exceed the limit.
-    if (parentDepth >= maxDepth - 1) {
+    // parentDepth is the depth of the parent; child would be at parentDepth + 1.
+    // Allow children at depths 1..maxDepth (root is depth 0), matching Angular behaviour.
+    if (parentDepth >= maxDepth) {
       console.warn(`[tree.store] addNode: depth would exceed maxDepth (${maxDepth}). parentDepth=${parentDepth}`);
       return '';
     }
@@ -238,13 +268,14 @@ export const useTreeStore = create<TreeState>((set, get) => ({
       if (!node) return state;
       let newTree = removeNode(state.treeData, nodeId);
       newTree = insertIntoParent(newTree, toParentId, { ...node, parent: toParentId });
-      return { treeData: newTree, isDirty: true } as Partial<TreeState> as TreeState;
+      return { treeData: newTree };
     });
+    useEditorStore.getState().setIsDirty(true);
   },
 
   addResource: (content, nodeId) => {
-    // Prevent adding content directly under the root node unless explicitly allowed by config
     const config = useEditorStore.getState().editorConfig;
+    // Prevent adding content directly under the root node unless explicitly allowed by config
     const allowContentUnderRoot = config?.config?.allowContentUnderRoot ?? false;
     const rootId = get().treeData[0]?.id;
     if (!allowContentUnderRoot && nodeId === rootId) {
@@ -253,6 +284,13 @@ export const useTreeStore = create<TreeState>((set, get) => ({
 
     // Prevent duplicate content anywhere in the collection (cross-unit)
     if (bfsFind(get().treeData, content.identifier)) {
+      return false;
+    }
+
+    // Enforce maxContentsLimit (default 1200) and maxQuestionsLimit (default 500)
+    const maxContents = (config?.config as unknown as Record<string, unknown>)?.['maxContentsLimit'] as number | undefined ?? 1200;
+    const currentLeafCount = countLeafNodes(get().treeData);
+    if (currentLeafCount >= maxContents) {
       return false;
     }
 
@@ -280,8 +318,24 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   },
 
   markDirty: () => {
-    import('../store/editor.store').then(({ useEditorStore: editorStore }) => {
-      editorStore.getState().setIsDirty(true);
+    useEditorStore.getState().setIsDirty(true);
+  },
+
+  replaceNodeIds: (identifiers) => {
+    if (!identifiers || Object.keys(identifiers).length === 0) return;
+    set((state) => {
+      const newTreeData = renameNodeIds(state.treeData, identifiers);
+      // Rebuild treeCache with renamed keys and clear isNew flags for persisted nodes
+      const newCache: Record<string, Record<string, unknown>> = {};
+      for (const [oldId, cached] of Object.entries(state.treeCache)) {
+        const newId = identifiers[oldId] ?? oldId;
+        const { isNew: _, ...rest } = cached;
+        newCache[newId] = rest;
+      }
+      const newSelectedId = state.selectedNodeId
+        ? (identifiers[state.selectedNodeId] ?? state.selectedNodeId)
+        : null;
+      return { treeData: newTreeData, treeCache: newCache, selectedNodeId: newSelectedId };
     });
   },
 

--- a/projects/collection-editor-react/src/store/tree.store.ts
+++ b/projects/collection-editor-react/src/store/tree.store.ts
@@ -1,0 +1,293 @@
+import { create } from 'zustand';
+import type { INode } from '../types/editor';
+import type { IContent } from '../types/content';
+import { useEditorStore } from './editor.store';
+
+interface TreeState {
+  treeData: INode[];
+  selectedNodeId: string | null;
+  treeCache: Record<string, Record<string, unknown>>;
+  breadcrumb: Array<{ id: string; name: string }>;
+  activeNodeMeta: Record<string, unknown>;
+  // actions
+  setTreeData: (nodes: INode[]) => void;
+  selectNode: (id: string) => void;
+  updateNode: (id: string, patch: Record<string, unknown>) => void;
+  addNode: (parentId: string, type: 'unit' | 'subunit') => string;
+  deleteNode: (id: string) => void;
+  reorderChildren: (parentId: string, fromIndex: number, toIndex: number) => void;
+  addResource: (content: IContent, nodeId: string) => void;
+  markDirty: () => void;
+  getNodeById: (id: string) => INode | undefined;
+  getChildrenOf: (id: string) => INode[];
+  getBreadcrumb: (id: string) => Array<{ id: string; name: string }>;
+  moveNode: (nodeId: string, fromParentId: string, toParentId: string) => void;
+}
+
+// BFS through treeData to find a node by id
+function bfsFind(nodes: INode[], id: string): INode | undefined {
+  const queue: INode[] = [...nodes];
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    if (node.id === id) return node;
+    if (node.children) queue.push(...node.children);
+  }
+  return undefined;
+}
+
+// Compute the depth of a target node (root nodes are depth 0)
+function getNodeDepth(nodes: INode[], targetId: string, depth = 0): number {
+  for (const n of nodes) {
+    if (n.id === targetId) return depth;
+    if (n.children?.length) {
+      const found = getNodeDepth(n.children, targetId, depth + 1);
+      if (found >= 0) return found;
+    }
+  }
+  return -1;
+}
+
+// Deep merge a patch into a node's properties within a tree
+// Fields that live both on INode top-level AND inside node.metadata
+const METADATA_MIRROR_FIELDS = new Set(['name', 'appIcon', 'description', 'keywords', 'trackable']);
+
+function deepMergeNode(nodes: INode[], id: string, patch: Record<string, unknown>): INode[] {
+  return nodes.map((node) => {
+    if (node.id === id) {
+      const explicitMetaPatch = (patch['metadata'] as Record<string, unknown>) ?? {};
+      // Mirror top-level patch fields into metadata so cleanMetadata sees the latest values
+      const mirroredFields: Record<string, unknown> = {};
+      for (const key of METADATA_MIRROR_FIELDS) {
+        if (key in patch) mirroredFields[key] = patch[key];
+      }
+      return {
+        ...node,
+        ...patch,
+        metadata: { ...(node.metadata ?? {}), ...mirroredFields, ...explicitMetaPatch },
+      };
+    }
+    if (node.children && node.children.length > 0) {
+      return { ...node, children: deepMergeNode(node.children, id, patch) };
+    }
+    return node;
+  });
+}
+
+// Insert a new node into parent's children
+function insertIntoParent(nodes: INode[], parentId: string, newNode: INode): INode[] {
+  return nodes.map((node) => {
+    if (node.id === parentId) {
+      return { ...node, children: [...(node.children ?? []), newNode] };
+    }
+    if (node.children && node.children.length > 0) {
+      return { ...node, children: insertIntoParent(node.children, parentId, newNode) };
+    }
+    return node;
+  });
+}
+
+// Recursively filter out a node
+function removeNode(nodes: INode[], id: string): INode[] {
+  return nodes
+    .filter((node) => node.id !== id)
+    .map((node) => ({
+      ...node,
+      children: node.children ? removeNode(node.children, id) : [],
+    }));
+}
+
+// Reorder children of a parent node
+function reorderInParent(nodes: INode[], parentId: string, from: number, to: number): INode[] {
+  return nodes.map((node) => {
+    if (node.id === parentId) {
+      const children = [...(node.children ?? [])];
+      const [moved] = children.splice(from, 1);
+      children.splice(to, 0, moved);
+      return { ...node, children };
+    }
+    if (node.children && node.children.length > 0) {
+      return { ...node, children: reorderInParent(node.children, parentId, from, to) };
+    }
+    return node;
+  });
+}
+
+// Build breadcrumb by walking parent references via BFS lookup
+function buildBreadcrumb(
+  nodes: INode[],
+  id: string,
+): Array<{ id: string; name: string }> {
+  const node = bfsFind(nodes, id);
+  if (!node) return [];
+  const crumbs: Array<{ id: string; name: string }> = [];
+  let current: INode | undefined = node;
+  while (current) {
+    crumbs.unshift({ id: current.id, name: current.name });
+    current = current.parent ? bfsFind(nodes, current.parent) : undefined;
+  }
+  return crumbs;
+}
+
+export const useTreeStore = create<TreeState>((set, get) => ({
+  treeData: [],
+  selectedNodeId: null,
+  treeCache: {},
+  breadcrumb: [],
+  activeNodeMeta: {},
+
+  setTreeData: (nodes) => {
+    const firstId = nodes[0]?.id ?? null;
+    set({ treeData: nodes, selectedNodeId: firstId });
+    // Activate the first node so activeNodeMeta and isCurrentNodeRoot are populated
+    if (firstId) {
+      // Use setTimeout to let the treeData state settle before selectNode reads it
+      setTimeout(() => get().selectNode(firstId), 0);
+    }
+  },
+
+  selectNode: (id) => {
+    const { treeData, treeCache, getBreadcrumb } = get();
+    const node = bfsFind(treeData, id);
+    const breadcrumb = getBreadcrumb(id);
+    // Merge treeCache so non-mirror fields (audience, board, targetBoardIds, etc.)
+    // are included in activeNodeMeta and available to SparkMetaForm on remount.
+    const activeNodeMeta = { ...(node?.metadata ?? {}), ...(treeCache[id] ?? {}) };
+
+    // Update editor store node flags (lazy to avoid circular)
+    import('../store/editor.store').then(({ useEditorStore: editorStore }) => {
+      editorStore.getState().setNodeFlags({
+        isFolder: node?.isFolder ?? false,
+        isRoot: !node?.parent,
+        isQuml: false,
+      });
+    });
+
+    set({ selectedNodeId: id, breadcrumb, activeNodeMeta });
+  },
+
+  updateNode: (id, patch) => {
+    set((state) => ({
+      treeData: deepMergeNode(state.treeData, id, patch),
+      treeCache: {
+        ...state.treeCache,
+        [id]: { ...(state.treeCache[id] ?? {}), ...patch },
+      },
+    }));
+  },
+
+  addNode: (parentId, _type) => {
+    const state = get();
+    const maxDepth = useEditorStore.getState().editorConfig?.config?.maxDepth ?? 4;
+    const parentDepth = getNodeDepth(state.treeData, parentId);
+
+    // parentDepth is the depth of the parent; the new child would be at parentDepth + 1.
+    // We allow depths 0 .. maxDepth-1, so the child must satisfy: parentDepth + 1 <= maxDepth - 1
+    // i.e. parentDepth >= maxDepth - 1 means the child would exceed the limit.
+    if (parentDepth >= maxDepth - 1) {
+      console.warn(`[tree.store] addNode: depth would exceed maxDepth (${maxDepth}). parentDepth=${parentDepth}`);
+      return '';
+    }
+
+    const newId = 'temp-' + Math.random().toString(36).slice(2);
+    const newNode: INode = {
+      id: newId,
+      identifier: newId,
+      name: 'Untitled Unit',
+      isFolder: true,
+      children: [],
+      parent: parentId,
+      metadata: {
+        mimeType: 'application/vnd.ekstep.content-collection',
+        code: newId,
+        name: 'Untitled Unit',
+        visibility: 'Parent',
+      },
+    };
+
+    set((state) => ({
+      treeData: insertIntoParent(state.treeData, parentId, newNode),
+      treeCache: {
+        ...state.treeCache,
+        [newId]: { ...newNode.metadata, isNew: true },
+      },
+    }));
+
+    get().selectNode(newId);
+    return newId;
+  },
+
+  deleteNode: (id) => {
+    set((state) => ({
+      treeData: removeNode(state.treeData, id),
+      selectedNodeId: state.selectedNodeId === id ? null : state.selectedNodeId,
+    }));
+  },
+
+  reorderChildren: (parentId, fromIndex, toIndex) => {
+    set((state) => ({
+      treeData: reorderInParent(state.treeData, parentId, fromIndex, toIndex),
+    }));
+  },
+
+  moveNode: (nodeId, _fromParentId, toParentId) => {
+    set((state) => {
+      const node = bfsFind(state.treeData, nodeId);
+      if (!node) return state;
+      let newTree = removeNode(state.treeData, nodeId);
+      newTree = insertIntoParent(newTree, toParentId, { ...node, parent: toParentId });
+      return { treeData: newTree, isDirty: true } as Partial<TreeState> as TreeState;
+    });
+  },
+
+  addResource: (content, nodeId) => {
+    // Prevent adding content directly under the root node unless explicitly allowed by config
+    const config = useEditorStore.getState().editorConfig;
+    const allowContentUnderRoot = config?.config?.allowContentUnderRoot ?? false;
+    const rootId = get().treeData[0]?.id;
+    if (!allowContentUnderRoot && nodeId === rootId) {
+      return;
+    }
+
+    const leafNode: INode = {
+      id: content.identifier,
+      identifier: content.identifier,
+      name: content.name,
+      isFolder: false,
+      children: [],
+      parent: nodeId,
+      mimeType: content.mimeType,
+      primaryCategory: content.primaryCategory,
+      contentType: content.contentType,
+      appIcon: content.appIcon,
+      status: content.status,
+      metadata: content as unknown as Record<string, unknown>,
+    };
+
+    set((state) => ({
+      treeData: insertIntoParent(state.treeData, nodeId, leafNode),
+    }));
+
+    get().markDirty();
+  },
+
+  markDirty: () => {
+    import('../store/editor.store').then(({ useEditorStore: editorStore }) => {
+      editorStore.getState().setIsDirty(true);
+    });
+  },
+
+  getNodeById: (id) => {
+    return bfsFind(get().treeData, id);
+  },
+
+  getChildrenOf: (id) => {
+    const node = bfsFind(get().treeData, id);
+    return node?.children ?? [];
+  },
+
+  getBreadcrumb: (id) => {
+    return buildBreadcrumb(get().treeData, id);
+  },
+}));
+
+export const getTreeStore = () => useTreeStore.getState;

--- a/projects/collection-editor-react/src/store/tree.store.ts
+++ b/projects/collection-editor-react/src/store/tree.store.ts
@@ -16,7 +16,7 @@ interface TreeState {
   addNode: (parentId: string, type: 'unit' | 'subunit') => string;
   deleteNode: (id: string) => void;
   reorderChildren: (parentId: string, fromIndex: number, toIndex: number) => void;
-  addResource: (content: IContent, nodeId: string) => void;
+  addResource: (content: IContent, nodeId: string) => boolean;
   markDirty: () => void;
   getNodeById: (id: string) => INode | undefined;
   getChildrenOf: (id: string) => INode[];
@@ -214,7 +214,8 @@ export const useTreeStore = create<TreeState>((set, get) => ({
       },
     }));
 
-    get().selectNode(newId);
+    // Defer selectNode so treeData settles before bfsFind runs — same pattern as setTreeData.
+    setTimeout(() => get().selectNode(newId), 0);
     return newId;
   },
 
@@ -247,7 +248,12 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     const allowContentUnderRoot = config?.config?.allowContentUnderRoot ?? false;
     const rootId = get().treeData[0]?.id;
     if (!allowContentUnderRoot && nodeId === rootId) {
-      return;
+      return false;
+    }
+
+    // Prevent duplicate content anywhere in the collection (cross-unit)
+    if (bfsFind(get().treeData, content.identifier)) {
+      return false;
     }
 
     const leafNode: INode = {
@@ -270,6 +276,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     }));
 
     get().markDirty();
+    return true;
   },
 
   markDirty: () => {

--- a/projects/collection-editor-react/src/store/ui.store.ts
+++ b/projects/collection-editor-react/src/store/ui.store.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+export type ModalType =
+  | 'publishChecklist'
+  | 'qualityParams'
+  | 'manageCollaborators'
+  | 'csvUpload'
+  | 'confirmDelete'
+  | 'resourceReorder'
+  | 'assignPageNumber'
+  | null;
+
+interface UiState {
+  activeModal: ModalType;
+  modalData: Record<string, unknown>;
+  openModal: (modal: ModalType, data?: Record<string, unknown>) => void;
+  closeModal: () => void;
+}
+
+export const useUiStore = create<UiState>((set) => ({
+  activeModal: null,
+  modalData: {},
+  openModal: (modal, data = {}) => set({ activeModal: modal, modalData: data }),
+  closeModal: () => set({ activeModal: null, modalData: {} }),
+}));

--- a/projects/collection-editor-react/src/styles/_content-types.scss
+++ b/projects/collection-editor-react/src/styles/_content-types.scss
@@ -1,0 +1,41 @@
+$ct-map: (
+  'video': (#EA580C, white),
+  'pdf': (#DC2626, white),
+  'h5p': (#0D9488, white),
+  'scorm': (#7C3AED, white),
+  'audio': (#DB2777, white),
+  'quiz': (#16A34A, white),
+  'default': (#6B7280, white)
+);
+
+@each $key, $vals in $ct-map {
+  $color: nth($vals, 1);
+  $text: nth($vals, 2);
+
+  .sbx-ct-sq--#{$key} {
+    background-color: $color;
+    color: $text;
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .sbx-ct-badge--#{$key} {
+    background-color: rgba($color, 0.12);
+    color: $color;
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-weight: 600;
+    display: inline-block;
+  }
+
+  .sbx-ct-tint--#{$key} {
+    color: $color;
+    font-weight: 600;
+  }
+}

--- a/projects/collection-editor-react/src/styles/_fonts.scss
+++ b/projects/collection-editor-react/src/styles/_fonts.scss
@@ -1,0 +1,4 @@
+/* Plus Jakarta Sans covers Latin glyphs only.
+   Indic chars (Devanagari, Tamil, Urdu) fall through to system Noto fonts.
+   Do NOT add Indic Unicode ranges to this @import. */
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap');

--- a/projects/collection-editor-react/src/styles/_tokens.scss
+++ b/projects/collection-editor-react/src/styles/_tokens.scss
@@ -1,0 +1,48 @@
+.sb-split-builder {
+  // Primary palette
+  --sbx-primary: #2D6AE3;
+  --sbx-primary-dark: #1A4FA8;
+  --sbx-primary-light: #EEF3FD;
+  --sbx-ai: #7A5BFF;
+  // Semantic
+  --sbx-success: #16A34A;
+  --sbx-error: #DC2626;
+  --sbx-warning: #D97706;
+  --sbx-info: #0EA5E9;
+  // Grays
+  --sbx-gray-50: #F9FAFB;
+  --sbx-gray-100: #F3F4F6;
+  --sbx-gray-200: #E5E7EB;
+  --sbx-gray-300: #D1D5DB;
+  --sbx-gray-400: #9CA3AF;
+  --sbx-gray-500: #6B7280;
+  --sbx-gray-600: #4B5563;
+  --sbx-gray-700: #374151;
+  --sbx-gray-800: #1F2937;
+  --sbx-gray-900: #111827;
+  // Radii
+  --sbx-r-xs: 4px;
+  --sbx-r-sm: 6px;
+  --sbx-r-md: 10px;
+  --sbx-r-lg: 14px;
+  --sbx-r-xl: 20px;
+  // Shadows
+  --sbx-shadow-1: 0 1px 3px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.06);
+  --sbx-shadow-2: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.06);
+  --sbx-shadow-3: 0 10px 15px rgba(0,0,0,0.08), 0 4px 6px rgba(0,0,0,0.05);
+  // CT colors
+  --sbx-ct-video: #EA580C;
+  --sbx-ct-pdf: #DC2626;
+  --sbx-ct-h5p: #0D9488;
+  --sbx-ct-scorm: #7C3AED;
+  --sbx-ct-audio: #DB2777;
+  --sbx-ct-quiz: #16A34A;
+  --sbx-ct-default: #6B7280;
+  // Font
+  --sbx-font: 'Plus Jakarta Sans', 'Noto Sans', 'Noto Sans Devanagari', 'Noto Sans Tamil', sans-serif;
+  // Topbar height
+  --sbx-topbar-h: 60px;
+  // Column widths
+  --sbx-tree-w: 284px;
+  --sbx-dock-w: 312px;
+}

--- a/projects/collection-editor-react/src/styles/_tokens.scss
+++ b/projects/collection-editor-react/src/styles/_tokens.scss
@@ -1,16 +1,44 @@
-.sb-split-builder {
-  // Primary palette
-  --sbx-primary: #2D6AE3;
-  --sbx-primary-dark: #1A4FA8;
-  --sbx-primary-light: #EEF3FD;
+// ── Pluggable theme tokens ────────────────────────────────────────────────────
+//
+// When mounted in spark-portal the host CSS vars on :root resolve and the
+// editor adopts the host theme (primary colour, radius, shadows, font).
+// Standalone / no host vars: fallback values → default blue theme.
+//
+// Host vars consumed (set by spark-portal ThemeProvider + index.css):
+//   --primary                          bare HSL triple, e.g. "12 50% 45%"
+//   --sunbird-spark-theme-primary-h/s/l  individual seed channels
+//   --destructive                      bare HSL triple for error colour
+//   --sunbird-success-green            bare HSL triple for success colour
+//   --border, --muted, --muted-foreground, --surface, --background, --foreground
+//   --r-xs / --r-sm / --r-md / --r-lg / --r-xl  radius scale
+//   --sunbird-shadow-sm / --sunbird-shadow-md / --sunbird-shadow-lg
+//   --app-font-family                  font stack
+
+:root {
+  // ── Primary palette ───────────────────────────────────────────────────────
+  --sbx-primary:       hsl(var(--primary, 217 71% 46%));
+  // Dark and light variants derived from the host's seed channels.
+  // Lightness is locked (32% dark, 96% light); hue + saturation follow theme.
+  --sbx-primary-dark:  hsl(
+    var(--sunbird-spark-theme-primary-h, 217)
+    var(--sunbird-spark-theme-primary-s, 71%)
+    32%
+  );
+  --sbx-primary-light: hsl(
+    var(--sunbird-spark-theme-primary-h, 217)
+    var(--sunbird-spark-theme-primary-s, 71%)
+    96%
+  );
   --sbx-ai: #7A5BFF;
-  // Semantic
-  --sbx-success: #16A34A;
-  --sbx-error: #DC2626;
-  --sbx-warning: #D97706;
-  --sbx-info: #0EA5E9;
-  // Grays
-  --sbx-gray-50: #F9FAFB;
+
+  // ── Semantic ──────────────────────────────────────────────────────────────
+  --sbx-success: hsl(var(--sunbird-success-green, 145 63% 49%));
+  --sbx-error:   hsl(var(--destructive,           0 84% 60%));
+  --sbx-warning: #D97706; // fixed amber — not theme-reactive
+  --sbx-info:    #0EA5E9; // fixed cyan  — not theme-reactive
+
+  // ── Grays (neutral — intentionally not theme-reactive) ────────────────────
+  --sbx-gray-50:  #F9FAFB;
   --sbx-gray-100: #F3F4F6;
   --sbx-gray-200: #E5E7EB;
   --sbx-gray-300: #D1D5DB;
@@ -20,29 +48,60 @@
   --sbx-gray-700: #374151;
   --sbx-gray-800: #1F2937;
   --sbx-gray-900: #111827;
-  // Radii
-  --sbx-r-xs: 4px;
-  --sbx-r-sm: 6px;
-  --sbx-r-md: 10px;
-  --sbx-r-lg: 14px;
-  --sbx-r-xl: 20px;
-  // Shadows
-  --sbx-shadow-1: 0 1px 3px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.06);
-  --sbx-shadow-2: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.06);
-  --sbx-shadow-3: 0 10px 15px rgba(0,0,0,0.08), 0 4px 6px rgba(0,0,0,0.05);
-  // CT colors
-  --sbx-ct-video: #EA580C;
-  --sbx-ct-pdf: #DC2626;
-  --sbx-ct-h5p: #0D9488;
-  --sbx-ct-scorm: #7C3AED;
-  --sbx-ct-audio: #DB2777;
-  --sbx-ct-quiz: #16A34A;
+
+  // ── Radii ─────────────────────────────────────────────────────────────────
+  --sbx-r-xs: var(--r-xs, 4px);
+  --sbx-r-sm: var(--r-sm, 6px);
+  --sbx-r-md: var(--r-md, 10px);
+  --sbx-r-lg: var(--r-lg, 14px);
+  --sbx-r-xl: var(--r-xl, 20px);
+
+  // ── Shadows ───────────────────────────────────────────────────────────────
+  --sbx-shadow-1: var(--sunbird-shadow-sm, 0 1px 3px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.06));
+  --sbx-shadow-2: var(--sunbird-shadow-md, 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.06));
+  --sbx-shadow-3: var(--sunbird-shadow-lg, 0 10px 15px rgba(0,0,0,0.08), 0 4px 6px rgba(0,0,0,0.05));
+
+  // ── Content-type badge colors (fixed semantic hues) ───────────────────────
+  --sbx-ct-video:   #EA580C;
+  --sbx-ct-pdf:     #DC2626;
+  --sbx-ct-h5p:     #0D9488;
+  --sbx-ct-scorm:   #7C3AED;
+  --sbx-ct-audio:   #DB2777;
+  --sbx-ct-quiz:    #16A34A;
   --sbx-ct-default: #6B7280;
-  // Font
-  --sbx-font: 'Plus Jakarta Sans', 'Noto Sans', 'Noto Sans Devanagari', 'Noto Sans Tamil', sans-serif;
-  // Topbar height
+
+  // ── Font ──────────────────────────────────────────────────────────────────
+  --sbx-font: var(
+    --app-font-family,
+    'Plus Jakarta Sans', 'Noto Sans', 'Noto Sans Devanagari', 'Noto Sans Tamil', sans-serif
+  );
+
+  // ── Layout constants ──────────────────────────────────────────────────────
   --sbx-topbar-h: 60px;
-  // Column widths
-  --sbx-tree-w: 284px;
-  --sbx-dock-w: 312px;
+  --sbx-tree-w:   284px;
+  --sbx-dock-w:   312px;
+
+  // ── Phase 2 — surfaces / borders (defer to host where available) ──────────
+  --sbx-surface:  hsl(var(--surface,            0  0% 100%));
+  --sbx-bg:       hsl(var(--background,        48 23%  91%));
+  --sbx-fg:       hsl(var(--foreground,          0  0%  13%));
+  --sbx-border:   hsl(var(--border,           210 25%  80%));
+  --sbx-muted:    hsl(var(--muted,            210 20%  96%));
+  --sbx-muted-fg: hsl(var(--muted-foreground, 210 11%  45%));
+
+  // ── Phase 3 — status-band tokens (extracted from component files) ─────────
+  // Uploading / processing band — primary-tinted, shifts with theme
+  --sbx-status-info-bg:     hsl(var(--primary, 217 71% 46%) / 0.06);
+  --sbx-status-info-border: hsl(var(--primary, 217 71% 46%) / 0.22);
+  // Success band — semantic green, fixed
+  --sbx-status-ok-bg:     #F0FDF4;
+  --sbx-status-ok-border: #BBF7D0;
+  // Error band — semantic red, fixed
+  --sbx-status-err-bg:     #FEF2F2;
+  --sbx-status-err-border: #FECACA;
+  // Warning / review-comment band — fixed amber (semantic, not brand-reactive)
+  --sbx-warn-bg:     #FFFBE6;
+  --sbx-warn-border: #FFE58F;
+  --sbx-warn-text:   #AD6800;
+  --sbx-warn-body:   #595959;
 }

--- a/projects/collection-editor-react/src/styles/global.scss
+++ b/projects/collection-editor-react/src/styles/global.scss
@@ -29,6 +29,9 @@
   user-select: none;
 
   &.filled {
+    // Match the outline chip's border width so selected/unselected chips are
+    // the same height and baseline-aligned.
+    border: 1.5px solid var(--sbx-primary);
     background: var(--sbx-primary);
     color: white;
   }

--- a/projects/collection-editor-react/src/styles/global.scss
+++ b/projects/collection-editor-react/src/styles/global.scss
@@ -1,0 +1,136 @@
+@use './tokens' as *;
+@use './fonts' as *;
+@use './content-types' as *;
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+.sb-split-builder {
+  font-family: var(--sbx-font);
+  color: var(--sbx-gray-900);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+// Chip
+.sbx-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: var(--sbx-r-xl);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  user-select: none;
+
+  &.filled {
+    background: var(--sbx-primary);
+    color: white;
+  }
+
+  &.outline {
+    border: 1.5px solid var(--sbx-gray-300);
+    color: var(--sbx-gray-700);
+    background: white;
+  }
+
+  &.outline:hover,
+  &.outline.active {
+    border-color: var(--sbx-primary);
+    color: var(--sbx-primary);
+    background: var(--sbx-primary-light);
+  }
+
+  &.filled.active {
+    background: var(--sbx-primary-dark);
+  }
+
+  .sbx-chip-remove {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    color: inherit;
+    opacity: 0.7;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}
+
+// Card
+.sbx-card {
+  background: white;
+  border-radius: var(--sbx-r-md);
+  box-shadow: var(--sbx-shadow-1);
+}
+
+// Buttons base
+.sbx-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  border-radius: var(--sbx-r-md);
+  padding: 0 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: all 0.15s;
+  white-space: nowrap;
+  box-sizing: border-box;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.sbx-btn-primary {
+  @extend .sbx-btn;
+  background: var(--sbx-primary);
+  color: white;
+
+  &:hover:not(:disabled) {
+    background: var(--sbx-primary-dark);
+  }
+}
+
+.sbx-btn-ghost {
+  @extend .sbx-btn;
+  background: transparent;
+  color: var(--sbx-gray-700);
+  border: 1.5px solid var(--sbx-gray-300);
+
+  &:hover:not(:disabled) {
+    border-color: var(--sbx-primary);
+    color: var(--sbx-primary);
+  }
+}
+
+.sbx-btn-danger {
+  @extend .sbx-btn;
+  background: transparent;
+  color: var(--sbx-error);
+  border: 1.5px solid var(--sbx-error);
+
+  &:hover:not(:disabled) {
+    background: var(--sbx-error);
+    color: white;
+  }
+}
+
+.sbx-btn-sm {
+  height: 36px;
+  padding: 0 14px;
+  font-size: 13px;
+  border-radius: var(--sbx-r-sm);
+}

--- a/projects/collection-editor-react/src/types/content.ts
+++ b/projects/collection-editor-react/src/types/content.ts
@@ -1,0 +1,66 @@
+export interface IContent {
+  identifier: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  contentType?: string;
+  primaryCategory?: string;
+  appIcon?: string;
+  channel?: string;
+  organisation?: string[];
+  framework?: string;
+  status?: string;
+  visibility?: string;
+  pkgVersion?: number;
+}
+
+export interface ILibraryItem extends IContent {
+  isSelected?: boolean;
+  isDragging?: boolean;
+}
+
+export const CT_COLOR_MAP = {
+  video: '#EA580C',
+  pdf: '#DC2626',
+  h5p: '#0D9488',
+  scorm: '#7C3AED',
+  audio: '#DB2777',
+  quiz: '#16A34A',
+  default: '#6B7280',
+} as const satisfies Record<string, string>;
+
+export const CT_ICON_MAP = {
+  video: 'Video',
+  pdf: 'FileText',
+  h5p: 'Layers',
+  scorm: 'Package',
+  audio: 'Music',
+  quiz: 'HelpCircle',
+  default: 'File',
+} as const satisfies Record<string, string>;
+
+// Canonical primaryCategory values shown in the Library
+export const LIBRARY_PRIMARY_CATEGORIES = [
+  'Course Assessment',
+  'eTextbook',
+  'Exam Question',
+  'Explanation Content',
+  'Learning Resource',
+  'Practice Question Set',
+  'SCORM Content',
+  'Teacher Resource',
+] as const;
+
+export type LibraryPrimaryCategory = typeof LIBRARY_PRIMARY_CATEGORIES[number];
+
+export const CT_FILTERS: ReadonlyArray<{ label: string; value: string }> = [
+  { label: 'All', value: 'all' },
+  { label: 'Course Assessment', value: 'Course Assessment' },
+  { label: 'eTextbook', value: 'eTextbook' },
+  { label: 'Exam Question', value: 'Exam Question' },
+  { label: 'Explanation Content', value: 'Explanation Content' },
+  { label: 'Learning Resource', value: 'Learning Resource' },
+  { label: 'Practice Question Set', value: 'Practice Question Set' },
+  { label: 'SCORM Content', value: 'SCORM Content' },
+  { label: 'Teacher Resource', value: 'Teacher Resource' },
+];

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -60,6 +60,8 @@ export interface IEditorConfig {
   metadata?: Record<string, unknown>;
   data?: unknown;
   enableSplitBuilder?: boolean;
+  /** Base URL for all API calls (e.g. "https://your-domain.com"). Omit when using a proxy. */
+  apiBaseUrl?: string;
 }
 
 export interface IEditorEvents {

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -25,6 +25,7 @@ export interface IUser {
 
 export interface IContext {
   authToken: string;
+  userToken?: string;
   userId: string;
   sid: string;
   did: string;

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -52,6 +52,8 @@ export interface IConfig {
   defaultFields?: Record<string, unknown>;
   maxDepth?: number;
   allowContentUnderRoot?: boolean;
+  /** URL for the iframe-based content preview player. Defaults to the bundled preview.html path. */
+  previewCdnUrl?: string;
 }
 
 export interface IEditorConfig {

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -1,0 +1,101 @@
+export type EditorMode = 'edit' | 'review' | 'read' | 'sourcingreview';
+
+export type ToolbarAction =
+  | 'back'
+  | 'preview'
+  | 'sendForReview'
+  | 'onFormValueChange'
+  | 'onFormStatusChange'
+  | 'addUnit'
+  | 'addSubUnit'
+  | 'saveCollection'
+  | 'publish'
+  | 'reject'
+  | 'sendBackForCorrections'
+  | 'sourcingApprove'
+  | 'sourcingReject'
+  | 'manageCollaborators'
+  | 'csvUpload';
+
+export interface IUser {
+  id: string;
+  fullName: string;
+  orgIds: string[];
+}
+
+export interface IContext {
+  authToken: string;
+  userId: string;
+  sid: string;
+  did: string;
+  uid?: string;
+  channel: string;
+  pdata: { id: string; ver: string; pid?: string };
+  env: string;
+  contentId?: string;
+  identifier?: string;
+  framework?: string;
+  targetFWIds?: string[];
+  rollup?: Record<string, string>;
+  tags?: string[];
+}
+
+export interface IConfig {
+  mode: EditorMode;
+  objectType: string;
+  primaryCategory?: string;
+  framework?: string[];
+  targetFWIds?: string[];
+  toolbarConfig?: Record<string, unknown>;
+  hierarchy?: Record<string, unknown>;
+  children?: unknown[];
+  defaultFields?: Record<string, unknown>;
+  maxDepth?: number;
+  allowContentUnderRoot?: boolean;
+}
+
+export interface IEditorConfig {
+  context: IContext;
+  config: IConfig;
+  metadata?: Record<string, unknown>;
+  data?: unknown;
+  enableSplitBuilder?: boolean;
+}
+
+export interface IEditorEvents {
+  onToolbarEvent?: (event: { action: ToolbarAction; data?: unknown }) => void;
+  onContentAdded?: (item: unknown, targetNodeId: string) => void;
+  onHierarchySaved?: (hierarchy: unknown) => void;
+  onError?: (error: Error) => void;
+}
+
+export interface INode {
+  id: string;
+  identifier: string;
+  name: string;
+  title?: string;
+  description?: string;
+  primaryCategory?: string;
+  mimeType?: string;
+  objectType?: string;
+  contentType?: string;
+  visibility?: string;
+  status?: string;
+  appIcon?: string;
+  isFolder?: boolean;
+  children?: INode[];
+  metadata?: Record<string, unknown>;
+  parent?: string;
+  index?: number;
+}
+
+export interface IButtonLoaders {
+  saveCollection: boolean;
+  publishCollection: boolean;
+  addFromLibrary: boolean;
+  rejectCollection: boolean;
+  sendBackCollection: boolean;
+  sourcingApproveCollection: boolean;
+  sourcingRejectCollection: boolean;
+}
+

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -33,6 +33,9 @@ export interface IContext {
   channel: string;
   pdata: { id: string; ver: string; pid?: string };
   env: string;
+  /** Current user profile — user.fullName auto-fills the author field.
+   *  When absent, the editor resolves it via /portal/user/v5/read. */
+  user?: { fullName?: string };
   contentId?: string;
   identifier?: string;
   framework?: string;

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -56,7 +56,8 @@ export interface IConfig {
   previewCdnUrl?: string;
   /**
    * API version for object/category/definition endpoint.
-   * Sandbox/older envs use 'v1'; current backend uses 'v4' (default).
+   * Defaults to 'v1' (works on both sandbox and test environments).
+   * Set to 'v4' only if your backend specifically requires it.
    */
   categoryDefinitionApiVersion?: 'v1' | 'v4';
 }

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -38,6 +38,10 @@ export interface IContext {
   targetFWIds?: string[];
   rollup?: Record<string, string>;
   tags?: string[];
+  cloudStorage?: {
+    provider?: string;
+    presigned_headers?: Record<string, string>;
+  };
 }
 
 export interface IConfig {

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -64,6 +64,15 @@ export interface IConfig {
    * Set to 'v4' only if your backend specifically requires it.
    */
   categoryDefinitionApiVersion?: 'v1' | 'v4';
+  /**
+   * Asset upload constraints for the app icon picker.
+   * Defaults: size = 1 MB, accepted = 'image/png,image/jpeg'.
+   * SVG is intentionally excluded to prevent active-content / XSS vectors.
+   */
+  assetConfig?: {
+    size?: number;
+    accepted?: string;
+  };
 }
 
 export interface IEditorConfig {

--- a/projects/collection-editor-react/src/types/editor.ts
+++ b/projects/collection-editor-react/src/types/editor.ts
@@ -54,6 +54,11 @@ export interface IConfig {
   allowContentUnderRoot?: boolean;
   /** URL for the iframe-based content preview player. Defaults to the bundled preview.html path. */
   previewCdnUrl?: string;
+  /**
+   * API version for object/category/definition endpoint.
+   * Sandbox/older envs use 'v1'; current backend uses 'v4' (default).
+   */
+  categoryDefinitionApiVersion?: 'v1' | 'v4';
 }
 
 export interface IEditorConfig {

--- a/projects/collection-editor-react/src/types/framework.ts
+++ b/projects/collection-editor-react/src/types/framework.ts
@@ -1,0 +1,26 @@
+export interface ITerm {
+  identifier: string;
+  name: string;
+  code: string;
+  index?: number;
+  associations?: ITerm[];
+}
+
+export interface ICategory {
+  identifier: string;
+  name: string;
+  code: string;
+  terms?: ITerm[];
+}
+
+export interface IFramework {
+  identifier: string;
+  name: string;
+  code: string;
+  categories?: ICategory[];
+}
+
+export interface IFrameworkDetails {
+  organisationFramework?: IFramework;
+  targetFrameworks?: IFramework[];
+}

--- a/projects/collection-editor-react/src/types/framework.ts
+++ b/projects/collection-editor-react/src/types/framework.ts
@@ -3,6 +3,13 @@ export interface ITerm {
   name: string;
   code: string;
   index?: number;
+  /** Framework category this term belongs to (e.g. 'board', 'medium').
+   *  Association entries carry this so a parent term's associations can be
+   *  filtered down to a single child category — mirrors Angular's
+   *  `a.category === field.sourceCategory` filter. */
+  category?: string;
+  status?: string;
+  description?: string;
   associations?: ITerm[];
 }
 

--- a/projects/collection-editor-react/src/types/framework.ts
+++ b/projects/collection-editor-react/src/types/framework.ts
@@ -23,4 +23,9 @@ export interface IFramework {
 export interface IFrameworkDetails {
   organisationFramework?: IFramework;
   targetFrameworks?: IFramework[];
+  /** Options for the 'framework' (Course Type) field — built from channel.frameworks
+   *  filtered/extended by orgFWType from the category definition. */
+  orgFrameworks?: Array<{ label: string; value: string }>;
+  /** Options for the 'additionalCategories' field — from channel.collectionAdditionalCategories. */
+  channelAdditionalCategories?: string[];
 }

--- a/projects/collection-editor-react/src/types/index.ts
+++ b/projects/collection-editor-react/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './editor';
+export * from './content';
+export * from './framework';

--- a/projects/collection-editor-react/src/utils/telemetry.ts
+++ b/projects/collection-editor-react/src/utils/telemetry.ts
@@ -1,0 +1,46 @@
+// Telemetry utility – mirrors Angular's telemetry.service.ts event format.
+// Call window.EkTelemetry if available (loaded by host app), else no-op.
+
+interface TelemetryContext {
+  channel?: string;
+  pdata?: { id: string; ver: string; pid?: string };
+  env?: string;
+  sid?: string;
+  uid?: string;
+  did?: string;
+  contentId?: string;
+}
+
+let _ctx: TelemetryContext = {};
+
+export function initTelemetry(ctx: TelemetryContext): void {
+  _ctx = ctx;
+}
+
+export function trackInteract(id: string, type: string, subtype = '', extra?: Record<string, unknown>): void {
+  try {
+    const win = window as unknown as Record<string, unknown>;
+    const ek = win['EkTelemetry'] as { interact?: (e: unknown) => void } | undefined;
+    ek?.interact?.({
+      eid: 'INTERACT',
+      context: _ctx,
+      edata: { type, subtype, id, extra },
+    });
+  } catch { /* no-op */ }
+}
+
+export function trackImpression(type: string, subtype: string, pageid: string): void {
+  try {
+    const win = window as unknown as Record<string, unknown>;
+    const ek = win['EkTelemetry'] as { impression?: (e: unknown) => void } | undefined;
+    ek?.impression?.({ eid: 'IMPRESSION', context: _ctx, edata: { type, subtype, pageid } });
+  } catch { /* no-op */ }
+}
+
+export function trackError(error: Error, id: string): void {
+  try {
+    const win = window as unknown as Record<string, unknown>;
+    const ek = win['EkTelemetry'] as { error?: (e: unknown) => void } | undefined;
+    ek?.error?.({ eid: 'ERROR', context: _ctx, edata: { err: error.message, errtype: 'SYSTEM', stacktrace: error.stack, pageid: id } });
+  } catch { /* no-op */ }
+}

--- a/projects/collection-editor-react/src/utils/validateRequiredFields.test.ts
+++ b/projects/collection-editor-react/src/utils/validateRequiredFields.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { findMissingRequiredFields } from './validateRequiredFields';
+import type { INode } from '../types/editor';
+
+const node = (over: Partial<INode>): INode => ({
+  id: 'n1',
+  identifier: 'n1',
+  name: 'Node',
+  isFolder: false,
+  children: [],
+  metadata: {},
+  ...over,
+});
+
+const rootConfig = [
+  { code: 'name', label: 'Title', required: true },
+  { code: 'description', label: 'Description', required: true },
+];
+const unitConfig = [{ code: 'description', label: 'Description', required: true }];
+
+describe('findMissingRequiredFields', () => {
+  it('reports empty required fields on root and unit nodes', () => {
+    const tree = [
+      node({
+        id: 'root', identifier: 'root', name: 'Course', isFolder: true,
+        metadata: { name: 'Course' }, // description missing
+        children: [
+          node({ id: 'u1', identifier: 'u1', name: 'Unit 1', isFolder: true, parent: 'root', metadata: {} }),
+        ],
+      }),
+    ];
+    const reports = findMissingRequiredFields(tree, {}, rootConfig, unitConfig, {});
+    expect(reports).toHaveLength(2);
+    expect(reports[0]).toMatchObject({ nodeId: 'root', missing: ['Description'] });
+    expect(reports[1]).toMatchObject({ nodeId: 'u1', missing: ['Description'] });
+  });
+
+  it('passes when metadata or treeCache fills the required fields', () => {
+    const tree = [
+      node({
+        id: 'root', identifier: 'root', name: 'Course', isFolder: true,
+        metadata: { name: 'Course', description: 'From metadata' },
+        children: [
+          node({ id: 'u1', identifier: 'u1', name: 'Unit 1', isFolder: true, parent: 'root', metadata: {} }),
+        ],
+      }),
+    ];
+    const cache = { u1: { description: 'From cache' } };
+    expect(findMissingRequiredFields(tree, cache, rootConfig, unitConfig, {})).toHaveLength(0);
+  });
+
+  it('skips leaf resources (edited via ContentEditForm, not SparkMetaForm)', () => {
+    const tree = [
+      node({
+        id: 'root', identifier: 'root', name: 'Course', isFolder: true,
+        metadata: { name: 'Course', description: 'ok' },
+        children: [
+          node({ id: 'leaf', identifier: 'leaf', name: 'Video', isFolder: false, parent: 'root', metadata: {} }),
+        ],
+      }),
+    ];
+    expect(findMissingRequiredFields(tree, {}, rootConfig, unitConfig, {})).toHaveLength(0);
+  });
+
+  it('counts seeded defaults (author/copyrightYear) as filled', () => {
+    const licensingConfig = [
+      { code: 'author', label: 'Author', required: true },
+      { code: 'copyrightYear', label: 'Copyright Year', required: true },
+    ];
+    const tree = [
+      node({ id: 'root', identifier: 'root', name: 'Course', isFolder: true, metadata: {} }),
+    ];
+    const reports = findMissingRequiredFields(
+      tree, {}, licensingConfig, null, { userFullName: 'Jane Doe' },
+    );
+    expect(reports).toHaveLength(0);
+  });
+});

--- a/projects/collection-editor-react/src/utils/validateRequiredFields.ts
+++ b/projects/collection-editor-react/src/utils/validateRequiredFields.ts
@@ -1,0 +1,85 @@
+import type { INode } from '../types/editor';
+import type { IFrameworkDetails } from '../types/framework';
+import { useFieldPrepare } from '../components/SparkMetaForm/hooks/useFieldPrepare';
+import type { IPrepareContext } from '../components/SparkMetaForm/hooks/useFieldPrepare';
+
+export interface MissingFieldsReport {
+  nodeId: string;
+  nodeName: string;
+  /** Labels of the empty required fields, in form order. */
+  missing: string[];
+}
+
+const EMPTY_FW: IFrameworkDetails = {};
+
+function isEmptyValue(v: unknown): boolean {
+  return (
+    v === undefined ||
+    v === null ||
+    v === '' ||
+    (Array.isArray(v) && v.length === 0)
+  );
+}
+
+/**
+ * Metadata-level required-field validation across the whole tree.
+ *
+ * formStatusMapper only records forms the user has mounted AND touched, so
+ * validateAllForms passes nodes that were never visited. This walks every
+ * root/unit node, prepares its field set through the same pipeline the form
+ * uses (useFieldPrepare is pure — required flags, dialcode visibility and
+ * seeded defaults all match what the form displays), and reports every node
+ * with an empty required field. Leaf resources are excluded: they are edited
+ * through ContentEditForm, not the SparkMetaForm configs.
+ */
+export function findMissingRequiredFields(
+  treeData: INode[],
+  treeCache: Record<string, Record<string, unknown>>,
+  rootFormConfig: Array<Record<string, unknown>> | null,
+  unitFormConfig: Array<Record<string, unknown>> | null,
+  ctx: IPrepareContext,
+): MissingFieldsReport[] {
+  const reports: MissingFieldsReport[] = [];
+
+  const walk = (nodes: INode[], atRootLevel: boolean) => {
+    for (const node of nodes) {
+      const isRoot = atRootLevel && !node.parent;
+      const formConfig = isRoot
+        ? rootFormConfig
+        : node.isFolder
+          ? unitFormConfig
+          : null;
+
+      if (formConfig && formConfig.length > 0) {
+        const merged = {
+          ...(node.metadata ?? {}),
+          ...(treeCache[node.id] ?? {}),
+        };
+        const fields = useFieldPrepare(formConfig, merged, EMPTY_FW, isRoot, ctx);
+        const missing = fields
+          .filter(
+            (f) =>
+              f.required &&
+              f.visible !== false &&
+              // appIcon lives in the title row, not the form grid — matches
+              // the fields the user actually sees asterisked.
+              f.inputType !== 'appIcon' &&
+              isEmptyValue(f.currentValue),
+          )
+          .map((f) => f.label);
+        if (missing.length > 0) {
+          reports.push({
+            nodeId: node.id,
+            nodeName: node.name || 'Untitled',
+            missing,
+          });
+        }
+      }
+
+      if (node.children?.length) walk(node.children, false);
+    }
+  };
+
+  walk(treeData, true);
+  return reports;
+}

--- a/projects/collection-editor-react/src/web-component/react-to-webcomponent.d.ts
+++ b/projects/collection-editor-react/src/web-component/react-to-webcomponent.d.ts
@@ -1,0 +1,13 @@
+declare module 'react-to-webcomponent' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function reactToWebComponent(
+    component: any,
+    React: any,
+    ReactDOM: any,
+    options?: {
+      props?: Record<string, string>;
+      shadow?: 'open' | 'closed';
+    }
+  ): CustomElementConstructor;
+  export default reactToWebComponent;
+}

--- a/projects/collection-editor-react/src/web-component/register.ts
+++ b/projects/collection-editor-react/src/web-component/register.ts
@@ -1,0 +1,36 @@
+import reactToWebComponent from 'react-to-webcomponent';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { CollectionEditor } from '../components/CollectionEditor';
+
+function injectGlobalStyles(): void {
+  if (document.getElementById('sb-ce-react-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'sb-ce-react-styles';
+  // Inject the Google Fonts import for Plus Jakarta Sans
+  style.textContent = "@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap');";
+  document.head.insertBefore(style, document.head.firstChild);
+}
+
+export function registerCollectionEditor(tagName = 'sb-collection-editor'): void {
+  injectGlobalStyles();
+  if (typeof customElements === 'undefined') return;
+  if (customElements.get(tagName)) return;
+
+  const WebComponent = reactToWebComponent(
+    CollectionEditor as Parameters<typeof reactToWebComponent>[0],
+    React,
+    ReactDOM as Parameters<typeof reactToWebComponent>[2],
+    {
+      props: {
+        config: 'json',
+        onToolbarEvent: 'function',
+        onContentAdded: 'function',
+        onHierarchySaved: 'function',
+        onError: 'function',
+      },
+    }
+  );
+
+  customElements.define(tagName, WebComponent);
+}

--- a/projects/collection-editor-react/tsconfig.build.json
+++ b/projects/collection-editor-react/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": false,
+    "declaration": true,
+    "declarationDir": "dist",
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "src/dev-main.tsx"]
+}

--- a/projects/collection-editor-react/tsconfig.json
+++ b/projects/collection-editor-react/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["src"]
+}

--- a/projects/collection-editor-react/vite.config.ts
+++ b/projects/collection-editor-react/vite.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import dts from 'vite-plugin-dts';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    dts({ include: ['src'] }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'CollectionEditorReact',
+      formats: ['es', 'cjs', 'umd'],
+      fileName: (format) =>
+        format === 'umd'
+          ? 'collection-editor.umd.js'
+          : format === 'es'
+          ? 'index.js'
+          : 'index.cjs',
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+      },
+    },
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      '/action': { target: 'http://localhost:3000', changeOrigin: true },
+      '/api': { target: 'http://localhost:3000', changeOrigin: true },
+      '/content': { target: 'http://localhost:3000', changeOrigin: true },
+      '/assets': { target: 'http://localhost:3000', changeOrigin: true },
+      '/learner': { target: 'http://localhost:3000', changeOrigin: true },
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler',
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/projects/collection-editor-react/vite.config.ts
+++ b/projects/collection-editor-react/vite.config.ts
@@ -33,6 +33,14 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      // Category-definition lives on a separate backend in dev (9000) and is
+      // served without the /action prefix. Must be listed BEFORE the generic
+      // '/action' rule so it wins the longest-prefix match.
+      '/action/object/category/definition': {
+        target: 'http://localhost:9000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/action/, ''),
+      },
       '/action': { target: 'http://localhost:3000', changeOrigin: true },
       '/api': { target: 'http://localhost:3000', changeOrigin: true },
       '/content': { target: 'http://localhost:3000', changeOrigin: true },

--- a/projects/collection-editor-react/vite.config.ts
+++ b/projects/collection-editor-react/vite.config.ts
@@ -61,6 +61,9 @@ export default defineConfig({
         },
       },
       '/learner': { target: 'http://localhost:3000', changeOrigin: true },
+      // Portal-service proxy — questionset/v2 hierarchy + question/v2 list
+      // (session-cookie authed) used for QuML questionset preview.
+      '/portal': { target: 'http://localhost:3000', changeOrigin: true },
     },
   },
   css: {

--- a/projects/collection-editor-react/vite.config.ts
+++ b/projects/collection-editor-react/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
+import { existsSync } from 'fs';
 
 export default defineConfig({
   plugins: [
@@ -44,7 +45,21 @@ export default defineConfig({
       '/action': { target: 'http://localhost:3000', changeOrigin: true },
       '/api': { target: 'http://localhost:3000', changeOrigin: true },
       '/content': { target: 'http://localhost:3000', changeOrigin: true },
-      '/assets': { target: 'http://localhost:3000', changeOrigin: true },
+      // Sunbird preview renderer plugins (org.sunbird.iframeEvent etc.)
+      '/sunbird-plugins': { target: 'http://localhost:3000', changeOrigin: true },
+      // Player web-component assets live in public/assets (copied from node_modules).
+      // Serve locally if present; otherwise fall through to the backend.
+      '/assets': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        bypass: (req) => {
+          const url = (req.url ?? '').split('?')[0];
+          if (existsSync(resolve(__dirname, 'public' + url))) {
+            return url; // serve from public/ via Vite static middleware
+          }
+          return undefined; // proxy to backend
+        },
+      },
       '/learner': { target: 'http://localhost:3000', changeOrigin: true },
     },
   },

--- a/projects/collection-editor-react/vitest.config.ts
+++ b/projects/collection-editor-react/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+// Standalone vitest config (kept separate from the library vite.config so the
+// dts/lib-build plugins don't run during tests). The cascade logic under test
+// is pure, so the default 'node' environment is sufficient.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

This PR delivers New React Collection Editor (`projects/collection-editor-react`)

---

## Changes

### 🔧 App Icon Upload — Full 4-Step Sunbird Asset Flow
The icon upload was calling the wrong endpoint and returning `UPLOAD_DENIED`. Replaced the single broken call with the correct Sunbird 4-step asset upload protocol:
1. `POST /action/asset/v1/create` — creates the asset record, returns `node_id`
2. `POST /action/content/v3/upload/url/{assetId}` — obtains Azure pre-signed URL
3. `PUT <signed-url>` — uploads the binary to Azure Blob Storage with required headers:
   - `x-ms-blob-type: BlockBlob` (was missing — caused `MissingRequiredHeader` error)
   - `Content-Type: application/octet-stream`
4. `POST /action/asset/v1/upload/{assetId}` — finalizes and returns `content_url`

Added `cloudStorage.presigned_headers` passthrough from `editorConfig.context` for environment-specific headers.

---

### 🔧 Library Dock — Three UX Fixes

**1. Informational toast on root-node add**
Adding library content to the root course node is not allowed. Previously the button was silently disabled. Now a click shows:
> _"Select a unit from the outline to add content — resources cannot be added directly to the course."_

**2. Cross-collection duplicate prevention**
Added a store-level guard in `addResource()` using `bfsFind` to check the entire tree (not just the current unit). Attempts to add duplicate content via drag-drop or the Add button now show a toast error. Previously only a UI-level check existed with no store guard.

**3. Auto-open Details Form on new unit add**
When a new unit is added via the OutlineTree, the Details Form now opens automatically. Applied the existing `setTimeout(() => selectNode(id), 0)` pattern to avoid Zustand `set()` race conditions.

---

### 🔧 Course Type & Additional Category — Channel API Integration
Both select fields were showing empty options. Root cause: `resolveOptions` in `useFieldPrepare.ts` had no handler for `framework` or `additionalCategories` field codes, and the data they require comes from the channel read API (not the framework API).

**New files:**
- `src/api/channel.ts` — `GET /api/channel/v1/read/{channelId}`
- `src/hooks/useChannelData.ts` — React Query hook, 10-min stale time

**Changes:**
- `IFrameworkDetails` extended with `orgFrameworks` and `channelAdditionalCategories`
- `SparkMetaForm.tsx` calls `useChannelData` and maps `channel.frameworks` → `orgFrameworks`
- `resolveOptions` now handles `code === 'framework'` and `code === 'additionalCategories'`

---

### 🔧 Editor Initialization & Toolbar
- Fixed unit form field mapping (`forms.unitMetadata` correctly used for unit nodes)
- Required field validation guard in form submission
- Toolbar button visibility logic updated for review/sourcing modes
- Dialcode panel fixes: link/unlink flow corrections
- OutlineTree: improved unit hierarchy rendering and depth enforcement

---

### 🔧 Collaborators, Bulk Upload, API Client
- `ManageCollaborators`: search and update user list fixes
- `CsvUpload`: file validation and upload flow corrections
- `api/client.ts`: auth header and base URL improvements
- `api/user.ts`: user search API response normalization

---

### 🔧 Content Status & Review Flow
- `useContentStatus.ts` — new hook to derive actionable button visibility from content `status` and `editorMode`
- Topbar button states (Send for Review, Publish, Reject, etc.) now correctly reflect live content status
- `ContextualEditor`: child resource form field display fixes

---

## Files Changed

| Area | Files |
|---|---|
| App Icon Upload | `src/api/asset.ts` (new), `SparkMetaForm/fields/AppIconPickerModal.tsx` |
| Library UX | `LibraryDock/LibraryDock.tsx`, `LibraryCard.tsx`, `LibraryCard.module.scss`, `store/tree.store.ts` |
| Channel / Form Fields | `src/api/channel.ts` (new), `src/hooks/useChannelData.ts` (new), `SparkMetaForm/SparkMetaForm.tsx`, `SparkMetaForm/hooks/useFieldPrepare.ts`, `src/types/framework.ts` |
| Toolbar / Topbar | `components/Topbar/Topbar.tsx` |
| Tree / OutlineTree | `components/OutlineTree/OutlineTree.tsx`, `TreeNode.tsx`, `store/tree.store.ts` |
| Editor Init | `hooks/useEditorInit.ts` |
| API Layer | `api/client.ts`, `api/user.ts`, `api/bulkUpload.ts`, `api/dialcode.ts` |
| Collaborators | `components/Collaborators/ManageCollaborators.tsx` |
| Content Status | `hooks/useContentStatus.ts` (new) |
| Category Definition | `api/categoryDefinition.ts` |
| Types | `types/editor.ts`, `types/framework.ts` |

## Test Plan
- [ ] Upload a PNG/JPG app icon — verify it saves and displays correctly
- [ ] Try adding library content to the root course node — verify informational toast appears
- [ ] Add the same content item twice to any unit — verify duplicate toast fires
- [ ] Add a new unit — verify Details Form opens automatically
- [ ] Open root node form → Details tab → verify Course Type and Additional Category dropdowns are populated
- [ ] Send for Review — verify required field validation blocks submission when fields are empty
- [ ] Dialcode: link and unlink a QR code to a unit — verify both directions work
- [ ] Collaborators: add/remove a user — verify search and save work
- [ ] CSV upload: upload a hierarchy CSV — verify validation and import flow


<img width="1467" height="830" alt="Screenshot 2026-06-18 at 16 03 27" src="https://github.com/user-attachments/assets/929bb837-12f6-4e4a-acd4-9bb27b02f0de" />
